### PR TITLE
Arbitrary query used for base of collection.

### DIFF
--- a/pygeoapi/plugin.py
+++ b/pygeoapi/plugin.py
@@ -43,7 +43,8 @@ PLUGINS = {
         'GeoPackage': 'pygeoapi.provider.geopackage.GeoPackageProvider',
         'OGR': 'pygeoapi.provider.ogr.OGRProvider',
         'PostgreSQL': 'pygeoapi.provider.postgresql.PostgreSQLProvider',
-        'PostgreSQLQuery': 'pygeoapi.provider.postgres_query.PostgreSQLQueryProvider',
+        'PostgreSQLQuery':
+            'pygeoapi.provider.postgres_query.PostgreSQLQueryProvider',
         'SQLite': 'pygeoapi.provider.sqlite.SQLiteProvider'
     },
     'formatter': {

--- a/pygeoapi/plugin.py
+++ b/pygeoapi/plugin.py
@@ -43,6 +43,7 @@ PLUGINS = {
         'GeoPackage': 'pygeoapi.provider.geopackage.GeoPackageProvider',
         'OGR': 'pygeoapi.provider.ogr.OGRProvider',
         'PostgreSQL': 'pygeoapi.provider.postgresql.PostgreSQLProvider',
+        'PostgreSQLQuery': 'pygeoapi.provider.postgres_query.PostgreSQLQueryProvider',
         'SQLite': 'pygeoapi.provider.sqlite.SQLiteProvider'
     },
     'formatter': {

--- a/pygeoapi/provider/postgres_query.py
+++ b/pygeoapi/provider/postgres_query.py
@@ -1,0 +1,316 @@
+# =================================================================
+#
+# Authors: Jorge Samuel Mendes de Jesus <jorge.dejesus@protonmail.com>
+#          Tom Kralidis <tomkralidis@gmail.com>
+#          Mary Bucknell <mbucknell@usgs.gov>
+#
+# Copyright (c) 2018 Jorge Samuel Mendes de Jesus
+# Copyright (c) 2019 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+# Testing local docker:
+# docker run --name "postgis" \
+# -v postgres_data:/var/lib/postgresql -p 5432:5432 \
+# -e ALLOW_IP_RANGE=0.0.0.0/0 \
+# -e POSTGRES_USER=postgres \
+# -e POSTGRES_PASS=postgres \
+# -e POSTGRES_DBNAME=test \
+# -d -t kartoza/postgis
+
+# Import dump:
+# gunzip < tests/data/hotosm_bdi_waterways.sql.gz |
+#  psql -U postgres -h 127.0.0.1 -p 5432 test
+
+import logging
+import json
+import psycopg2
+from psycopg2.sql import SQL, Identifier, Literal
+from pygeoapi.provider.base import BaseProvider, \
+    ProviderConnectionError, ProviderQueryError
+
+from psycopg2.extras import RealDictCursor
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DatabaseConnection(object):
+    """Database connection class to be used as 'with' statement.
+     The class returns a connection object.
+    """
+
+    def __init__(self, conn_dic, columns, context="query"):
+        """
+        PostgreSQLProvider Class constructor returning
+        :param conn_dic: dictionary with connection parameters
+                    to be used by psycopg2
+            dbname – the database name (database is a deprecated alias)
+            user – user name used to authenticate
+            password – password used to authenticate
+            host – database host address
+             (defaults to UNIX socket if not provided)
+            port – connection port number
+             (defaults to 5432 if not provided)
+            search_path – search path to be used (by order) , normally
+             data is in the public schema, [public],
+             or in a specific schema ["osm", "public"].
+             Note: First we should have the schema
+             being used and then public
+        :param columns: list of dictionaries mapping column names to property names
+        :param context: query or hits, if query then it will determine
+                table column otherwise will not do it
+        :returns: psycopg2.extensions.connection
+        """
+
+        self.conn_dic = conn_dic
+        self.context = context
+        self.columns = (', ').join(
+                ['{} "{}"'.format(col, prop) for (col, prop) in columns.items()])
+        self.fields = dict((v, '') for v in columns.values())
+        self.conn = None
+
+    def __enter__(self):
+        try:
+            search_path = self.conn_dic.pop('search_path', ['public'])
+            if search_path != ['public']:
+                self.conn_dic["options"] = f'-c \
+                search_path={",".join(search_path)}'
+                LOGGER.debug(f'Using search path: {search_path} ')
+            self.conn = psycopg2.connect(**self.conn_dic)
+
+        except psycopg2.OperationalError:
+            LOGGER.error('Couldnt connect to Postgis using:{}'.format(
+                str(self.conn_dic)))
+            raise ProviderConnectionError()
+
+        self.cur = self.conn.cursor()
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # some logic to commit/rollback
+        self.conn.close()
+
+
+class PostgreSQLQueryProvider(BaseProvider):
+    """Generic provider for Postgresql based on psycopg2
+    using sync approach and server side
+    cursor (using support class DatabaseCursor)
+    """
+
+    ## TODO: think about SQL injection and how to sanitize the query config parameter
+
+    def __init__(self, provider_def):
+        """
+        PostgreSQLProvider Class constructor
+        :param provider_def: provider definitions from yml pygeoapi-config.
+                             data, name, id_field and query set in parent class
+                             data contains the connection information
+                             for class DatabaseCursor
+        :returns: pygeoapi.providers.base.PostgreSQLProvider
+        """
+
+        BaseProvider.__init__(self, provider_def)
+
+        self.name = provider_def['name']
+        self.query_table = provider_def['query_table']
+        self.id_field = provider_def['id_field']
+        self.conn_dic = provider_def['data']
+        self.geom = provider_def.get('geom_field', 'geom')
+        self.columns = provider_def.get('column_property_mapping');
+        self.properties_to_cols = dict(zip(self.columns.values(), self.columns.keys()))
+
+        LOGGER.debug('Setting Postgresql properties:')
+        LOGGER.debug('Connection String:{}'.format(
+            ",".join(("{}={}".format(*i) for i in self.conn_dic.items()))))
+        LOGGER.debug('Name:{}'.format(self.name))
+        LOGGER.debug('ID_field:{}'.format(self.id_field))
+        LOGGER.debug('Query:{}'.format(self.query_table))
+
+        LOGGER.debug('Get available fields/properties')
+        self.get_fields()
+
+    def get_fields(self):
+        if not self.fields:
+            with DatabaseConnection(self.conn_dic, self.columns) as db:
+                self.fields = db.fields
+        return self.fields
+
+    def query(self, startindex=0, limit=10, resulttype='results',
+              bbox=[], datetime=None, properties=[], sortby=[]):
+        """
+        Query Postgis for all the content.
+        e,g: http://localhost:5000/collections/hotosm_bdi_waterways/items?
+        limit=1&resulttype=results
+        :param startindex: starting record to return (default 0)
+        :param limit: number of records to return (default 10)
+        :param resulttype: return results or hit limit (default results)
+        :param bbox: bounding box [minx,miny,maxx,maxy]
+        :param datetime: temporal (datestamp or extent)
+        :param properties: list of tuples (name, value)
+        :param sortby: list of dicts (property, order)
+        :returns: GeoJSON FeaturesCollection
+        """
+        LOGGER.debug('Querying PostGIS')
+
+        if resulttype == 'hits':
+
+            with DatabaseConnection(self.conn_dic,
+                                    self.columns, context="hits") as db:
+                cursor = db.conn.cursor(cursor_factory=RealDictCursor)
+                sql_query = SQL("select count(*) as hits from {}").\
+                    format(SQL(self.query_table))
+                try:
+                    cursor.execute(sql_query)
+                except Exception as err:
+                    LOGGER.error('Error executing sql_query: {}: {}'.format(
+                        sql_query.as_string(cursor)), err)
+                    raise ProviderQueryError()
+
+                hits = cursor.fetchone()["hits"]
+
+            return self.__response_feature_hits(hits)
+
+        end_index = startindex + limit
+
+        with DatabaseConnection(self.conn_dic, self.columns) as db:
+            cursor = db.conn.cursor(cursor_factory=RealDictCursor)
+            if properties:
+                property_clauses = \
+                    [SQL('{0} = {1}').format(
+                        Identifier(self.properties_to_cols.get(k)), Literal(v)) for k, v in properties]
+                where_clause = \
+                    SQL(' WHERE {0}').format(
+                        SQL(' AND ').join(property_clauses)).as_string(cursor)
+            else:
+                where_clause = ''
+            ## TODO add in geom when geom column is available
+            sql_query = \
+                SQL("DECLARE \"geo_cursor\" CURSOR FOR \
+                SELECT {0} FROM {1}{2}".
+                    format(db.columns, self.query_table, where_clause))
+
+            #sql_query = SQL("DECLARE \"geo_cursor\" CURSOR FOR \
+            # SELECT {0},ST_AsGeoJSON({1}) FROM {2}{3}").\
+            #    format(db.columns,
+            #           Identifier(self.geom),
+            #           Identifier(self.table),
+            #           where_clause)
+
+            LOGGER.debug('SQL Query: {}'.format(sql_query.as_string(cursor)))
+            LOGGER.debug('Start Index: {}'.format(startindex))
+            LOGGER.debug('End Index: {}'.format(end_index))
+            try:
+                cursor.execute(sql_query)
+                for index in [startindex, limit]:
+                    cursor.execute("fetch forward {} from geo_cursor"
+                                   .format(index))
+            except Exception as err:
+                LOGGER.error('Error executing sql_query: {}'.format(
+                    sql_query.as_string(cursor)))
+                LOGGER.error(err)
+                raise ProviderQueryError()
+
+            row_data = cursor.fetchall()
+
+            feature_collection = {
+                'type': 'FeatureCollection',
+                'features': []
+            }
+
+            for rd in row_data:
+                feature_collection['features'].append(
+                    self.__response_feature(rd))
+
+            return feature_collection
+
+    def get(self, identifier):
+        """
+        Query the provider for a specific
+        feature id e.g: /collections/hotosm_bdi_waterways/items/13990765
+        :param identifier: feature id
+        :returns: GeoJSON FeaturesCollection
+        """
+
+        #TODO: Add back in geom query when available
+        LOGGER.debug('Get item from Postgis')
+        with DatabaseConnection(self.conn_dic, self.columns) as db:
+            cursor = db.conn.cursor(cursor_factory=RealDictCursor)
+
+            sql_query = SQL("SELECT {} FROM {} WHERE {}=%s".format(
+                db.columns, self.query_table, self.id_field)
+            )
+
+            #sql_query = SQL("select {0},ST_AsGeoJSON({1}) \
+            #from {2} WHERE {3}=%s").format(db.columns,
+            #                               Identifier(self.geom),
+            #                               Identifier(self.table),
+            #                               Identifier(self.id_field))
+
+            LOGGER.debug('SQL Query: {}'.format(sql_query.as_string(db.conn)))
+            LOGGER.debug('Identifier: {}'.format(identifier))
+            try:
+                cursor.execute(sql_query, (identifier, ))
+            except Exception as err:
+                LOGGER.error('Error executing sql_query: {}'.format(
+                    sql_query.as_string(cursor)))
+                LOGGER.error(err)
+                raise ProviderQueryError()
+
+            row_data = cursor.fetchall()[0]
+            feature = self.__response_feature(row_data)
+
+            return feature
+
+    def __response_feature(self, row_data):
+        """
+        Assembles GeoJSON output from DB query
+        :param row_data: DB row result
+        :returns: `dict` of GeoJSON Feature
+        """
+
+        rd = dict(row_data)
+        feature = {
+            'type': 'Feature'
+        }
+        feature["geometry"] = {} #TODO: Add this back in json.loads(
+            #rd.pop('st_asgeojson'))
+
+        feature['properties'] = rd
+        feature['id'] = rd.pop(self.columns.get(self.id_field))
+
+        return feature
+
+    def __response_feature_hits(self, hits):
+        """Assembles GeoJSON/Feature number
+        e.g: http://localhost:5000/collections/
+        hotosm_bdi_waterways/items?resulttype=hits
+        :returns: GeoJSON FeaturesCollection
+        """
+
+        feature_collection = {"features": [],
+                              "type": "FeatureCollection"}
+        feature_collection['numberMatched'] = hits
+
+        return feature_collection

--- a/pygeoapi/provider/postgres_query.py
+++ b/pygeoapi/provider/postgres_query.py
@@ -93,7 +93,8 @@ class DatabaseConnection(object):
             self.conn = psycopg2.connect(**self.conn_dic)
 
         except psycopg2.OperationalError:
-            LOGGER.error(f'Couldn\'t connect to Postgis using: {self.conn_dic!s}')
+            LOGGER.error(
+                f'Couldn\'t connect to Postgis using: {self.conn_dic!s}')
             raise ProviderConnectionError()
 
         self.cur = self.conn.cursor()
@@ -172,7 +173,8 @@ class PostgreSQLQueryProvider(BaseProvider):
         if properties:
             property_clauses = \
                 [SQL('{} = {}').format(
-                    Identifier(self.properties_to_cols[k]), Literal(v)) for k, v in properties]
+                    Identifier(self.properties_to_cols[k]),
+                    Literal(v)) for k, v in properties]
             where_conditions += property_clauses
         if bbox:
             bbox_clause = SQL('{} && ST_MakeEnvelope({})').format(
@@ -250,8 +252,14 @@ class PostgreSQLQueryProvider(BaseProvider):
         with DatabaseConnection(self.conn_dic) as db:
             cursor = db.conn.cursor(cursor_factory=RealDictCursor)
 
-            sql_query = SQL('SELECT {}, {}, ST_AsGeoJSON({})  FROM {} WHERE {}=%s').format(
-                self.columns, Identifier(self.id_field),Identifier(self.geom), SQL(self.query_table), Identifier(self.id_field))
+            sql_query = \
+                SQL('SELECT {}, {}, ST_AsGeoJSON({})  FROM {} WHERE {}=%s') \
+                    .format(
+                    self.columns,
+                    Identifier(self.id_field),
+                    Identifier(self.geom),
+                    SQL(self.query_table),
+                    Identifier(self.id_field))
 
             LOGGER.debug('SQL Query: {}'.format(sql_query.as_string(db.conn)))
             LOGGER.debug('Identifier: {}'.format(identifier))

--- a/pygeoapi/provider/postgres_query.py
+++ b/pygeoapi/provider/postgres_query.py
@@ -129,7 +129,8 @@ class PostgreSQLQueryProvider(BaseProvider):
         self.id_field = provider_def['id_field']
         self.conn_dic = provider_def['data']
         self.geom = provider_def.get('geom_field', 'geom')
-        self.columns_to_properties = provider_def.get('column_property_mapping')
+        self.columns_to_properties = \
+            provider_def.get('column_property_mapping')
         self.columns = SQL(', ').join(
             [SQL('{} {}').format(Identifier(col), Identifier(prop))
              for (col, prop) in self.columns_to_properties.items()])
@@ -215,11 +216,14 @@ class PostgreSQLQueryProvider(BaseProvider):
 
             with DatabaseConnection(self.conn_dic) as db:
                 cursor = db.conn.cursor(cursor_factory=RealDictCursor)
-                sql_query = SQL(
-                'DECLARE "geo_cursor" CURSOR FOR {} FROM {} {}'
-                ).format(select_clause, SQL(self.query_table), where_clause)
+                sql_query = \
+                    SQL('DECLARE "geo_cursor" CURSOR FOR {} FROM {} {}'
+                        ).format(select_clause,
+                                 SQL(self.query_table),
+                                 where_clause)
 
-                LOGGER.debug('SQL Query: {}'.format(sql_query.as_string(cursor)))
+                LOGGER.debug('SQL Query: {}'.format(
+                    sql_query.as_string(cursor)))
                 LOGGER.debug('Start Index: {}'.format(startindex))
                 LOGGER.debug('End Index: {}'.format(startindex + limit))
                 try:
@@ -252,14 +256,14 @@ class PostgreSQLQueryProvider(BaseProvider):
         with DatabaseConnection(self.conn_dic) as db:
             cursor = db.conn.cursor(cursor_factory=RealDictCursor)
 
-            sql_query = \
-                SQL('SELECT {}, {}, ST_AsGeoJSON({})  FROM {} WHERE {}=%s') \
-                    .format(
-                    self.columns,
-                    Identifier(self.id_field),
-                    Identifier(self.geom),
-                    SQL(self.query_table),
-                    Identifier(self.id_field))
+            sql_query = SQL(
+                'SELECT {}, {}, ST_AsGeoJSON({})  FROM {} WHERE {}=%s') \
+                .format(
+                self.columns,
+                Identifier(self.id_field),
+                Identifier(self.geom),
+                SQL(self.query_table),
+                Identifier(self.id_field))
 
             LOGGER.debug('SQL Query: {}'.format(sql_query.as_string(db.conn)))
             LOGGER.debug('Identifier: {}'.format(identifier))

--- a/tests/test_postgresql_query_provider.py
+++ b/tests/test_postgresql_query_provider.py
@@ -1,0 +1,116 @@
+# =================================================================
+#
+# Authors: Just van den Broecke <justb4@gmail.com>
+#          Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2019 Just van den Broecke
+# Copyright (c) 2019 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+# Needs to be run like: python3 -m pytest
+
+import pytest
+from pygeoapi.provider.postgres_query import PostgreSQLQueryProvider
+
+
+@pytest.fixture()
+def config():
+    return {
+        'name': 'PostgreSQLQuery',
+        'data': {'host': '127.0.0.1',
+                 'dbname': 'test',
+                 'user': 'postgres',
+                 'password': 'postgres',
+                 'search_path': ['osm', 'public']
+                 },
+        'id_field': 'osm_id',
+        'column_property_mapping': {
+            'name': 'name',
+            'waterway': 'waterway',
+            'covered': 'covered',
+            'width': 'width',
+            'depth': 'depth',
+            'z_index': 'zIndex'
+        },
+        'query_table': 'hotosm_bdi_waterways',
+        'geom_field': 'foo_geom'
+    }
+
+
+def test_query(config):
+    """Testing query for a valid JSON object with geometry"""
+
+    p = PostgreSQLQueryProvider(config)
+    feature_collection = p.query()
+    assert feature_collection.get('type', None) == 'FeatureCollection'
+    features = feature_collection.get('features', None)
+    assert features is not None
+    feature = features[0]
+    properties = feature.get('properties', None)
+    assert properties is not None
+    geometry = feature.get('geometry', None)
+    assert geometry is not None
+
+
+def test_query_with_property_filter(config):
+    """Test query  valid features when filtering by property"""
+    p = PostgreSQLQueryProvider(config)
+    feature_collection = p.query(properties=[("waterway", "stream")])
+    features = feature_collection.get('features', None)
+    stream_features = list(
+        filter(lambda feature: feature['properties']['waterway'] == 'stream',
+               features))
+    assert (len(features) == len(stream_features))
+
+    feature_collection = p.query()
+    features = feature_collection.get('features', None)
+    stream_features = list(
+        filter(lambda feature: feature['properties']['waterway'] == 'stream',
+               features))
+    other_features = list(
+        filter(lambda feature: feature['properties']['waterway'] != 'stream',
+               features))
+    assert (len(features) != len(stream_features))
+    assert (len(other_features) != 0)
+
+
+def test_query_bbox(config):
+    """Test query with a specified bounding box"""
+    psp = PostgreSQLQueryProvider(config)
+    boxed_feature_collection = psp.query(
+        bbox=[29.3373, -3.4099, 29.3761, -3.3924]
+    )
+    assert len(boxed_feature_collection['features']) == 5
+
+
+def test_get(config):
+    """Testing query for a specific object"""
+    p = PostgreSQLQueryProvider(config)
+    result = p.get(29701937)
+    assert isinstance(result, dict)
+    assert 'geometry' in result
+    assert 'properties' in result
+    assert 'id' in result
+    assert 'Kanyosha' in result['properties']['name']


### PR DESCRIPTION
I have created an enhanced postgres provider (postgres_query) which takes two new properties to replace the "table" config property. The property, column_property_mapping, is a dictionary mapping column names to property names. This is used in conjunction with the query_table parameter which can be a table name or a join statement.

This work is related to issue #291. I elected to create a new provider. Much of the code is duplicated in the postgresql provider. With additional work, I could merge these two but wanted to get feedback before that happened.

In order to test this well, I would also need to enhance the postgres data that is loaded for testing with probably some sort of relationship table that can be used for joining. I have tested this locally using my own postgres data, joining two tables.