### PR TITLE
add canonical link to each html representation

### DIFF
--- a/pygeoapi/templates/base.html
+++ b/pygeoapi/templates/base.html
@@ -14,6 +14,9 @@
     <![endif]-->
     {% for link in data['links'] %}
       <link rel="{{ link['rel'] }}" type="{{ link['type'] }}" title="{{ link['title'] }}" href="{{ link['href'] }}"/>
+      {% if (link['rel']=="self" and link['type']=="text/html") %}
+      <link rel="canonical" href="{{ link['href'].split('?')[0] }}" />
+      {% endif %}
     {% endfor %}
     {% block extrahead %}
     {% endblock %}


### PR DESCRIPTION
fixes #150 

todo: make sure all methods return max (and at least) 1 "self" link of type "text/html"

toverify: for /items, if a filter is applied, does it make sense to use /items as canonical, or should it include the filter