### PR TITLE
Proposal for enabling property filtering with ogr provider

### DIFF
--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -176,6 +176,9 @@ class OGRProvider(BaseProvider):
         self.driver = None
         self.conn = None
 
+        LOGGER.debug('Grabbing field information')
+        self.fields = self.get_fields()
+    
     def _list_open_options(self):
         return [
             f"{key}={str(value)}" for key, value in self.open_options.items()]
@@ -284,6 +287,20 @@ class OGRProvider(BaseProvider):
 
                 # layer.SetSpatialFilterRect(
                 # float(minx), float(miny), float(maxx), float(maxy))
+
+            if properties:
+                LOGGER.debug('processing properties')
+
+                attribute_filter = ' and '.join(
+                    map(
+                        lambda x: '{} = \'{}\''.format(x[0], x[1]),
+                        properties
+                    )
+                )
+
+                LOGGER.debug(attribute_filter)
+
+                layer.SetAttributeFilter(attribute_filter)
 
             # Make response based on resulttype specified
             if resulttype == 'hits':

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -178,7 +178,7 @@ class OGRProvider(BaseProvider):
 
         LOGGER.debug('Grabbing field information')
         self.fields = self.get_fields()
-    
+
     def _list_open_options(self):
         return [
             f"{key}={str(value)}" for key, value in self.open_options.items()]

--- a/tests/test_ogr_gpkg_provider.py
+++ b/tests/test_ogr_gpkg_provider.py
@@ -362,3 +362,25 @@ def test_query_bbox_with_startindex_4326(config_gpkg_4326):
     assert geometry is not None
     assert properties['straatnaam'] == 'Egypte'
     assert properties['huisnummer'] == '6'
+
+
+def test_query_with_property_filtering(config_gpkg_4326):
+    """Testing query with property filtering"""
+
+    p = OGRProvider(config_gpkg_4326)
+
+    feature_collection = p.query(
+        properties=[
+            ('straatnaam', 'Arnhemseweg')
+        ]
+    )
+
+    assert feature_collection.get('type', None) == 'FeatureCollection'
+    features = feature_collection.get('features', None)
+    assert len(features) > 1
+
+    for feature in features:
+        assert 'properties' in feature
+        assert 'straatnaam' in feature['properties']
+
+        assert feature['properties']['straatnaam'] == 'Arnhemseweg'

--- a/tests/test_ogr_shapefile_provider.py
+++ b/tests/test_ogr_shapefile_provider.py
@@ -320,3 +320,25 @@ def test_query_bbox_with_startindex_4326(config_shapefile_4326):
     assert geometry is not None
     assert properties['straatnaam'] == 'Egypte'
     assert properties['huisnummer'] == '6'
+
+
+def test_query_with_property_filtering(config_shapefile_4326):
+    """Testing query with property filtering"""
+
+    p = OGRProvider(config_shapefile_4326)
+
+    feature_collection = p.query(
+        properties=[
+            ('straatnaam', 'Arnhemseweg')
+        ]
+    )
+
+    assert feature_collection.get('type', None) == 'FeatureCollection'
+    features = feature_collection.get('features', None)
+    assert len(features) > 1
+
+    for feature in features:
+        assert 'properties' in feature
+        assert 'straatnaam' in feature['properties']
+
+        assert feature['properties']['straatnaam'] == 'Arnhemseweg'

--- a/tests/test_ogr_sqlite_provider.py
+++ b/tests/test_ogr_sqlite_provider.py
@@ -183,3 +183,25 @@ def test_query_bbox_with_startindex_4326(config_sqlite_4326):
     assert geometry is not None
     assert properties['straatnaam'] == 'Egypte'
     assert properties['huisnummer'] == '4'
+
+
+def test_query_with_property_filtering(config_sqlite_4326):
+    """Testing query with property filtering"""
+
+    p = OGRProvider(config_sqlite_4326)
+
+    feature_collection = p.query(
+        properties=[
+            ('straatnaam', 'Arnhemseweg')
+        ]
+    )
+
+    assert feature_collection.get('type', None) == 'FeatureCollection'
+    features = feature_collection.get('features', None)
+    assert len(features) > 1
+
+    for feature in features:
+        assert 'properties' in feature
+        assert 'straatnaam' in feature['properties']
+
+        assert feature['properties']['straatnaam'] == 'Arnhemseweg'

--- a/tests/test_ogr_wfs_provider.py
+++ b/tests/test_ogr_wfs_provider.py
@@ -399,6 +399,46 @@ def test_query_with_startindex(config_MapServer_WFS):
     assert '101696.68' in properties['xrd']
     geometry = feature.get('geometry', None)
     assert geometry is not None
+
+
+def test_query_with_property_filtering_gs(config_GeoServer_WFS):
+    """Testing query with property filtering on geoserver backend"""
+
+    p = OGRProvider(config_GeoServer_WFS)
+
+    feature_collection = p.query(
+        properties=[
+            ('postcode', '9711LM'),
+            ('huisnummer', 106),
+        ]
+    )
+
+    for feature in feature_collection['features']:
+        assert 'properties' in feature
+        assert 'postcode' in feature['properties']
+        assert 'huisnummer' in feature['properties']
+
+        assert feature['properties']['postcode'] == '9711LM'
+        assert feature['properties']['huisnummer'] == 106
+
+
+def test_query_with_property_filtering_ms(config_MapServer_WFS):
+    """Testing query with property filtering on mapserver backend"""
+
+    p = OGRProvider(config_MapServer_WFS)
+
+    feature_collection = p.query(
+        properties=[
+            ('station', '21'),
+        ]
+    )
+
+    for feature in feature_collection['features']:
+        assert 'properties' in feature
+        assert 'station' in feature['properties']
+
+        assert feature['properties']['station'] == '21'
+
 #
 # # OK, but backend GeoServer PDOK WFS takes too much time....
 # # def test_query_with_limit_gs(config_GeoServer_WFS):


### PR DESCRIPTION
Being able to filter on the properties of ogr data sources is very important for me. So i've developed the following code to add this ability to the provider in question. I can improve upon this pull request and add tests if this feature is something you guys would consider adding.

I did wonder why `get_fields` was not used yet, perhaps there was a problem that prevented the loading of fields?

Using this project to consume legacy api's and expose them through a modern easy to implement protocol sounds very appealing to me, so i would love to help :+1: 