### PR TITLE
add schema-org microdata based on schema.org/DataCatalog & Dataset

### DIFF
--- a/pygeoapi/templates/base.html
+++ b/pygeoapi/templates/base.html
@@ -17,8 +17,10 @@
     {% endblock %}
   </head>
   <body>
-    <header>
-      <h1><a title="{{ config['metadata']['identification']['title'] }}" href="{{ config['server']['url'] }}/?f=html">{{ config['metadata']['identification']['title'] }}</a><a title="JSON" href="{{ config['server']['url'] }}/"><img alt="JSON" src="{{ config['server']['url'] }}/static/img/json.png" width="30" height="30"/></a></h1>
+    <header itemscope itemtype="http://schema.org/DataCatalog" itemref="collections">
+      <meta itemprop="url" content="{{ config['server']['url'] }}" />
+      <h1><a title="{{ config['metadata']['identification']['title'] }}" href="{{ config['server']['url'] }}/?f=html"><span itemprop="name">{{ config['metadata']['identification']['title'] }}</span></a>
+        <a title="JSON" href="{{ config['server']['url'] }}/"><img alt="JSON" src="{{ config['server']['url'] }}/static/img/json.png" width="30" height="30"/></a></h1>
       <span itemprop="description">{{ config['metadata']['identification']['description'] }}</span>
     </header>
     <hr/>

--- a/pygeoapi/templates/collection.html
+++ b/pygeoapi/templates/collection.html
@@ -1,14 +1,19 @@
 {% extends "base.html" %}
 {% block title %}{{ super() }} {{ data['title'] }} {% endblock %}
 {% block body %}
-    <section id="collection">
-      <h2>{{ data['title'] }}<a title="JSON" href="{{ config['server']['url'] }}/collections/{{ data['name'] }}"><img alt="JSON" src="{{ config['server']['url'] }}/static/img/json.png" width="30" height="30"/></a></h2>
-      <div>{{ data['description'] }}</div>
+    <section id="collections" itemprop="dataset" itemscope itemtype="http://schema.org/Dataset">
+      <meta  itemprop="includedInDataCatalog" content="{{ config['server']['url'] }}" />
+      <h2 itemprop="name">{{ data['title'] }}<a title="JSON" href="{{ config['server']['url'] }}/collections/{{ data['name'] }}"><img alt="JSON" src="{{ config['server']['url'] }}/static/img/json.png" width="30" height="30"/></a></h2>
+      <div itemprop="description">{{ data['description'] }}</div>
       <div><a title="Browse Features" href="{{ config['server']['url'] }}/collections/{{ data['name'] }}/items?f=html">Browse Features</a></div>
       <h2>Links</h2>
       <ul>
       {% for link in data['links'] %}
-          <li><a title="{{ link['rel'] }}" href="{{ link['href'] }}">{{ link['href'] }}</a></li>
+          <li itemprop="distribution" itemscope itemtype="http://schema.org/DataDownload">
+            <a itemprop="contentURL" title="{{ link['rel'] }}" href="{{ link['href'] }}">
+            <span  itemprop="name">{{ link['title'] }}</span> (<span itemprop="encodingFormat">{{ link['type'] }}</span>)
+            <meta itemprop="inLanguage" content="{{ link['hreflang'] }}" />
+            </a></li>
       {% endfor %}
       </ul>
     </section>

--- a/pygeoapi/templates/collections.html
+++ b/pygeoapi/templates/collections.html
@@ -2,10 +2,16 @@
 {% block title %}{{ super() }} Collections {% endblock %}
 {% block body %}
     <section id="collections">
+      <meta itemprop="url" content="{{ config['server']['url'] }}" />
+      <meta itemprop="name" content="{{ config['metadata']['identification']['title'] }}" />
+      <meta itemprop="description" content="{{ config['metadata']['identification']['description'] }}" />
       <h2>Collections <a title="JSON" href="{{ config['server']['url'] }}/collections"><img alt="JSON" src="{{ config['server']['url'] }}/static/img/json.png" width="30" height="30"/></a></h2>
       <ul>
       {% for k, v in config['datasets'].items()%}
-          <li><a title="{{ v['title'] }}" href="{{ config['server']['url'] }}/collections/{{ k }}?f=html">{{ v['title'] }}</a></li>
+          <li itemprop="dataset" itemscope itemtype="http://schema.org/Dataset">
+            <meta itemprop="url" content="{{ config['server']['url'] }}/collections/{{ k }}" />
+            <a itemprop="url" href="{{ config['server']['url'] }}/collections/{{ k }}?f=html">
+              <span itemprop="name">{{ v['title'] }}</span></a><br/><span itemprop="description">{{ v['description'] }}</span></li>
       {% endfor %}
       </ul>
     </section>

--- a/pygeoapi/templates/items.html
+++ b/pygeoapi/templates/items.html
@@ -15,7 +15,8 @@
 {% endblock %}
 
 {% block body %}
-    <section id="items">
+  <section id="collections"></section>    
+  <section id="items">
       <div class="row col-sm-12">
           <h2>Items</h2>
       </div>

--- a/pygeoapi/templates/root.html
+++ b/pygeoapi/templates/root.html
@@ -1,14 +1,91 @@
 {% extends "base.html" %}
 {% block title %}{{ super() }} Home {% endblock %}
 {% block body %}
-    <section id="service-metadata">
-      <h2>Service Metadata</h2>
+    <section id="collections">
       <table>
         <tr>
-          <td>Provider</td>
-          <td><a title="{{ config['metadata']['provider']['name'] }}" href="{{ config['metadata']['provider']['url'] }}">{{ config['metadata']['provider']['name'] }}</a></td>
+          <td>Keywords</td>
+          <td itemprop="keywords">
+            {% for v in config['metadata']['identification']['keywords'] %}
+              {{ v }}, {% endfor %}</td>
+        </tr>
+        <tr>
+          <td>Terms of service</td>
+          <td>{{ config['metadata']['identification']['terms_of_service'] }}</td>
+        </tr>
+        <tr>
+          <td>License</td>
+          <td itemprop="license"><a itemscope itemtype="http://schema.org/URL" href="{{ config['metadata']['license']['url'] }}">
+            {{ config['metadata']['license']['name'] }}</a></td>
         </tr>
       </table>
+
+      <h2>Provider</h2>
+      <div itemprop="provider" itemscope itemtype="http://schema.org/Organization">
+        <table>
+        <tr>
+          <td>Organization</td>
+          <td itemprop="name">{{ config['metadata']['provider']['name'] }}</td>
+        </tr>
+        <tr>
+          <td>Url</td>
+          <td><a itemprop="url" href="{{ config['metadata']['provider']['url'] }}">
+              {{ config['metadata']['provider']['url'] }}</a></td>
+        </tr>
+        </table>
+
+        <h3>Contact point</h3>
+        <table itemprop="contactPoint" itemscope itemtype="http://schema.org/Contactpoint">
+          <tr>
+            <td>Email</td>
+            <td itemprop="Email">{{ config['metadata']['contact']['email'] }}</td>
+          </tr>
+          <tr>
+              <td>Telephone</td>
+              <td itemprop="Telephone">{{ config['metadata']['contact']['phone'] }}</td>
+          </tr>
+          <tr>
+              <td>Fax</td>
+              <td itemprop="faxNumber">{{ config['metadata']['contact']['fax'] }}</td>
+          </tr>
+          <tr>
+              <td>Contact url</td>
+              <td itemprop="url">{{ config['metadata']['contact']['url'] }}</td>
+          </tr>
+          <tr>
+              <td>Hours</td>
+              <td itemprop="hoursAvailable">{{ config['metadata']['contact']['hours'] }}</td>
+          </tr>
+          <tr>
+            <td>contactType</td>
+            <td itemprop="contactType">{{ config['metadata']['contact']['instructions'] }}</td>  
+          </tr>
+        </table>
+
+        <h3>Address</h3>
+        <table itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+          <tr>
+            <td>Address</td>
+            <td itemprop="streetAddress">{{ config['metadata']['contact']['address'] }}</td>
+          </tr>
+          <tr>
+              <td>Postalcode</td>
+              <td itemprop="postalCode">{{ config['metadata']['contact']['postalcode'] }}</td>
+            </tr>
+          <tr>
+            <td>City</td>
+            <td itemprop="addressLocality">{{ config['metadata']['contact']['city'] }}</td>
+          </tr>
+          <tr>
+            <td>Region</td>
+            <td itemprop="addressRegion">{{ config['metadata']['contact']['stateorprovince'] }}</td>
+          </tr>
+          <tr>
+              <td>Country</td> 
+              <td itemprop="addressCountry">{{ config['metadata']['contact']['country'] }}</td>	
+          </tr>
+        </table>
+      </div>
     </section>
     <section id="conformance">
         <h2><a href="{{ config['server']['url'] }}/conformance?f=html">Conformance</a></h2>

--- a/pygeoapi/templates/root.html
+++ b/pygeoapi/templates/root.html
@@ -10,7 +10,7 @@
 
   <section id="identification">
     <h1>{{ config['metadata']['identification']['title'] }}</h1>
-    <p>{{ config['metadata']['identification']['title'] }}</p>   
+    <p>{{ config['metadata']['identification']['description'] }}</p>   
     
     <div class="card large">
       <div class="section">


### PR DESCRIPTION
A suggestion to use microdata to annotate root, collections & collection pages

Due to header having service-title, I had to link it to other metadata about the service using itemref="collections"

Pages validated in google structured data testing tool:

home

![image](https://user-images.githubusercontent.com/299829/56066143-313bba00-5d77-11e9-92c9-e577014c7d26.png)

collections

![image](https://user-images.githubusercontent.com/299829/56066076-00f41b80-5d77-11e9-9b16-3ea71763cb26.png)

collections/lakes

![image](https://user-images.githubusercontent.com/299829/56066085-06e9fc80-5d77-11e9-88c3-e78b2d005b9f.png)

