### PR TITLE
api: fix to report an array of bbox in collection description

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -295,9 +295,14 @@ class API(object):
             collection['description'] = v['description']
             collection['keywords'] = v['keywords']
 
+            bbox = v['extents']['spatial']['bbox']
+            # The output should be an array of bbox, so if the user only
+            # provided a single bbox, wrap it in a array.
+            if not isinstance(bbox[0], list):
+                bbox = [bbox]
             collection['extent'] = {
                 'spatial': {
-                    'bbox': v['extents']['spatial']['bbox']
+                    'bbox': bbox
                 }
             }
             if 'crs' in v['extents']['spatial']:

--- a/tests/pygeoapi-test-config.yml
+++ b/tests/pygeoapi-test-config.yml
@@ -83,7 +83,7 @@ metadata:
 datasets:
     obs:
         title: Observations
-        description: Observations
+        description: Observations_description
         keywords:
             - observations
             - monitoring

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -169,8 +169,18 @@ def test_describe_collections(config, api_):
 
     assert collection['id'] == 'obs'
     assert collection['title'] == 'Observations'
-    assert collection['description'] == 'Observations'
+    assert collection['description'] == 'Observations_description'
     assert len(collection['links']) == 6
+    assert collection['extent'] == {
+        'spatial': {
+            'bbox': [[-180, -90, 180, 90]],
+            'crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+        },
+        'temporal': {
+            'interval': [['2000-10-30T18:24:39', '2007-10-30T08:57:29']],
+            'trs': 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+        }
+    }
 
     rsp_headers, code, response = api_.describe_collections(
         req_headers, {'f': 'html'}, 'obs')


### PR DESCRIPTION
The latest version of the OAPI-F spec mandates the bbox to be
advertized as an array of bbox.
This commits accept the service configuration to have just
a single bbox or an array of bbox, and adapt accordingly to
generate the collection description.