### PR TITLE
allow other projections than WGS84 (EPSG:4326) such as NZTM (EPSG:219…

### DIFF
--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -263,6 +263,9 @@ class PostgreSQLProvider(BaseProvider):
                 feature_collection['features'].append(
                     self.__response_feature(rd))
 
+            cursor.execute(SQL('SELECT ST_SRID({}) AS srid FROM {} LIMIT 1').format(Identifier(self.geom), Identifier(self.table)))
+            srid_result = cursor.fetchall()
+            feature_collection['crs:epsg'] = srid_result[0]['srid']
             return feature_collection
 
     def get(self, identifier):
@@ -298,6 +301,12 @@ class PostgreSQLProvider(BaseProvider):
             row_data = cursor.fetchall()[0]
             feature = self.__response_feature(row_data)
 
+            cursor.execute(SQL('SELECT ST_SRID({}) AS srid FROM {} WHERE {}=%s').format(
+                Identifier(self.geom), Identifier(self.table),
+                Identifier(self.id_field),
+            ), (identifier,))
+            srid_result = cursor.fetchall()
+            feature['crs:epsg'] = srid_result[0]['srid']
             return feature
 
     def __response_feature(self, row_data):

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -263,7 +263,10 @@ class PostgreSQLProvider(BaseProvider):
                 feature_collection['features'].append(
                     self.__response_feature(rd))
 
-            cursor.execute(SQL('SELECT ST_SRID({}) AS srid FROM {} LIMIT 1').format(Identifier(self.geom), Identifier(self.table)))
+            sql = 'SELECT ST_SRID({}) AS srid FROM {} LIMIT 1'
+            cursor.execute(SQL(sql).format(
+                Identifier(self.geom), Identifier(self.table))
+            )
             srid_result = cursor.fetchall()
             feature_collection['crs:epsg'] = srid_result[0]['srid']
             return feature_collection
@@ -301,7 +304,8 @@ class PostgreSQLProvider(BaseProvider):
             row_data = cursor.fetchall()[0]
             feature = self.__response_feature(row_data)
 
-            cursor.execute(SQL('SELECT ST_SRID({}) AS srid FROM {} WHERE {}=%s').format(
+            sql = 'SELECT ST_SRID({}) AS srid FROM {} WHERE {}=%s'
+            cursor.execute(SQL(sql).format(
                 Identifier(self.geom), Identifier(self.table),
                 Identifier(self.id_field),
             ), (identifier,))

--- a/pygeoapi/templates/item.html
+++ b/pygeoapi/templates/item.html
@@ -87,6 +87,11 @@
 {% endblock %}
 
 {% block extrafoot %}
+    {% if data['crs:epsg'] and data['crs:epsg'] != 4326 %}
+    <script src="https://unpkg.com/proj4@2.0.1/dist/proj4.js"></script>
+    <script src="https://epsg.io/4326.js"></script>
+    <script src="https://epsg.io/{{ data['crs:epsg'] }}.js"></script>
+    {% endif %}
     <script>
     var map = L.map('items-map').setView([{{ 45 }}, {{ -75 }}], 10);
     map.addLayer(new L.TileLayer(
@@ -96,6 +101,10 @@
         }
     ));
     var geojson_data = {{ data |to_json }};
+    {% if data['crs:epsg'] and data['crs:epsg'] != 4326 %}
+    var projector = proj4('EPSG:{{ data['crs:epsg'] }}', 'EPSG:4326');
+    geojson_data.geometry.coordinates = geojson_data.geometry.coordinates.map(l1 => l1.map(l2 => l2.map(coord => projector.forward(coord))));
+    {% endif %}
     var items = new L.GeoJSON(geojson_data);
 
     map.addLayer(items);

--- a/pygeoapi/templates/items.html
+++ b/pygeoapi/templates/items.html
@@ -68,12 +68,17 @@
         {% endfor %}
         </div>
       </div>
+
     </section>
 {% endblock %}
 
 {% block extrafoot %}
 {% if data['features'] %}
-
+    {% if data['crs:epsg'] and data['crs:epsg'] != 4326 %}
+    <script src="https://unpkg.com/proj4@2.0.1/dist/proj4.js"></script>
+    <script src="https://epsg.io/4326.js"></script>
+    <script src="https://epsg.io/{{ data['crs:epsg'] }}.js"></script>
+    {% endif %}
     <script>
     var map = L.map('items-map').setView([{{ 45 }}, {{ -75 }}], 5);
     map.addLayer(new L.TileLayer(
@@ -83,6 +88,13 @@
         }
     ));
     var geojson_data = {{ data['features'] |to_json }};
+    {% if data['crs:epsg'] and data['crs:epsg'] != 4326 %}
+    var projector = proj4('EPSG:{{ data['crs:epsg'] }}', 'EPSG:4326');
+    geojson_data = geojson_data.map(g => {
+      g.geometry.coordinates = g.geometry.coordinates.map(l1 => l1.map(l2 => l2.map(coord => projector.forward(coord))));
+      return g;
+    });
+    {% endif %}
     var items = new L.GeoJSON(geojson_data, {
         onEachFeature: function (feature, layer) {
             var url = '{{ data['items_path'] }}/' + feature.id + '?f=html';


### PR DESCRIPTION
…3) in viewer #306

So, we can now have source data in another projection and the OSM Leaflet map should still show the coordinates projected into WGS84.