### PR TITLE
 rename feature.ID to feature.id

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -164,7 +164,7 @@ def get_oas_30(cfg):
                         'description': 'successful operation'
                     },
                     400: {
-                        'description': 'Invalid ID supplied'
+                        'description': 'Invalid id supplied'
                     },
                     404: {
                         'description': 'not found'
@@ -189,7 +189,7 @@ def get_oas_30(cfg):
                         'description': 'successful operation'
                     },
                     400: {
-                        'description': 'Invalid ID supplied'
+                        'description': 'Invalid id supplied'
                     },
                     404: {
                         'description': 'not found'
@@ -229,7 +229,7 @@ def get_oas_30(cfg):
 
         paths['{}/items/{{id}}'.format(collection_name_path)] = {
             'get': {
-                'summary': 'Get {} feature by ID'.format(v['title']),
+                'summary': 'Get {} feature by id'.format(v['title']),
                 'description': v['description'],
                 'tags': [k],
                 'parameters': [
@@ -241,7 +241,7 @@ def get_oas_30(cfg):
                         'description': 'successful operation'
                     },
                     400: {
-                        'description': 'Invalid ID supplied'
+                        'description': 'Invalid id supplied'
                     },
                     404: {
                         'description': 'not found'
@@ -293,7 +293,7 @@ def get_oas_30(cfg):
                         'description': 'successful operation'
                     },
                     400: {
-                        'description': 'Invalid ID supplied'
+                        'description': 'Invalid id supplied'
                     },
                     404: {
                         'description': 'not found'
@@ -322,7 +322,7 @@ def get_oas_30(cfg):
                         'description': 'successful operation'
                     },
                     400: {
-                        'description': 'Invalid ID supplied'
+                        'description': 'Invalid id supplied'
                     },
                     404: {
                         'description': 'not found'

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -83,7 +83,7 @@ class CSVProvider(BaseProvider):
             LOGGER.debug('Slicing CSV rows')
             for row in itertools.islice(data_, startindex, startindex+limit):
                 feature = {'type': 'Feature'}
-                feature['ID'] = row.pop(self.id_field)
+                feature['id'] = row.pop(self.id_field)
                 feature['geometry'] = {
                     'type': 'Point',
                     'coordinates': [
@@ -102,7 +102,7 @@ class CSVProvider(BaseProvider):
                 else:
                     feature['properties'] = row
 
-                if identifier is not None and feature['ID'] == identifier:
+                if identifier is not None and feature['id'] == identifier:
                     found = True
                     result = feature
                 feature_collection['features'].append(feature)

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -264,10 +264,10 @@ class ElasticsearchProvider(BaseProvider):
         for feature in results['hits']['hits']:
             id_ = feature['_source']['properties'][self.id_field]
             LOGGER.debug('serializing id {}'.format(id_))
-            feature['_source']['ID'] = id_
+            feature['_source']['id'] = id_
             if self.properties:
                 feature_thinned = {
-                    'ID': feature['_source']['properties'][self.id_field],
+                    'id': feature['_source']['properties'][self.id_field],
                     'type': feature['_source']['type'],
                     'geometry': feature['_source']['geometry'],
                     'properties': OrderedDict()
@@ -301,7 +301,7 @@ class ElasticsearchProvider(BaseProvider):
                                  id=identifier)
             LOGGER.debug('Serializing feature')
             id_ = result['_source']['properties'][self.id_field]
-            result['_source']['ID'] = id_
+            result['_source']['id'] = id_
         except Exception as err:
             LOGGER.error(err)
             return None

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -85,7 +85,7 @@ class GeoJSONProvider(BaseProvider):
         assert data['type'] == 'FeatureCollection'
         # All features must have ids, TODO must be unique strings
         for i in data['features']:
-            i['ID'] = i['properties'][self.id_field]
+            i['id'] = i['properties'][self.id_field]
 
         return data
 

--- a/pygeoapi/templates/item.html
+++ b/pygeoapi/templates/item.html
@@ -8,7 +8,7 @@
   {% endif %}
 {% endfor %}     
 <a href="../items">Items</a>
-<a href="./{{ data['ID'] }}">{{ data['title'] or data['ID'] }}</a>
+<a href="./{{ data['id'] }}">{{ data['title'] or data['id'] }}</a>
 {% endblock %}
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
@@ -20,7 +20,7 @@
     <section id="items">
       <div class="row">
         <div class="col-sm">
-          <h2>Item {{ data['ID'] }}</h2>
+          <h2>Item {{ data['id'] }}</h2>
         </div>
       </div>
       <div class="row">
@@ -29,6 +29,7 @@
         </div>
         <div class="col-md-6 col-sm-12">
             <table>
+              <caption>Item properties</caption>
               <thead>
               <tr>
                 <th>Property</th>
@@ -37,8 +38,8 @@
             </thead>
             <tbody>
               <tr>
-                <td>ID</td>
-                <td>{{ data.ID }}</td>
+                <td>id</td>
+                <td>{{ data.id }}</td>
               </tr>
               {% for k, v in data['properties'].items() %}
               <tr>

--- a/pygeoapi/templates/items.html
+++ b/pygeoapi/templates/items.html
@@ -17,10 +17,9 @@
 {% block body %}
   <section id="collections"></section>    
   <section id="items">
-      <div class="row col-sm-12">
-          <h2>Items</h2>
-      </div>
-
+    <div class="row col-sm-12">
+        <h2>Items</h2>
+    </div>
     {% if data['features'] %}
     <div class="row">
       <div class="col-sm-12 col-md-6">
@@ -28,9 +27,10 @@
       </div>  
       <div class="col-sm-12 col-md-6">
           <table>
+            <caption>Items</caption>
             <thead>
             <tr>
-                <th>ID</th>
+                <th>id</th>
                 {% for k, v in data['features'][0]['properties'].items() %}
                 <th>{{ k }}</td>
                 {% endfor %}
@@ -39,7 +39,7 @@
           <tbody>
             {% for ft in data['features'] %}
               <tr>
-                <td data-label="ID"><a href="{{ data['items_path']}}/{{ ft.ID }}">{{ ft.ID }}</a></td>
+                <td data-label="id"><a href="{{ data['items_path']}}/items/{{ ft.id }}">{{ ft.id }}</a></td>
                   {% for k, v in ft['properties'].items() %}
                   <td data-label="{{ k }}">{{ v }}</td>
                   {% endfor %}
@@ -82,7 +82,7 @@
     var geojson_data = {{ data['features'] |to_json }};
     var items = new L.GeoJSON(geojson_data, {
         onEachFeature: function (feature, layer) {
-            var html_ = '<span><a href="items/' + feature.ID + '?f=html">' + feature.ID + '</a></span>';
+            var html_ = '<span><a href="items/' + feature.id + '?f=html">' + feature.id + '</a></span>';
             layer.bindPopup(html_);
         }
     });

--- a/tests/pygeoapi-test-openapi.yml
+++ b/tests/pygeoapi-test-openapi.yml
@@ -116,7 +116,7 @@ paths:
         200:
           description: successful operation
         400:
-          description: Invalid ID supplied
+          description: Invalid id supplied
         404:
           description: not found
       summary: Get feature collection metadata
@@ -134,7 +134,7 @@ paths:
         200:
           description: successful operation
         400:
-          description: Invalid ID supplied
+          description: Invalid id supplied
         404:
           description: not found
       summary: Get Observations features
@@ -150,10 +150,10 @@ paths:
         200:
           description: successful operation
         400:
-          description: Invalid ID supplied
+          description: Invalid id supplied
         404:
           description: not found
-      summary: Get Observations feature by ID
+      summary: Get Observations feature by id
       tags:
       - obs
   /conformance:
@@ -181,7 +181,7 @@ paths:
         200:
           description: successful operation
         400:
-          description: Invalid ID supplied
+          description: Invalid id supplied
         404:
           description: not found
       summary: Get process metadata
@@ -210,7 +210,7 @@ paths:
         200:
           description: successful operation
         400:
-          description: Invalid ID supplied
+          description: Invalid id supplied
         404:
           description: not found
       summary: Process Hello World process execution

--- a/tests/test_csv__formatter.py
+++ b/tests/test_csv__formatter.py
@@ -51,7 +51,7 @@ def fixture():
             'foo': 'bar',
             'title': None,
           },
-          'ID': 48693
+          'id': 48693
         }]
     }
 

--- a/tests/test_csv__provider.py
+++ b/tests/test_csv__provider.py
@@ -68,7 +68,7 @@ def test_query(fixture, config):
     assert len(results['features']) == 5
     assert results['numberMatched'] == 5
     assert results['numberReturned'] == 5
-    assert results['features'][0]['ID'] == '371'
+    assert results['features'][0]['id'] == '371'
     assert results['features'][0]['properties']['value'] == '89.9'
 
     assert results['features'][0]['geometry']['coordinates'][0] == -75.0
@@ -76,11 +76,11 @@ def test_query(fixture, config):
 
     results = p.query(limit=1)
     assert len(results['features']) == 1
-    assert results['features'][0]['ID'] == '371'
+    assert results['features'][0]['id'] == '371'
 
     results = p.query(startindex=2, limit=1)
     assert len(results['features']) == 1
-    assert results['features'][0]['ID'] == '238'
+    assert results['features'][0]['id'] == '238'
 
     assert len(results['features'][0]['properties']) == 3
 
@@ -96,5 +96,5 @@ def test_get(fixture, config):
     assert results is None
 
     result = p.get('964')
-    assert result['ID'] == '964'
+    assert result['id'] == '964'
     assert result['properties']['value'] == '99.9'

--- a/tests/test_elasticsearch__provider.py
+++ b/tests/test_elasticsearch__provider.py
@@ -47,7 +47,7 @@ def test_query(config):
     assert len(results['features']) == 10
     assert results['numberMatched'] == 242
     assert results['numberReturned'] == 10
-    assert results['features'][0]['ID'] == 6691831
+    assert results['features'][0]['id'] == 6691831
     assert results['features'][0]['properties']['nameascii'] == 'Vatican City'
 
     results = p.query(properties=[('nameascii', 'Vatican City')])
@@ -57,11 +57,11 @@ def test_query(config):
 
     results = p.query(limit=1)
     assert len(results['features']) == 1
-    assert results['features'][0]['ID'] == 6691831
+    assert results['features'][0]['id'] == 6691831
 
     results = p.query(startindex=2, limit=1)
     assert len(results['features']) == 1
-    assert results['features'][0]['ID'] == 1559804
+    assert results['features'][0]['id'] == 1559804
 
     results = p.query(sortby=[{'property': 'nameascii', 'order': 'A'}])
     assert results['features'][0]['properties']['nameascii'] == 'Abidjan'
@@ -89,5 +89,5 @@ def test_get(config):
     assert results is None
 
     result = p.get('3413829')
-    assert result['ID'] == 3413829
+    assert result['id'] == 3413829
     assert result['properties']['ls_name'] == 'Reykjavik'

--- a/tests/test_geojson_provider.py
+++ b/tests/test_geojson_provider.py
@@ -62,7 +62,7 @@ def test_create(fixture, config):
     p = GeoJSONProvider(config)
     new_feature = {
         'type': 'Feature',
-        'ID': '123-456',
+        'id': '123-456',
         'geometry': {
             'type': 'Point',
             'coordinates': [0.0, 0.0]},


### PR DESCRIPTION
this replaces the use of feature.ID by feature.id, in html templates as well as elastic, json & csv providers as suggested in #94 