### PR TITLE
Python autoformatter

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: stable
+    hooks:
+      - id: black
+        language_version: python3.7
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+      - id: flake8

--- a/.toml
+++ b/.toml
@@ -1,0 +1,13 @@
+[tool.black]
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.github
+  | \.__pycache__
+  | \.venv
+  | aws-lambda
+  | docker
+  | docs
+)/
+'''

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ Please read the [docker/README](https://github.com/geopython/pygeoapi/blob/maste
 details of the Docker implementation. To get started quickly
 [several examples](https://github.com/geopython/pygeoapi/blob/master/docker/examples) will get you up and running.
 
+## Development
+
 ### Unit Testing
 
 Unit tests are run using `pytest` from the top project folder:
 
-```
+```sh
 pytest tests
 ```
 
@@ -98,4 +100,20 @@ NB beware that some tests require Provider dependencies (libraries) to be availa
 and that the ElasticSearch and Postgres tests require their respective
 backend servers running.
 
+Running a subset of the tests is possible, e.g.:
+
+```sh
+pytest tests/test_api.py`
+```
+
 Environment variables are set in the file [pytest.ini](pytest.ini).
+
+### Linting and formatting
+
+[`black`](https://github.com/psf/black) is used for auto-formatting code; [`flake8`](https://pypi.org/project/flake8/) is used to check compliance against [PEP 8](https://www.python.org/dev/peps/pep-0008/). These tools are combined into an automatic workflow with [`pre-commit`](https://pre-commit.com/). When you attempt to commit, pre-commit will first auto-format any Python files that you changed; then it will check PEP 8 compliance. You will have the opportunity to review the automatic changes (since you will need to `git add` them again).
+
+You will need the development dependencies (`requirements-dev.txt`) installed. Then run
+```sh
+pre-commit install
+```
+to install the pre-commit hooks into `.git`. Now whenever you commit, these checks will automatically operate.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,8 @@ coverage
 
 # PEP8
 flake8
+pre-commit
+black
 
 # packaging/PyPI
 twine

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,12 +44,11 @@ def get_test_file_path(filename):
     if os.path.isfile(filename):
         return filename
     else:
-        return 'tests/{}'.format(filename)
+        return "tests/{}".format(filename)
 
 
 def make_req_headers(**kwargs):
-    environ = create_environ('/collections/obs/items',
-                             'http://localhost:5000/')
+    environ = create_environ("/collections/obs/items", "http://localhost:5000/")
     environ.update(kwargs)
     request = Request(environ)
     return request.headers
@@ -57,13 +56,13 @@ def make_req_headers(**kwargs):
 
 @pytest.fixture()
 def config():
-    with open(get_test_file_path('pygeoapi-test-config.yml')) as fh:
+    with open(get_test_file_path("pygeoapi-test-config.yml")) as fh:
         return yaml_load(fh)
 
 
 @pytest.fixture()
 def openapi():
-    with open(get_test_file_path('pygeoapi-test-openapi.yml')) as fh:
+    with open(get_test_file_path("pygeoapi-test-openapi.yml")) as fh:
         return yaml_load(fh)
 
 
@@ -76,28 +75,26 @@ def test_api(config, api_, openapi):
     assert api_.config == config
     assert isinstance(api_.config, dict)
 
-    req_headers = make_req_headers(HTTP_CONTENT_TYPE='application/json')
+    req_headers = make_req_headers(HTTP_CONTENT_TYPE="application/json")
     rsp_headers, code, response = api_.openapi(req_headers, {}, openapi)
-    assert rsp_headers['Content-Type'] ==\
-        'application/vnd.oai.openapi+json;version=3.0'
+    assert rsp_headers["Content-Type"] == "application/vnd.oai.openapi+json;version=3.0"
     root = json.loads(response)
 
     assert isinstance(root, dict)
 
-    a = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
+    a = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
     req_headers = make_req_headers(HTTP_ACCEPT=a)
     rsp_headers, code, response = api_.openapi(req_headers, {}, openapi)
-    assert rsp_headers['Content-Type'] == 'text/html'
+    assert rsp_headers["Content-Type"] == "text/html"
 
     req_headers = make_req_headers()
-    rsp_headers, code, response = api_.openapi(req_headers, {'f': 'foo'},
-                                               openapi)
+    rsp_headers, code, response = api_.openapi(req_headers, {"f": "foo"}, openapi)
     assert code == 400
 
 
 def test_api_exception(config, api_):
     req_headers = make_req_headers()
-    rsp_headers, code, response = api_.root(req_headers, {'f': 'foo'})
+    rsp_headers, code, response = api_.root(req_headers, {"f": "foo"})
     assert code == 400
 
 
@@ -106,19 +103,19 @@ def test_root(config, api_):
     rsp_headers, code, response = api_.root(req_headers, {})
     root = json.loads(response)
 
-    assert rsp_headers['Content-Type'] == 'application/json'
-    assert rsp_headers['X-Powered-By'].startswith('pygeoapi')
+    assert rsp_headers["Content-Type"] == "application/json"
+    assert rsp_headers["X-Powered-By"].startswith("pygeoapi")
 
     assert isinstance(root, dict)
-    assert 'links' in root
-    assert len(root['links']) == 6
-    assert 'title' in root
-    assert root['title'] == 'pygeoapi default instance'
-    assert 'description' in root
-    assert root['description'] == 'pygeoapi provides an API to geospatial data'
+    assert "links" in root
+    assert len(root["links"]) == 6
+    assert "title" in root
+    assert root["title"] == "pygeoapi default instance"
+    assert "description" in root
+    assert root["description"] == "pygeoapi provides an API to geospatial data"
 
-    rsp_headers, code, response = api_.root(req_headers, {'f': 'html'})
-    assert rsp_headers['Content-Type'] == 'text/html'
+    rsp_headers, code, response = api_.root(req_headers, {"f": "html"})
+    assert rsp_headers["Content-Type"] == "text/html"
 
 
 def test_conformance(config, api_):
@@ -127,246 +124,265 @@ def test_conformance(config, api_):
     root = json.loads(response)
 
     assert isinstance(root, dict)
-    assert 'conformsTo' in root
-    assert len(root['conformsTo']) == 4
+    assert "conformsTo" in root
+    assert len(root["conformsTo"]) == 4
 
-    rsp_headers, code, response = api_.conformance(
-        req_headers, {'f': 'foo'})
+    rsp_headers, code, response = api_.conformance(req_headers, {"f": "foo"})
     assert code == 400
 
-    rsp_headers, code, response = api_.conformance(
-        req_headers, {'f': 'html'})
-    assert rsp_headers['Content-Type'] == 'text/html'
+    rsp_headers, code, response = api_.conformance(req_headers, {"f": "html"})
+    assert rsp_headers["Content-Type"] == "text/html"
 
 
 def test_describe_collections(config, api_):
     req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {'f': 'foo'})
+    rsp_headers, code, response = api_.describe_collections(req_headers, {"f": "foo"})
     assert code == 400
 
     req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {'f': 'html'})
-    assert rsp_headers['Content-Type'] == 'text/html'
+    rsp_headers, code, response = api_.describe_collections(req_headers, {"f": "html"})
+    assert rsp_headers["Content-Type"] == "text/html"
 
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {})
+    rsp_headers, code, response = api_.describe_collections(req_headers, {})
     collections = json.loads(response)
 
     assert len(collections) == 2
-    assert len(collections['collections']) == 1
-    assert len(collections['links']) == 2
+    assert len(collections["collections"]) == 1
+    assert len(collections["links"]) == 2
 
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {}, 'foo')
+    rsp_headers, code, response = api_.describe_collections(req_headers, {}, "foo")
     collection = json.loads(response)
 
     assert code == 400
 
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {}, 'obs')
+    rsp_headers, code, response = api_.describe_collections(req_headers, {}, "obs")
     collection = json.loads(response)
 
-    assert collection['id'] == 'obs'
-    assert collection['title'] == 'Observations'
-    assert collection['description'] == 'My cool observations'
-    assert len(collection['links']) == 6
-    assert collection['extent'] == {
-        'spatial': {
-            'bbox': [[-180, -90, 180, 90]],
-            'crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+    assert collection["id"] == "obs"
+    assert collection["title"] == "Observations"
+    assert collection["description"] == "My cool observations"
+    assert len(collection["links"]) == 6
+    assert collection["extent"] == {
+        "spatial": {
+            "bbox": [[-180, -90, 180, 90]],
+            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
         },
-        'temporal': {
-            'interval': [['2000-10-30T18:24:39', '2007-10-30T08:57:29']],
-            'trs': 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
-        }
+        "temporal": {
+            "interval": [["2000-10-30T18:24:39", "2007-10-30T08:57:29"]],
+            "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
+        },
     }
 
     rsp_headers, code, response = api_.describe_collections(
-        req_headers, {'f': 'html'}, 'obs')
-    assert rsp_headers['Content-Type'] == 'text/html'
+        req_headers, {"f": "html"}, "obs"
+    )
+    assert rsp_headers["Content-Type"] == "text/html"
 
 
 def test_get_collection_items(config, api_):
     req_headers = make_req_headers()
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {}, 'foo')
+    rsp_headers, code, response = api_.get_collection_items(req_headers, {}, "foo")
     features = json.loads(response)
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'f': 'foo'}, 'obs')
+        req_headers, {"f": "foo"}, "obs"
+    )
     features = json.loads(response)
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'bbox': '1,2,3'}, 'obs')
+        req_headers, {"bbox": "1,2,3"}, "obs"
+    )
     features = json.loads(response)
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'bbox': '1,2,3,4c'}, 'obs')
+        req_headers, {"bbox": "1,2,3,4c"}, "obs"
+    )
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'f': 'html'}, 'obs')
-    assert rsp_headers['Content-Type'] == 'text/html'
+        req_headers, {"f": "html"}, "obs"
+    )
+    assert rsp_headers["Content-Type"] == "text/html"
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {}, 'obs')
+    rsp_headers, code, response = api_.get_collection_items(req_headers, {}, "obs")
     features = json.loads(response)
 
-    assert len(features['features']) == 5
+    assert len(features["features"]) == 5
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'resulttype': 'hits'}, 'obs')
+        req_headers, {"resulttype": "hits"}, "obs"
+    )
     features = json.loads(response)
 
-    assert len(features['features']) == 0
+    assert len(features["features"]) == 0
 
     # Invalid limit
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'limit': 0}, 'obs')
+        req_headers, {"limit": 0}, "obs"
+    )
     features = json.loads(response)
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'limit': 2}, 'obs')
+        req_headers, {"limit": 2}, "obs"
+    )
     features = json.loads(response)
 
-    assert len(features['features']) == 2
-    assert features['features'][1]['properties']['stn_id'] == '35'
+    assert len(features["features"]) == 2
+    assert features["features"][1]["properties"]["stn_id"] == "35"
 
-    links = features['links']
+    links = features["links"]
     assert len(links) == 4
-    assert '/collections/obs/items?f=json' in links[0]['href']
-    assert links[0]['rel'] == 'self'
-    assert '/collections/obs/items?f=html' in links[1]['href']
-    assert links[1]['rel'] == 'alternate'
-    assert '/collections/obs/items?startindex=2&limit=2' in links[2]['href']
-    assert links[2]['rel'] == 'next'
-    assert '/collections/obs' in links[3]['href']
-    assert links[3]['rel'] == 'collection'
+    assert "/collections/obs/items?f=json" in links[0]["href"]
+    assert links[0]["rel"] == "self"
+    assert "/collections/obs/items?f=html" in links[1]["href"]
+    assert links[1]["rel"] == "alternate"
+    assert "/collections/obs/items?startindex=2&limit=2" in links[2]["href"]
+    assert links[2]["rel"] == "next"
+    assert "/collections/obs" in links[3]["href"]
+    assert links[3]["rel"] == "collection"
 
     # Invalid startindex
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'startindex': -1}, 'obs')
+        req_headers, {"startindex": -1}, "obs"
+    )
     features = json.loads(response)
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'startindex': 2}, 'obs')
+        req_headers, {"startindex": 2}, "obs"
+    )
     features = json.loads(response)
 
-    assert len(features['features']) == 3
-    assert features['features'][1]['properties']['stn_id'] == '2147'
+    assert len(features["features"]) == 3
+    assert features["features"][1]["properties"]["stn_id"] == "2147"
 
-    links = features['links']
+    links = features["links"]
     assert len(links) == 4
-    assert '/collections/obs/items?f=json' in links[0]['href']
-    assert links[0]['rel'] == 'self'
-    assert '/collections/obs/items?f=html' in links[1]['href']
-    assert links[1]['rel'] == 'alternate'
-    assert '/collections/obs/items?startindex=0' in links[2]['href']
-    assert links[2]['rel'] == 'prev'
-    assert '/collections/obs' in links[3]['href']
-    assert links[3]['rel'] == 'collection'
+    assert "/collections/obs/items?f=json" in links[0]["href"]
+    assert links[0]["rel"] == "self"
+    assert "/collections/obs/items?f=html" in links[1]["href"]
+    assert links[1]["rel"] == "alternate"
+    assert "/collections/obs/items?startindex=0" in links[2]["href"]
+    assert links[2]["rel"] == "prev"
+    assert "/collections/obs" in links[3]["href"]
+    assert links[3]["rel"] == "collection"
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'startindex': 1, 'limit': 1,
-                      'bbox': '-180,90,180,90'}, 'obs')
+        req_headers, {"startindex": 1, "limit": 1, "bbox": "-180,90,180,90"}, "obs"
+    )
     features = json.loads(response)
 
-    assert len(features['features']) == 1
+    assert len(features["features"]) == 1
 
-    links = features['links']
+    links = features["links"]
     assert len(links) == 5
-    assert '/collections/obs/items?f=json&limit=1&bbox=-180,90,180,90' in \
-        links[0]['href']
-    assert links[0]['rel'] == 'self'
-    assert '/collections/obs/items?f=html&limit=1&bbox=-180,90,180,90' in \
-        links[1]['href']
-    assert links[1]['rel'] == 'alternate'
-    assert '/collections/obs/items?startindex=0&limit=1&bbox=-180,90,180,90' \
-        in links[2]['href']
-    assert links[2]['rel'] == 'prev'
-    assert '/collections/obs/items?startindex=2&limit=1&bbox=-180,90,180,90' \
-        in links[3]['href']
-    assert links[3]['rel'] == 'next'
-    assert '/collections/obs' in links[4]['href']
-    assert links[4]['rel'] == 'collection'
+    assert (
+        "/collections/obs/items?f=json&limit=1&bbox=-180,90,180,90" in links[0]["href"]
+    )
+    assert links[0]["rel"] == "self"
+    assert (
+        "/collections/obs/items?f=html&limit=1&bbox=-180,90,180,90" in links[1]["href"]
+    )
+    assert links[1]["rel"] == "alternate"
+    assert (
+        "/collections/obs/items?startindex=0&limit=1&bbox=-180,90,180,90"
+        in links[2]["href"]
+    )
+    assert links[2]["rel"] == "prev"
+    assert (
+        "/collections/obs/items?startindex=2&limit=1&bbox=-180,90,180,90"
+        in links[3]["href"]
+    )
+    assert links[3]["rel"] == "next"
+    assert "/collections/obs" in links[4]["href"]
+    assert links[4]["rel"] == "collection"
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'sortby': 'stn_id', 'stn_id': '35'}, 'obs')
+        req_headers, {"sortby": "stn_id", "stn_id": "35"}, "obs"
+    )
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'sortby': 'stn_id:FOO', 'stn_id': '35', 'value': '89.9'},
-        'obs')
+        req_headers, {"sortby": "stn_id:FOO", "stn_id": "35", "value": "89.9"}, "obs"
+    )
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'sortby': 'stn_id:A'}, 'obs')
+        req_headers, {"sortby": "stn_id:A"}, "obs"
+    )
     features = json.loads(response)
     # FIXME? this test errors out currently
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'f': 'csv'}, 'obs')
+        req_headers, {"f": "csv"}, "obs"
+    )
 
-    assert rsp_headers['Content-Type'] == 'text/csv; charset=utf-8'
+    assert rsp_headers["Content-Type"] == "text/csv; charset=utf-8"
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2003'}, 'obs')
+        req_headers, {"datetime": "2003"}, "obs"
+    )
 
     assert code == 200
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '1999'}, 'obs')
+        req_headers, {"datetime": "1999"}, "obs"
+    )
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2010-04-22'}, 'obs')
+        req_headers, {"datetime": "2010-04-22"}, "obs"
+    )
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2001-11-11/2003-12-18'}, 'obs')
+        req_headers, {"datetime": "2001-11-11/2003-12-18"}, "obs"
+    )
 
     assert code == 200
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '../2003-12-18'}, 'obs')
+        req_headers, {"datetime": "../2003-12-18"}, "obs"
+    )
 
     assert code == 200
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2001-11-11/..'}, 'obs')
+        req_headers, {"datetime": "2001-11-11/.."}, "obs"
+    )
 
     assert code == 200
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '1999/2005-04-22'}, 'obs')
+        req_headers, {"datetime": "1999/2005-04-22"}, "obs"
+    )
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2002/2014-04-22'}, 'obs')
+        req_headers, {"datetime": "2002/2014-04-22"}, "obs"
+    )
 
-    api_.config['datasets']['obs']['extents'].pop('temporal')
+    api_.config["datasets"]["obs"]["extents"].pop("temporal")
 
     rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2002/2014-04-22'}, 'obs')
+        req_headers, {"datetime": "2002/2014-04-22"}, "obs"
+    )
 
     assert code == 200
 
@@ -374,166 +390,166 @@ def test_get_collection_items(config, api_):
 def test_get_collection_item(config, api_):
     req_headers = make_req_headers()
     rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {'f': 'foo'}, 'obs', '371')
+        req_headers, {"f": "foo"}, "obs", "371"
+    )
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {}, 'foo', '371')
+        req_headers, {}, "foo", "371"
+    )
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {}, 'obs', 'notfound')
+        req_headers, {}, "obs", "notfound"
+    )
 
     assert code == 404
 
     rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {'f': 'html'}, 'obs', '371')
+        req_headers, {"f": "html"}, "obs", "371"
+    )
 
-    assert rsp_headers['Content-Type'] == 'text/html'
+    assert rsp_headers["Content-Type"] == "text/html"
 
     rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {}, 'obs', '371')
+        req_headers, {}, "obs", "371"
+    )
     features = json.loads(response)
 
-    assert features['properties']['stn_id'] == '35'
+    assert features["properties"]["stn_id"] == "35"
 
 
 def test_describe_processes(config, api_):
     req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {}, 'foo')
+    rsp_headers, code, response = api_.describe_processes(req_headers, {}, "foo")
     processes = json.loads(response)
 
     assert code == 404
 
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {})
+    rsp_headers, code, response = api_.describe_processes(req_headers, {})
     processes = json.loads(response)
 
-    assert len(processes['processes']) == 1
+    assert len(processes["processes"]) == 1
 
     rsp_headers, code, response = api_.describe_processes(
-        req_headers, {}, 'hello-world')
+        req_headers, {}, "hello-world"
+    )
     process = json.loads(response)
 
-    assert process['id'] == 'hello-world'
-    assert process['title'] == 'Hello World process'
-    assert process['description'] == 'Hello World process'
-    assert len(process['links']) == 1
-    assert len(process['inputs']) == 1
-    assert len(process['outputs']) == 1
-    assert len(process['outputTransmission']) == 1
-    assert len(process['jobControlOptions']) == 1
+    assert process["id"] == "hello-world"
+    assert process["title"] == "Hello World process"
+    assert process["description"] == "Hello World process"
+    assert len(process["links"]) == 1
+    assert len(process["inputs"]) == 1
+    assert len(process["outputs"]) == 1
+    assert len(process["outputTransmission"]) == 1
+    assert len(process["jobControlOptions"]) == 1
 
-    api_.config['processes'] = {}
-
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {}, 'foo')
-    processes = json.loads(response)
-    assert len(processes['processes']) == 0
-
-    api_.config.pop('processes')
+    api_.config["processes"] = {}
 
     req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {}, 'foo')
+    rsp_headers, code, response = api_.describe_processes(req_headers, {}, "foo")
     processes = json.loads(response)
-    assert len(processes['processes']) == 0
+    assert len(processes["processes"]) == 0
+
+    api_.config.pop("processes")
+
+    req_headers = make_req_headers()
+    rsp_headers, code, response = api_.describe_processes(req_headers, {}, "foo")
+    processes = json.loads(response)
+    assert len(processes["processes"]) == 0
 
 
 def test_execute_process(config, api_):
-    req_body = {
-        'inputs': [{
-            'id': 'name',
-            'value': 'test'
-        }]
-    }
+    req_body = {"inputs": [{"id": "name", "value": "test"}]}
 
     req_headers = make_req_headers()
     rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, '', 'hello-world')
+        req_headers, {}, "", "hello-world"
+    )
     response = json.loads(response)
     assert code == 400
 
     rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body), 'foo')
+        req_headers, {}, json.dumps(req_body), "foo"
+    )
     response = json.loads(response)
 
     assert code == 404
 
     rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body), 'hello-world')
+        req_headers, {}, json.dumps(req_body), "hello-world"
+    )
     response = json.loads(response)
 
-    assert response['outputs'][0]['value'] == 'test'
+    assert response["outputs"][0]["value"] == "test"
 
-    api_.config['processes'] = {}
+    api_.config["processes"] = {}
 
     req_headers = make_req_headers()
     rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body), 'hello-world')
+        req_headers, {}, json.dumps(req_body), "hello-world"
+    )
     response = json.loads(response)
-    assert response['code'] == 'NotFound'
+    assert response["code"] == "NotFound"
 
-    api_.config.pop('processes')
+    api_.config.pop("processes")
 
     req_headers = make_req_headers()
     rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body), 'hello-world')
+        req_headers, {}, json.dumps(req_body), "hello-world"
+    )
     response = json.loads(response)
-    assert response['code'] == 'NotFound'
+    assert response["code"] == "NotFound"
 
 
 def test_check_format():
-    args = {
-        'f': 'html'
-    }
+    args = {"f": "html"}
 
     req_headers = {}
 
     assert check_format({}, req_headers) is None
 
-    assert check_format(args, req_headers) == 'html'
+    assert check_format(args, req_headers) == "html"
 
-    args['f'] = 'json'
-    assert check_format(args, req_headers) == 'json'
+    args["f"] = "json"
+    assert check_format(args, req_headers) == "json"
 
-    args['f'] = 'html'
-    assert check_format(args, req_headers) == 'html'
+    args["f"] = "html"
+    assert check_format(args, req_headers) == "html"
 
-    req_headers['Accept'] = 'text/html'
-    assert check_format({}, req_headers) == 'html'
+    req_headers["Accept"] = "text/html"
+    assert check_format({}, req_headers) == "html"
 
-    req_headers['Accept'] = 'application/json'
-    assert check_format({}, req_headers) == 'json'
+    req_headers["Accept"] = "application/json"
+    assert check_format({}, req_headers) == "json"
 
-    req_headers['accept'] = 'text/html'
-    assert check_format({}, req_headers) == 'html'
+    req_headers["accept"] = "text/html"
+    assert check_format({}, req_headers) == "html"
 
-    hh = 'text/html,application/xhtml+xml,application/xml;q=0.9,'
+    hh = "text/html,application/xhtml+xml,application/xml;q=0.9,"
 
-    req_headers['Accept'] = hh
-    assert check_format({}, req_headers) == 'html'
+    req_headers["Accept"] = hh
+    assert check_format({}, req_headers) == "html"
 
-    req_headers['accept'] = hh
-    assert check_format({}, req_headers) == 'html'
+    req_headers["accept"] = hh
+    assert check_format({}, req_headers) == "html"
 
     req_headers = make_req_headers(HTTP_ACCEPT=hh)
-    assert check_format({}, req_headers) == 'html'
+    assert check_format({}, req_headers) == "html"
 
-    req_headers = make_req_headers(HTTP_ACCEPT='text/html')
-    assert check_format({}, req_headers) == 'html'
+    req_headers = make_req_headers(HTTP_ACCEPT="text/html")
+    assert check_format({}, req_headers) == "html"
 
-    req_headers = make_req_headers(HTTP_ACCEPT='application/json')
-    assert check_format({}, req_headers) == 'json'
+    req_headers = make_req_headers(HTTP_ACCEPT="application/json")
+    assert check_format({}, req_headers) == "json"
 
     # Overrule HTTP content negotiation
-    args['f'] = 'html'
-    assert check_format(args, req_headers) == 'html'
+    args["f"] = "html"
+    assert check_format(args, req_headers) == "html"
 
-    req_headers = make_req_headers(HTTP_ACCEPT='text/html')
-    args['f'] = 'json'
-    assert check_format(args, req_headers) == 'json'
+    req_headers = make_req_headers(HTTP_ACCEPT="text/html")
+    args["f"] = "json"
+    assert check_format(args, req_headers) == "json"


### PR DESCRIPTION
cf. #288 

I simply implemented the advice here: https://ljvmiranda921.github.io/notebook/2018/06/21/precommits-using-black-and-flake8/

So there's some additional development set-up, that I have also included into the README.

When you commit, you'll either see:

```
git commit -m"adds development section to readmme; adds instructions about pre-commit hooks"
black................................................(no files to check)Skipped
Flake8...............................................(no files to check)Skipped
[python-autoformatter 1b7cb77] adds development section to readmme; adds instructions about pre-commit hooks
 1 file changed, 19 insertions(+), 1 deletion(-)
```

or 

```
git commit -m"sample use of black on tests"
black....................................................................Passed
Flake8...................................................................Passed
[python-autoformatter 1ebaf6f] sample use of black on tests
 1 file changed, 219 insertions(+), 203 deletions(-)
```

depending on whether or not any Python source files have been touched.

As you can see, I ran a sample on `tests/test_api.py` (I didn't change any functionality). Up-front there will be quite a few changes.

**Question: should I run this across the entire source in this PR?**