### PR TITLE
fix ES dependency

### DIFF
--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -1,3 +1,3 @@
-elasticsearch==7.0.5
+elasticsearch==7.0.4
 GDAL>=2.2,<3.0
 psycopg2==2.7.6

--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -1,3 +1,3 @@
-elasticsearch
+elasticsearch==7.0.5
 GDAL>=2.2,<3.0
 psycopg2==2.7.6


### PR DESCRIPTION
Looks like ES support broke with 7.0.5 of the package.  Pinning to 7.0.4 for now to get the build passing again.  For good measure I've followed up with an [issue](https://github.com/elastic/elasticsearch-py/issues/1026) upstream.