### PR TITLE
#129 #112 Move setting config options for CORS and JSONIFY to module level

### DIFF
--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -48,6 +48,14 @@ if 'PYGEOAPI_CONFIG' not in os.environ:
 with open(os.environ.get('PYGEOAPI_CONFIG')) as fh:
     CONFIG = yaml.load(fh)
 
+# CORS: optionally enable from config.
+if CONFIG['server'].get('cors', False):
+    from flask_cors import CORS
+    CORS(APP)
+
+APP.config['JSONIFY_PRETTYPRINT_REGULAR'] = \
+    CONFIG['server'].get('pretty_print', True)
+
 api_ = API(CONFIG)
 
 
@@ -155,13 +163,6 @@ def execute_process(name=None):
 @click.option('--debug', '-d', default=False, is_flag=True, help='debug')
 def serve(ctx, debug=False):
     """Serve pygeoapi via Flask"""
-
-    if not api_.config['server']['pretty_print']:
-        APP.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
-
-    if 'cors' in api_.config['server'] and api_.config['server']['cors']:
-        from flask_cors import CORS
-        CORS(APP)
 
 #    setup_logger(CONFIG['logging'])
     APP.run(debug=True, host=api_.config['server']['bind']['host'],


### PR DESCRIPTION
Should fix #129.

Tested for all True/False combinations and HTTP header checks.