### PR TITLE
safeguard urlize for jinja pre-2.8

### DIFF
--- a/pygeoapi/templates/item.html
+++ b/pygeoapi/templates/item.html
@@ -53,7 +53,7 @@
                     </ul>
                 </td>
                 {% else %}
-                <td>{{ v | urlize(25, target='_blank') }}</td>
+                <td>{{ v | urlize(25) }}</td>
                 {% endif %}
               </tr>
               {% endfor %}

--- a/pygeoapi/templates/items.html
+++ b/pygeoapi/templates/items.html
@@ -44,7 +44,7 @@
                 <td data-label="id"><a href="{{ data['items_path']}}/{{ ft.id }}">{{ ft.id }}</a></td>
                   {% for k, v in ft['properties'].items() %}
                   {% if loop.index < 5 %}
-                  <td data-label="{{ k }}">{{ v | urlize(20, target='_blank') }}</td>
+                  <td data-label="{{ k }}">{{ v | urlize(20) }}</td>
                   {% endif %}
                   {% endfor %}
               </tr>


### PR DESCRIPTION
Per http://jinja.pocoo.org/docs/2.10/templates/#urlize, this PR removes the `target` parameter from the jinja2 `urlize` filter for pre 2.8 installs of jinja2.