### PR TITLE
Fix stale link in Map marker popup text

### DIFF
--- a/pygeoapi/templates/items.html
+++ b/pygeoapi/templates/items.html
@@ -82,8 +82,9 @@
     var geojson_data = {{ data['features'] |to_json }};
     var items = new L.GeoJSON(geojson_data, {
         onEachFeature: function (feature, layer) {
-            var html_ = '<span><a href="items/' + feature.id + '?f=html">' + feature.id + '</a></span>';
-            layer.bindPopup(html_);
+            var url = '{{ data['items_path'] }}/' + feature.id + '?f=html';
+            var html = '<span><a href="' + url + '">' + feature.id + '</a></span>';
+            layer.bindPopup(html);
         }
     });
 


### PR DESCRIPTION
Using the same convention as in table view id links on line 42: use the `data['items_path'] `. This always has the full URL base-path. Also will work later when behind a path-based proxy.