### PR TITLE
Added serialization for Decimal to util.py

### DIFF
--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -30,6 +30,7 @@
 """Generic util functions used in the code"""
 
 from datetime import date, datetime, time
+from decimal import Decimal
 import logging
 
 import yaml
@@ -101,6 +102,8 @@ def json_serial(obj):
     if isinstance(obj, (datetime, date, time)):
         serial = obj.isoformat()
         return serial
+    elif isinstance(obj, Decimal):
+        return float(obj)
 
     msg = '{} type {} not serializable'.format(obj, type(obj))
     LOGGER.error(msg)


### PR DESCRIPTION
In my testing of the postgresql provider, I have a table which contains "number" columns. The postgres provider converts this column to a `decimal.Decimal` which can not be serialized. I added the fix to util.py. The same Stack Overflow issue also references added an additional handler for decimal.Decimal.

I have not updated the tests. This would require adding a column to the test data which I would be happy to do.