### PR TITLE
Fixes Issue 269

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,3 @@ openapi.yml
 
 #Eclipse project
 .project
-docker-compose.yml
-.gitignore
-notes.txt
-pygeoapi-config-local.yml

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ openapi.yml
 
 #Eclipse project
 .project
+docker-compose.yml
+.gitignore
+notes.txt
+pygeoapi-config-local.yml

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -72,8 +72,11 @@ class DatabaseConnection(object):
              (defaults to UNIX socket if not provided)
             port – connection port number
              (defaults to 5432 if not provided)
-            schema – schema to use as search path, normally
-             data is in the public schema
+            search_path – search path to be used (by order) , normally
+             data is in the public schema, [public],
+             or in a specific schema ["osm", "public"].
+             Note: First we should have the schema
+             being used and then public
 
         :param table: table name containing the data. This variable is used to
                 assemble column information
@@ -87,18 +90,18 @@ class DatabaseConnection(object):
         self.context = context
         self.columns = None
         self.conn = None
-        self.schema = None
 
     def __enter__(self):
         try:
-            self.schema = self.conn_dic.pop('schema', None)
-            if self.schema == 'public' or self.schema is None:
+            self.search_path = self.conn_dic.pop('search_path', None)
+            if self.search_path is ['public'] or self.search_path is None:
                 pass
             else:
-                self.conn_dic["options"] = '-c search_path={}'.format(
-                    self.schema)
-                LOGGER.debug('Using schema {} as search path'.format(
-                    self.schema))
+                if "public" not in self.search_path:
+                    self.search_path = self.search_path + ["publc"]
+                self.search_path = ",".join(self.search_path)
+                self.conn_dic["options"] = f'-c search_path={self.search_path}'
+                LOGGER.debug(f'Using search path: {self.search_path} ')
             self.conn = psycopg2.connect(**self.conn_dic)
 
         except psycopg2.OperationalError:
@@ -149,6 +152,8 @@ class PostgreSQLProvider(BaseProvider):
         self.table = provider_def['table']
         self.id_field = provider_def['id_field']
         self.conn_dic = provider_def['data']
+        self.geom = provider_def.get('geom_field') \
+            if provider_def.get('geom_field') else "geom"
 
         LOGGER.debug('Setting Postgresql properties:')
         LOGGER.debug('Connection String:{}'.format(
@@ -188,7 +193,8 @@ class PostgreSQLProvider(BaseProvider):
                 except Exception as err:
                     LOGGER.error('Error executing sql_query: {}: {}'.format(
                         sql_query.as_string(cursor)), err)
-                    LOGGER.error('Using public schema: {}'.format(db.schema))
+                    LOGGER.error('Using search_path : {}'.format(
+                        db.search_path))
                     raise ProviderQueryError()
 
                 hits = cursor.fetchone()["hits"]
@@ -202,7 +208,7 @@ class PostgreSQLProvider(BaseProvider):
             sql_query = SQL("DECLARE \"geo_cursor\" CURSOR FOR \
              SELECT {0},ST_AsGeoJSON({1}) FROM {2}").\
                 format(db.columns,
-                       Identifier('geom'),
+                       Identifier(self.geom),
                        Identifier(self.table))
 
             LOGGER.debug('SQL Query: {}'.format(sql_query))
@@ -216,7 +222,7 @@ class PostgreSQLProvider(BaseProvider):
             except Exception as err:
                 LOGGER.error('Error executing sql_query: {}'.format(
                     sql_query.as_string(cursor)))
-                LOGGER.error('Using public schema: {}'.format(db.schema))
+                LOGGER.error('Using search_path: {}'.format(db.search_path))
                 LOGGER.error(err)
                 raise ProviderQueryError()
 
@@ -249,7 +255,7 @@ class PostgreSQLProvider(BaseProvider):
 
             sql_query = SQL("select {0},ST_AsGeoJSON({1}) \
             from {2} WHERE {3}=%s").format(db.columns,
-                                           Identifier('geom'),
+                                           Identifier(self.geom),
                                            Identifier(self.table),
                                            Identifier(self.id_field))
 
@@ -260,7 +266,7 @@ class PostgreSQLProvider(BaseProvider):
             except Exception as err:
                 LOGGER.error('Error executing sql_query: {}'.format(
                     sql_query.as_string(cursor)))
-                LOGGER.error('Using public schema: {}'.format(db.schema))
+                LOGGER.error('Using search path : {}'.format(db.search_path))
                 LOGGER.error(err)
                 raise ProviderQueryError()
 

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -188,8 +188,6 @@ class PostgreSQLProvider(BaseProvider):
                 except Exception as err:
                     LOGGER.error('Error executing sql_query: {}: {}'.format(
                         sql_query.as_string(cursor)), err)
-                    LOGGER.error('Using search_path : {}'.format(
-                        db.search_path))
                     raise ProviderQueryError()
 
                 hits = cursor.fetchone()["hits"]
@@ -217,7 +215,6 @@ class PostgreSQLProvider(BaseProvider):
             except Exception as err:
                 LOGGER.error('Error executing sql_query: {}'.format(
                     sql_query.as_string(cursor)))
-                LOGGER.error('Using search_path: {}'.format(db.search_path))
                 LOGGER.error(err)
                 raise ProviderQueryError()
 
@@ -261,7 +258,6 @@ class PostgreSQLProvider(BaseProvider):
             except Exception as err:
                 LOGGER.error('Error executing sql_query: {}'.format(
                     sql_query.as_string(cursor)))
-                LOGGER.error('Using search path : {}'.format(db.search_path))
                 LOGGER.error(err)
                 raise ProviderQueryError()
 

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -93,15 +93,10 @@ class DatabaseConnection(object):
 
     def __enter__(self):
         try:
-            self.search_path = self.conn_dic.pop('search_path', None)
-            if self.search_path is ['public'] or self.search_path is None:
-                pass
-            else:
-                if "public" not in self.search_path:
-                    self.search_path = self.search_path + ["publc"]
-                self.search_path = ",".join(self.search_path)
-                self.conn_dic["options"] = f'-c search_path={self.search_path}'
-                LOGGER.debug(f'Using search path: {self.search_path} ')
+            search_path = self.conn_dic.pop('search_path', ['public'])
+            if search_path != ['public']:
+                self.conn_dic["options"] = f'-c search_path={search_path}'
+                LOGGER.debug(f'Using search path: {search_path} ')
             self.conn = psycopg2.connect(**self.conn_dic)
 
         except psycopg2.OperationalError:
@@ -152,8 +147,7 @@ class PostgreSQLProvider(BaseProvider):
         self.table = provider_def['table']
         self.id_field = provider_def['id_field']
         self.conn_dic = provider_def['data']
-        self.geom = provider_def.get('geom_field') \
-            if provider_def.get('geom_field') else "geom"
+        self.geom = provider_def.get('geom_field','geom')
 
         LOGGER.debug('Setting Postgresql properties:')
         LOGGER.debug('Connection String:{}'.format(

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -95,7 +95,8 @@ class DatabaseConnection(object):
         try:
             search_path = self.conn_dic.pop('search_path', ['public'])
             if search_path != ['public']:
-                self.conn_dic["options"] = f'-c search_path={search_path}'
+                self.conn_dic["options"] = f'-c \
+                search_path={",".join(search_path)}'
                 LOGGER.debug(f'Using search path: {search_path} ')
             self.conn = psycopg2.connect(**self.conn_dic)
 
@@ -147,7 +148,7 @@ class PostgreSQLProvider(BaseProvider):
         self.table = provider_def['table']
         self.id_field = provider_def['id_field']
         self.conn_dic = provider_def['data']
-        self.geom = provider_def.get('geom_field','geom')
+        self.geom = provider_def.get('geom_field', 'geom')
 
         LOGGER.debug('Setting Postgresql properties:')
         LOGGER.debug('Connection String:{}'.format(

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -30,6 +30,7 @@
 """Generic util functions used in the code"""
 
 from datetime import date, datetime, time
+from decimal import Decimal
 import logging
 
 import yaml
@@ -101,6 +102,8 @@ def json_serial(obj):
     if isinstance(obj, (datetime, date, time)):
         serial = obj.isoformat()
         return serial
+    elif isinstance(obj, Decimal):
+        return float(obj)
 
     msg = '{} type {} not serializable'.format(obj, type(obj))
     LOGGER.error(msg)

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -42,10 +42,12 @@ def config():
         'data': {'host': '127.0.0.1',
                  'dbname': 'test',
                  'user': 'postgres',
-                 'password': 'postgres'
+                 'password': 'postgres',
+                 'search_path': ['osm', 'public']
                  },
         'id_field': 'osm_id',
-        'table': 'hotosm_bdi_waterways'
+        'table': 'hotosm_bdi_waterways',
+        'geom_field': 'foo_geom'
     }
 
 


### PR DESCRIPTION
Based on the discussion on #269  Have implemented the following configuration on the postgresql driver:

```
        provider:
            name: PostgreSQL
            data:
                host: 127.0.0.1
                dbname: test
                user: postgres
                password: postgres
                port: 5432
                search_path: [osm,public]
            id_field: osm_id
            table: hotosm_bdi_waterways
            geom_field: foo_geom
```

There is no `schema` parameters since using the proposed search path `[x, public] ` will ensure that tables are found and functions in PostGIS are properly called

The dataset  `hotosm_bdi_waterways` has been updated to use a specific schema and defined geometry column. 

If geometry column is not defined it will be set to 'geom' and if no search path is set then it will be public