### PR TITLE
add properties support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ dist: xenial
 python:
   - "3.5"
 
+services:
+  - elasticsearch
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libsqlite3-mod-spatialite pandoc devscripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
 #  - pygeoapi generate_openapi_document -c pygeoapi-config.yml > pygeoapi-openapi.yml
 
 script:
+  - pygeoapi generate_openapi_document -c pygeoapi-config.yml > pygeoapi-openapi.yml
   - pytest --cov=pygeoapi
   - find . -type f -name "*.py" | xargs flake8
   - python setup.py --long-description | rst2html5.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ dist: xenial
 python:
   - "3.5"
 
-services:
-  - elasticsearch
-
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libsqlite3-mod-spatialite pandoc devscripts
@@ -20,8 +17,8 @@ install:
 env:
   - PYGEOAPI_CONFIG=pygeoapi-config.yml
 
-before_script:
-  - pygeoapi generate_openapi_document -c pygeoapi-config.yml > pygeoapi-openapi.yml
+#before_script:
+#  - pygeoapi generate_openapi_document -c pygeoapi-config.yml > pygeoapi-openapi.yml
 
 script:
   - pytest --cov=pygeoapi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: xenial
+#dist: xenial
 
 python:
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-#dist: xenial
+dist: xenial
 
 python:
   - "3.5"

--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -11,7 +11,7 @@ server:
     limit: 10
 
 logging:
-    level: INFO
+    level: ERROR
     #logfile: /tmp/pygeoapi.log
 
 metadata:

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -327,14 +327,7 @@ class API(object):
 
         LOGGER.debug('processing property parameters')
         for k, v in args.items():
-            if k not in reserved_fieldnames:
-                if k not in p.fields.keys():
-                    exception = {
-                        'code': 'InvalidParameterValue',
-                        'description': 'invalid property'
-                    }
-                    LOGGER.error('invalid property: {}'.format(k))
-                    return headers_, 400, json.dumps(exception)
+            if k in reserved_fieldnames:
                 properties.append((k, v))
 
         LOGGER.debug('Querying provider')

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -48,6 +48,16 @@ class BaseProvider(object):
         self.data = provider_def['data']
         self.id_field = provider_def['id_field']
         self.time_field = provider_def.get('time_field')
+        self.fields = {}
+
+    def get_fields(self):
+        """
+        Get provider field information (names, types)
+
+        :returns: dict of fields
+        """
+
+        raise NotImplementedError()
 
     def query(self):
         """

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -54,13 +54,14 @@ class CSVProvider(BaseProvider):
         BaseProvider.__init__(self, provider_def)
 
     def _load(self, startindex=0, limit=10, resulttype='results',
-              identifier=None, bbox=[], time=None):
+              identifier=None, bbox=[], time=None, properties=[]):
         """
         Load CSV data
 
         :param startindex: starting record to return (default 0)
         :param limit: number of records to return (default 10)
         :param resulttype: return results or hit limit (default results)
+        :param properties: list of tuples (name, value)
 
         :returns: dict of GeoJSON FeatureCollection
         """
@@ -101,13 +102,16 @@ class CSVProvider(BaseProvider):
         return feature_collection
 
     def query(self, startindex=0, limit=10, resulttype='results',
-              bbox=[], time=None):
+              bbox=[], time=None, properties=[]):
         """
         CSV query
 
         :param startindex: starting record to return (default 0)
         :param limit: number of records to return (default 10)
         :param resulttype: return results or hit limit (default results)
+        :param bbox: bounding box [minx,miny,maxx,maxy]
+        :param time: temporal (datestamp or extent)
+        :param properties: list of tuples (name, value)
 
         :returns: dict of GeoJSON FeatureCollection
         """

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -90,11 +90,17 @@ class GeoJSONProvider(BaseProvider):
         return data
 
     def query(self, startindex=0, limit=10, resulttype='results',
-              bbox=[], time=None):
+              bbox=[], time=None, properties=[]):
         """
         query the provider
 
-        :param bbox: Bounding Box in [W, S, E, N] order
+        :param startindex: starting record to return (default 0)
+        :param limit: number of records to return (default 10)
+        :param resulttype: return results or hit limit (default results)
+        :param bbox: bounding box [minx,miny,maxx,maxy]
+        :param time: temporal (datestamp or extent)
+        :param properties: list of tuples (name, value)
+
         :returns: FeatureCollection dict of 0..n GeoJSON features
         """
         # TODO filter by bbox without resorting to third-party libs

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -143,7 +143,7 @@ class SQLiteProvider(BaseProvider):
         return cursor
 
     def query(self, startindex=0, limit=10, resulttype='results',
-              bbox=[], time=None):
+              bbox=[], time=None, properties=[]):
         """
         Query Sqlite for all the content.
         e,g: http://localhost:5000/collections/countries/items?
@@ -152,6 +152,9 @@ class SQLiteProvider(BaseProvider):
         :param startindex: starting record to return (default 0)
         :param limit: number of records to return (default 10)
         :param resulttype: return results or hit limit (default results)
+        :param bbox: bounding box [minx,miny,maxx,maxy]
+        :param time: temporal (datestamp or extent)
+        :param properties: list of tuples (name, value)
 
         :returns: GeoJSON FeaturesCollection
         """

--- a/pygeoapi/templates/items.html
+++ b/pygeoapi/templates/items.html
@@ -18,13 +18,13 @@
     <section id="items">
       <h2>{{ data['title'] }}</h2>
       <span>{{ data['description'] }}</span>
-      <h2>Features <a title="JSON" href="./"><img alt="JSON" src="{{ config['server']['url'] }}/static/img/json.png" width="30" height="30"/></a></h2>
+      <h2>Features <a title="JSON" href="./items"><img alt="JSON" src="{{ config['server']['url'] }}/static/img/json.png" width="30" height="30"/></a></h2>
       <table>
           <tr>
             <td>
       <ul>
       {% for feature in data['features'] %}
-          <li><a title="{{ feature['ID'] }}" href="./{{ feature['ID'] }}?f=html">{{ feature['ID'] }}</a></li>
+          <li><a title="{{ feature['ID'] }}" href="./items/{{ feature['ID'] }}?f=html">{{ feature['ID'] }}</a></li>
       {% endfor %}
       </ul>
            </td>
@@ -48,7 +48,7 @@
     var geojson_data = {{ data['features'] |to_json }};
     var items = new L.GeoJSON(geojson_data, {
         onEachFeature: function (feature, layer) {
-            var html_ = '<span><a href="./' + feature.ID + '?f=html">' + feature.ID + '</a></span>';
+            var html_ = '<span><a href="./items' + feature.ID + '?f=html">' + feature.ID + '</a></span>';
             layer.bindPopup(html_);
         }
     });


### PR DESCRIPTION
This PR implements [feature property filtering](https://cdn.rawgit.com/opengeospatial/WFS_FES/3.0.0-draft.1/docs/17-069.html#_parameters_for_filtering_on_feature_properties).

Note that `pygeoapi.api.query` passes non reserved parameters as tuples to the respective backend's `query` method.  While the method signatures have been updated, functionality has only been implemented in the Elasticsearch backend as first pass (hoping the other provider maintainers can implement in their own backends).