### PR TITLE
add helper function for YAML parsing

### DIFF
--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -31,11 +31,11 @@
 import os
 
 import click
-import yaml
 
 from flask import Flask, make_response, request
 
 from pygeoapi.api import API
+from pygeoapi.util import yaml_load
 
 APP = Flask(__name__)
 APP.url_map.strict_slashes = False
@@ -46,7 +46,7 @@ if 'PYGEOAPI_CONFIG' not in os.environ:
     raise RuntimeError('PYGEOAPI_CONFIG environment variable not set')
 
 with open(os.environ.get('PYGEOAPI_CONFIG')) as fh:
-    CONFIG = yaml.load(fh, Loader=yaml.FullLoader)
+    CONFIG = yaml_load(fh)
 
 # CORS: optionally enable from config.
 if CONFIG['server'].get('cors', False):
@@ -73,7 +73,7 @@ def root():
 @APP.route('/api')
 def api():
     with open(os.environ.get('PYGEOAPI_OPENAPI')) as ff:
-        openapi = yaml.load(ff, Loader=yaml.FullLoader)
+        openapi = yaml_load(ff)
 
     headers, status_code, content = api_.api(request.headers, request.args,
                                              openapi)

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -33,6 +33,7 @@ import click
 import yaml
 
 from pygeoapi.plugin import load_plugin
+from pygeoapi.util import yaml_load
 
 LOGGER = logging.getLogger(__name__)
 
@@ -477,5 +478,5 @@ def generate_openapi_document(ctx, config_file):
     if config_file is None:
         raise click.ClickException('--config/-c required')
     with open(config_file) as ff:
-        s = yaml.load(ff, Loader=yaml.FullLoader)
+        s = yaml_load(ff)
         click.echo(yaml.safe_dump(get_oas(s), default_flow_style=False))

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -29,6 +29,8 @@
 
 import logging
 
+import yaml
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -47,6 +49,22 @@ def get_url(scheme, host, port, basepath):
     url = '{}{}'.format(url, basepath)
 
     return url
+
+
+def yaml_load(fh):
+    """
+    serializes a YAML files into a pyyaml object
+
+    :param fh: file handle
+
+    :returns: `dict` representation of YAML
+    """
+
+    try:
+        return yaml.load(fh, Loader=yaml.FullLoader)
+    except AttributeError as err:
+        LOGGER.warning('YAML loading error: {}'.format(err))
+        return yaml.load(fh)
 
 
 def str2bool(value):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,11 +31,11 @@ import json
 import os
 
 import pytest
-import yaml
 
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
 from pygeoapi.api import API, check_format
+from pygeoapi.util import yaml_load
 
 
 def get_test_file_path(filename):
@@ -58,13 +58,13 @@ def make_req_headers(**kwargs):
 @pytest.fixture()
 def config():
     with open(get_test_file_path('pygeoapi-test-config.yml')) as fh:
-        return yaml.load(fh, Loader=yaml.FullLoader)
+        return yaml_load(fh)
 
 
 @pytest.fixture()
 def openapi():
     with open(get_test_file_path('pygeoapi-test-openapi.yml')) as fh:
-        return yaml.load(fh, Loader=yaml.FullLoader)
+        return yaml_load(fh)
 
 
 @pytest.fixture()


### PR DESCRIPTION
Given https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation, this PR isolates YAML parsing into a single function which attempts to safely open a YAML file using `loader=yaml.FullLoader`, and falls back to pre pyyaml 5.1 behaviour depending on which version pyyaml is installed.