### PR TITLE
#89 fix check_format function

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -642,16 +642,25 @@ def check_format(args, headers):
     :returns: format value
     """
 
+    # Optional f=html or f=json query param
+    # overrides accept
     format_ = args.get('f')
+    if format_:
+        return format_
+
+    # Format not specified: get from accept headers
+    format_ = 'text/html'
 
     if 'accept' in headers.keys():
         format_ = headers['accept']
     elif 'Accept' in headers.keys():
         format_ = headers['Accept']
 
-    if format_ == 'text/html':
+    format_ = format_.split(',')
+
+    if 'text/html' in format_:
         format_ = 'html'
-    elif format_ == 'application/json':
+    elif 'application/json' in format_:
         format_ = 'json'
 
     return format_

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -649,19 +649,21 @@ def check_format(args, headers):
         return format_
 
     # Format not specified: get from accept headers
-    format_ = 'text/html'
-
+    # format_ = 'text/html'
+    headers_ = None
     if 'accept' in headers.keys():
-        format_ = headers['accept']
+        headers_ = headers['accept']
     elif 'Accept' in headers.keys():
-        format_ = headers['Accept']
+        headers_ = headers['Accept']
 
-    format_ = format_.split(',')
+    format_ = None
+    if headers_:
+        headers_ = headers_.split(',')
 
-    if 'text/html' in format_:
-        format_ = 'html'
-    elif 'application/json' in format_:
-        format_ = 'json'
+        if 'text/html' in headers_:
+            format_ = 'html'
+        elif 'application/json' in headers_:
+            format_ = 'json'
 
     return format_
 


### PR DESCRIPTION
This PR should fix #89 with  new implementation of `check_format()`. Main problem was that a browser `accept` header in request is a ','-separated string of accepted formats and the function checks for e.g. `text/html`.
