### PR TITLE
Issue 210 missing  HTTPS for schema.org

### DIFF
--- a/pygeoapi/templates/collection.html
+++ b/pygeoapi/templates/collection.html
@@ -5,8 +5,8 @@
 / <a href="./{{ data['name'] }}">{{ data['title'] }}</a>
 {% endblock %}
 {% block body %}
-    <section id="collection" itemscope itemtype="//schema.org/Dataset">
-      <span itemprop="includedInDataCatalog" itemscope itemtype="//schema.org/DataCatalog">
+    <section id="collection" itemscope itemtype="https://schema.org/Dataset">
+      <span itemprop="includedInDataCatalog" itemscope itemtype="https://schema.org/DataCatalog">
         <meta itemprop="url" content="{{ config['server']['url'] }}/collections" />
         <meta itemprop="name" content="{{ config['metadata']['identification']['title'] | striptags }}" />
         <meta itemprop="description" content="{{ config['metadata']['identification']['description'] | striptags }}" />
@@ -22,7 +22,7 @@
       <h3>View</h3>
       <ul>
         <li>
-          <div itemprop="distribution" itemscope itemtype="//schema.org/DataDownload">
+          <div itemprop="distribution" itemscope itemtype="https://schema.org/DataDownload">
             <meta itemprop="encodingFormat" content="text/html" />
             <a title="Browse Items" itemprop="contentURL" href="{{ config['server']['url'] }}/collections/{{ data['name'] }}/items">
               Browse through the items of "{{ data['title'] }}</a>"</div>
@@ -31,7 +31,7 @@
       <h3>Links</h3>
       <ul>
       {% for link in data['links'] %}
-          <li itemprop="distribution" itemscope itemtype="//schema.org/DataDownload">
+          <li itemprop="distribution" itemscope itemtype="https://schema.org/DataDownload">
             <a itemprop="contentURL" title="{{ link['rel'] }}" href="{{ link['href'] }}">
             <span itemprop="name">{{ link['title'] }}</span> (<span itemprop="encodingFormat">{{ link['type'] }}</span>)
             <meta itemprop="inLanguage" content="{{ link['hreflang'] }}" />

--- a/pygeoapi/templates/collection.html
+++ b/pygeoapi/templates/collection.html
@@ -7,7 +7,7 @@
 {% block body %}
     <section id="collection" itemscope itemtype="//schema.org/Dataset">
       <span itemprop="includedInDataCatalog" itemscope itemtype="//schema.org/DataCatalog">
-        <meta itemprop="url" content="{{ config['server']['url'] }}/collections/{{ data['name'] }}" />
+        <meta itemprop="url" content="{{ config['server']['url'] }}/collections" />
         <meta itemprop="name" content="{{ config['metadata']['identification']['title'] | striptags }}" />
         <meta itemprop="description" content="{{ config['metadata']['identification']['description'] | striptags }}" />
       </span>

--- a/pygeoapi/templates/collection.html
+++ b/pygeoapi/templates/collection.html
@@ -5,8 +5,8 @@
 / <a href="./{{ data['name'] }}">{{ data['title'] }}</a>
 {% endblock %}
 {% block body %}
-    <section id="collection" itemscope itemtype="http://schema.org/Dataset">
-      <span itemprop="includedInDataCatalog" itemscope itemtype="http://schema.org/DataCatalog">
+    <section id="collection" itemscope itemtype="//schema.org/Dataset">
+      <span itemprop="includedInDataCatalog" itemscope itemtype="//schema.org/DataCatalog">
         <meta itemprop="url" content="{{ config['server']['url'] }}/collections/{{ data['name'] }}" />
         <meta itemprop="name" content="{{ config['metadata']['identification']['title'] | striptags }}" />
         <meta itemprop="description" content="{{ config['metadata']['identification']['description'] | striptags }}" />
@@ -22,7 +22,7 @@
       <h3>View</h3>
       <ul>
         <li>
-          <div itemprop="distribution" itemscope itemtype="http://schema.org/DataDownload">
+          <div itemprop="distribution" itemscope itemtype="//schema.org/DataDownload">
             <meta itemprop="encodingFormat" content="text/html" />
             <a title="Browse Items" itemprop="contentURL" href="{{ config['server']['url'] }}/collections/{{ data['name'] }}/items">
               Browse through the items of "{{ data['title'] }}</a>"</div>
@@ -31,7 +31,7 @@
       <h3>Links</h3>
       <ul>
       {% for link in data['links'] %}
-          <li itemprop="distribution" itemscope itemtype="http://schema.org/DataDownload">
+          <li itemprop="distribution" itemscope itemtype="//schema.org/DataDownload">
             <a itemprop="contentURL" title="{{ link['rel'] }}" href="{{ link['href'] }}">
             <span itemprop="name">{{ link['title'] }}</span> (<span itemprop="encodingFormat">{{ link['type'] }}</span>)
             <meta itemprop="inLanguage" content="{{ link['hreflang'] }}" />

--- a/pygeoapi/templates/collections.html
+++ b/pygeoapi/templates/collections.html
@@ -4,7 +4,7 @@
 / <a href="./collections">Collections</a>
 {% endblock %}
 {% block body %}
-    <section id="collections" itemscope itemtype="//schema.org/DataCatalog">
+    <section id="collections" itemscope itemtype="https://schema.org/DataCatalog">
     <meta itemprop="url" content="{{ config['server']['url'] }}" />
     <meta itemprop="name" content="{{ config['metadata']['identification']['title'] | striptags }}" />
     <meta itemprop="description" content="{{ config['metadata']['identification']['description'] | striptags }}" />
@@ -18,7 +18,7 @@
               </thead>
               <tbody>
                 {% for k, v in config['datasets'].items() %}
-                <tr itemprop="dataset" itemscope itemtype="//schema.org/Dataset">
+                <tr itemprop="dataset" itemscope itemtype="https://schema.org/Dataset">
                   <td data-label="name">
                     <meta itemprop="url" content="{{ config['server']['url'] }}/collections/{{ k }}" />
                     <a  title="{{ v['title'] | striptags | truncate }}" 

--- a/pygeoapi/templates/collections.html
+++ b/pygeoapi/templates/collections.html
@@ -4,7 +4,7 @@
 / <a href="./collections">Collections</a>
 {% endblock %}
 {% block body %}
-    <section id="collections" itemscope itemtype="http://schema.org/DataCatalog">
+    <section id="collections" itemscope itemtype="//schema.org/DataCatalog">
     <meta itemprop="url" content="{{ config['server']['url'] }}" />
     <meta itemprop="name" content="{{ config['metadata']['identification']['title'] | striptags }}" />
     <meta itemprop="description" content="{{ config['metadata']['identification']['description'] | striptags }}" />
@@ -18,7 +18,7 @@
               </thead>
               <tbody>
                 {% for k, v in config['datasets'].items() %}
-                <tr itemprop="dataset" itemscope itemtype="http://schema.org/Dataset">
+                <tr itemprop="dataset" itemscope itemtype="//schema.org/Dataset">
                   <td data-label="name">
                     <meta itemprop="url" content="{{ config['server']['url'] }}/collections/{{ k }}" />
                     <a  title="{{ v['title'] | striptags | truncate }}" 

--- a/pygeoapi/templates/process.html
+++ b/pygeoapi/templates/process.html
@@ -5,7 +5,7 @@
 / <a href="./{{ data['id'] }}">{{ data['title'] }}</a>
 {% endblock %}
 {% block body %}
-    <section id="processes" itemscope itemtype="//schema.org/WebAPI">
+    <section id="processes" itemscope itemtype="https://schema.org/WebAPI">
       <h2 itemprop="name">{{ data['title'] }}</h2>
       <div itemprop="description">{{ data['description'] }}</div>
       <meta itemprop="url" content="{{ config['server']['url'] }}/processes/{{ data['id'] }}" />
@@ -22,7 +22,7 @@
               </thead>
               <tbody>
                 {% for input_ in data['inputs'] %}
-                <tr itemprop="parameter" itemscope itemtype="//schema.org/Parameter">
+                <tr itemprop="parameter" itemscope itemtype="https://schema.org/Parameter">
                   <td itemprop="id" data-label="name">{{ input_['id'] }}</td>
                   <td itemprop="name" data-label="title">{{ input_['title'] }}</td>
                   <td itemprop="description" data-label="description">

--- a/pygeoapi/templates/process.html
+++ b/pygeoapi/templates/process.html
@@ -5,7 +5,7 @@
 / <a href="./{{ data['id'] }}">{{ data['title'] }}</a>
 {% endblock %}
 {% block body %}
-    <section id="processes" itemscope itemtype="http://schema.org/WebAPI">
+    <section id="processes" itemscope itemtype="//schema.org/WebAPI">
       <h2 itemprop="name">{{ data['title'] }}</h2>
       <div itemprop="description">{{ data['description'] }}</div>
       <meta itemprop="url" content="{{ config['server']['url'] }}/processes/{{ data['id'] }}" />
@@ -22,7 +22,7 @@
               </thead>
               <tbody>
                 {% for input_ in data['inputs'] %}
-                <tr itemprop="parameter" itemscope itemtype="http://schema.org/Parameter">
+                <tr itemprop="parameter" itemscope itemtype="//schema.org/Parameter">
                   <td itemprop="id" data-label="name">{{ input_['id'] }}</td>
                   <td itemprop="name" data-label="title">{{ input_['title'] }}</td>
                   <td itemprop="description" data-label="description">

--- a/pygeoapi/templates/processes.html
+++ b/pygeoapi/templates/processes.html
@@ -19,7 +19,7 @@
               </thead>
               <tbody>
                 {% for p in data['processes'] %}
-                <tr itemscope itemtype="http://schema.org/WebAPI">
+                <tr itemscope itemtype="//schema.org/WebAPI">
                   <td itemprop="name" data-label="name">
                     <meta itemprop="url" content="{{ config['server']['url'] }}/processes/{{ p['id'] }}" />
                     <a title="{{ p['title'] | striptags | truncate }}" href="{{ config['server']['url'] }}/processes/{{ p['id'] }}">{{ p['title'] | striptags | truncate }}</a>

--- a/pygeoapi/templates/processes.html
+++ b/pygeoapi/templates/processes.html
@@ -19,7 +19,7 @@
               </thead>
               <tbody>
                 {% for p in data['processes'] %}
-                <tr itemscope itemtype="//schema.org/WebAPI">
+                <tr itemscope itemtype="https://schema.org/WebAPI">
                   <td itemprop="name" data-label="name">
                     <meta itemprop="url" content="{{ config['server']['url'] }}/processes/{{ p['id'] }}" />
                     <a title="{{ p['title'] | striptags | truncate }}" href="{{ config['server']['url'] }}/processes/{{ p['id'] }}">{{ p['title'] | striptags | truncate }}</a>

--- a/pygeoapi/templates/root.html
+++ b/pygeoapi/templates/root.html
@@ -3,7 +3,7 @@
 {% block body %}
 
 <br/>
-<section id="collections"  itemscope itemtype="//schema.org/DataCatalog">
+<section id="collections"  itemscope itemtype="https://schema.org/DataCatalog">
   <meta itemprop="url" content="{{ config['server']['url'] }}" />
 <div class="row">
   <div class="col-md-8 col-sm-12">
@@ -72,7 +72,7 @@
   </section>
 
   </div>
-  <div class="col-md-4 col-sm-12" itemprop="provider" itemscope itemtype="//schema.org/Organization">
+  <div class="col-md-4 col-sm-12" itemprop="provider" itemscope itemtype="https://schema.org/Organization">
     <div class="card fluid">
       <div class="section dark">
        <b>Provider</b>
@@ -87,9 +87,9 @@
       <div class="section dark">
           <b>Contact point</b>
       </div>
-      <div class="section" itemprop="contactPoint" itemscope itemtype="//schema.org/ContactPoint">
+      <div class="section" itemprop="contactPoint" itemscope itemtype="https://schema.org/ContactPoint">
         <b>Address</b><br/>
-        <div class="section" itemprop="address" itemscope itemtype="//schema.org/PostalAddress">
+        <div class="section" itemprop="address" itemscope itemtype="https://schema.org/PostalAddress">
           <span itemprop="streetAddress">{{ config['metadata']['contact']['address'] }}</span><br/>
           <span itemprop="addressLocality">{{ config['metadata']['contact']['city'] }}</span>,
           <span itemprop="addressRegion">{{ config['metadata']['contact']['stateorprovince'] }}</span><br/>

--- a/pygeoapi/templates/root.html
+++ b/pygeoapi/templates/root.html
@@ -3,7 +3,7 @@
 {% block body %}
 
 <br/>
-<section id="collections"  itemscope itemtype="http://schema.org/DataCatalog">
+<section id="collections"  itemscope itemtype="//schema.org/DataCatalog">
   <meta itemprop="url" content="{{ config['server']['url'] }}" />
 <div class="row">
   <div class="col-md-8 col-sm-12">
@@ -72,7 +72,7 @@
   </section>
 
   </div>
-  <div class="col-md-4 col-sm-12" itemprop="provider" itemscope itemtype="http://schema.org/Organization">
+  <div class="col-md-4 col-sm-12" itemprop="provider" itemscope itemtype="//schema.org/Organization">
     <div class="card fluid">
       <div class="section dark">
        <b>Provider</b>
@@ -87,9 +87,9 @@
       <div class="section dark">
           <b>Contact point</b>
       </div>
-      <div class="section" itemprop="contactPoint" itemscope itemtype="http://schema.org/ContactPoint">
+      <div class="section" itemprop="contactPoint" itemscope itemtype="//schema.org/ContactPoint">
         <b>Address</b><br/>
-        <div class="section" itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        <div class="section" itemprop="address" itemscope itemtype="//schema.org/PostalAddress">
           <span itemprop="streetAddress">{{ config['metadata']['contact']['address'] }}</span><br/>
           <span itemprop="addressLocality">{{ config['metadata']['contact']['city'] }}</span>,
           <span itemprop="addressRegion">{{ config['metadata']['contact']['stateorprovince'] }}</span><br/>


### PR DESCRIPTION
closes #210 and #213  

It was implemmented a generic schema (//) on schema.org links. Code was then tested using a pygeoapi/Gunicorn using HTTPS local certificates (https://github.com/FiloSottile/mkcert)

Browser didn't reported any mixed content problem

I requesting for @pvgenuchten  to comment on ticket #213  and check if there is changes needed