### PR TITLE
fix pathing to work with subpaths behind proxies

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -145,7 +145,7 @@ class API(object):
 
         return headers_, 200, json.dumps(fcm)
 
-    def api(self, headers, args, request_path, openapi):
+    def api(self, headers, args, openapi):
         """
         Provide OpenAPI document
 
@@ -159,9 +159,11 @@ class API(object):
         headers_ = HEADERS.copy()
         format_ = check_format(args, headers)
 
+        path = '/'.join([self.config['server']['url'].rstrip('/'), 'api'])
+
         if format_ == 'html':
             data = {
-                'openapi-document-path': request_path
+                'openapi-document-path': path
             }
             headers_['Content-Type'] = 'text/html'
             content = _render_j2_template(self.config, 'api.html', data)
@@ -528,15 +530,16 @@ class API(object):
             content['links'][0]['rel'] = 'alternate'
             content['links'][1]['rel'] = 'self'
 
-            # For constructing proper URIs to Items
-            path_info = headers.environ['PATH_INFO']
-            if path_info.endswith('/'):
-                path_info = path_info[:-1]
+            # For constructing proper URIs to items
+            path_info = '/'.join([
+                self.config['server']['url'].rstrip('/'),
+                headers.environ['PATH_INFO'].strip('/')])
 
             content['items_path'] = path_info
             content['dataset_path'] = '/'.join(path_info.split('/')[:-1])
             content['collections_path'] = '/'.join(path_info.split('/')[:-2])
             content['startindex'] = startindex
+
             content = _render_j2_template(self.config, 'items.html',
                                           content)
             return headers_, 200, content

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -68,7 +68,7 @@ def api():
         openapi = yaml.load(ff)
 
     headers, status_code, content = api_.api(request.headers, request.args,
-                                             request.path, openapi)
+                                             openapi)
 
     response = make_response(content, status_code)
     if headers:

--- a/pygeoapi/templates/api.html
+++ b/pygeoapi/templates/api.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>    
+    <title>{{ config['metadata']['identification']['title'] }} OpenAPI Document</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.17.0/swagger-ui.css">
     <script src="https://unpkg.com/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
     <script>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,7 +77,7 @@ def test_api(config, api_, openapi):
     assert isinstance(api_.config, dict)
 
     req_headers = make_req_headers(HTTP_CONTENT_TYPE='application/json')
-    rsp_headers, code, response = api_.api(req_headers, {}, '/api', openapi)
+    rsp_headers, code, response = api_.api(req_headers, {}, openapi)
     assert rsp_headers['Content-Type'] ==\
         'application/openapi+json;version=3.0'
     root = json.loads(response)
@@ -86,7 +86,7 @@ def test_api(config, api_, openapi):
 
     a = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
     req_headers = make_req_headers(HTTP_ACCEPT=a)
-    rsp_headers, code, response = api_.api(req_headers, {}, '/api', openapi)
+    rsp_headers, code, response = api_.api(req_headers, {}, openapi)
     assert rsp_headers['Content-Type'] == 'text/html'
 
 


### PR DESCRIPTION
This PR ensures that links resolve correctly whether pygeoapi is deployed to the root or subpath of a server.