### PR TITLE
#112 Loosen GDAL version dep to 2.1 or higher

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,4 +15,4 @@ pytest-env
 pyOpenSSL==17.5.0
 ndg-httpsclient==0.4.4
 pyasn1==0.4.2
-GDAL>=2.2
+GDAL>=2.1


### PR DESCRIPTION
Needed to run demo server on Debian Stretch slim Docker for now. Only ESRI FeatureServer works on GDAL >= 2.3. Need to revisit later. But with this change we can build/deploy the Demo Server directly from the main geoapi GH repo `master`.