### PR TITLE
Implement configurable OGC schema locations

### DIFF
--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2019 Tom Kralidis
+# Copyright (c) 2020 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -42,6 +42,7 @@ server:
     map:
         url: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
         attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+    # ogc_schemas_location: /opt/schemas.opengis.net
 
 logging:
     level: ERROR

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2019 Tom Kralidis
+# Copyright (c) 2020 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -29,6 +29,7 @@
 
 from copy import deepcopy
 import logging
+import os
 
 import click
 import yaml
@@ -38,12 +39,25 @@ from pygeoapi.util import yaml_load
 
 LOGGER = logging.getLogger(__name__)
 
-# TODO: handle this better once schemas are public/final
-# allow also for schema caching
 OPENAPI_YAML = {
     'oapif': 'http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml',  # noqa
     'oapip': 'https://raw.githubusercontent.com/opengeospatial/wps-rest-binding/master/core/openapi'  # noqa
 }
+
+
+def get_ogc_schemas_location(server_config):
+
+    osl = server_config.get('ogc_schemas_location', None)
+
+    value = 'http://schemas.opengis.net'
+
+    if osl is not None:
+        if osl.startswith('http'):
+            value = osl
+        elif osl.startswith('/'):
+            value = os.path.join(server_config['url'], 'schemas')
+
+    return value
 
 
 # TODO: remove this function once OGC API - Processing is final
@@ -101,6 +115,10 @@ def get_oas_30(cfg):
     """
 
     paths = {}
+
+    osl = get_ogc_schemas_location(cfg['server'])
+    OPENAPI_YAML['oapif'] = os.path.join(osl, 'ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml')  # noqa
+
     LOGGER.debug('setting up server info')
     oas = {
         'openapi': '3.0.2',

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -4,6 +4,7 @@
 #
 #
 # Copyright (c) 2019 Francesco Bartoli
+# Copyright (c) 2020 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -46,7 +47,6 @@ app = Starlette()
 app.mount('/static', StaticFiles(
     directory='{}{}static'.format(os.path.dirname(os.path.realpath(__file__)),
                                   os.sep)))
-
 CONFIG = None
 
 if 'PYGEOAPI_CONFIG' not in os.environ:
@@ -60,6 +60,13 @@ if CONFIG['server'].get('cors', False):
     from starlette.middleware.cors import CORSMiddleware
     app.add_middleware(CORSMiddleware, allow_origins=['*'])
 
+OGC_SCHEMAS_LOCATION = CONFIG['server'].get('ogc_schemas_location', None)
+
+if (OGC_SCHEMAS_LOCATION is not None and
+        not OGC_SCHEMAS_LOCATION.startswith('http')):
+    if not os.path.exists(OGC_SCHEMAS_LOCATION):
+        raise RuntimeError('OGC schemas misconfigured')
+    app.mount('/schemas', StaticFiles(directory=OGC_SCHEMAS_LOCATION))
 
 api_ = API(CONFIG)
 

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2019 Tom Kralidis
+# Copyright (c) 2020 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -33,6 +33,7 @@ from datetime import date, datetime, time
 from decimal import Decimal
 import json
 import logging
+import mimetypes
 import os
 import re
 from urllib.parse import urlparse
@@ -46,6 +47,9 @@ LOGGER = logging.getLogger(__name__)
 
 TEMPLATES = '{}{}templates'.format(os.path.dirname(
     os.path.realpath(__file__)), os.sep)
+
+mimetypes.add_type('text/plain', '.yaml')
+mimetypes.add_type('text/plain', '.yml')
 
 
 def dategetter(date_property, collection):
@@ -199,3 +203,15 @@ def render_j2_template(config, template, data):
 
     template = env.get_template(template)
     return template.render(config=config, data=data, version=__version__)
+
+
+def get_mimetype(filename):
+    """
+    helper function to return MIME type of a given file
+
+    :param filename: filename (with extension)
+
+    :returns: MIME type of given filename
+    """
+
+    return mimetypes.guess_type(filename)[0]

--- a/tests/cite/ogcapi-features/cite.config.yml
+++ b/tests/cite/ogcapi-features/cite.config.yml
@@ -2,7 +2,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 5001
-    url: http://localhost:5001
+    url: http://147.102.109.27:5001
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     language: en-US

--- a/tests/cite/ogcapi-features/cite.config.yml
+++ b/tests/cite/ogcapi-features/cite.config.yml
@@ -2,7 +2,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 5001
-    url: http://147.102.109.27:5001
+    url: http://localhost:5001
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     language: en-US

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,47 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2020 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from pygeoapi.openapi import get_ogc_schemas_location
+
+
+def test_str2bool():
+
+    default = {
+        'url': 'http://localhost:5000'
+    }
+
+    osl = get_ogc_schemas_location(default)
+    assert osl == 'http://schemas.opengis.net'
+
+    default['ogc_schemas_location'] = 'http://example.org/schemas'
+    osl = get_ogc_schemas_location(default)
+    assert osl == 'http://example.org/schemas'
+
+    default['ogc_schemas_location'] = '/opt/schemas.opengis.net'
+    osl = get_ogc_schemas_location(default)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2019 Tom Kralidis
+# Copyright (c) 2020 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -96,3 +96,9 @@ def test_json_serial():
 
     with pytest.raises(TypeError):
         util.json_serial('foo')
+
+
+def test_mimetype():
+    assert util.get_mimetype('file.xml') == 'application/xml'
+    assert util.get_mimetype('file.yml') == 'text/plain'
+    assert util.get_mimetype('file.yaml') == 'text/plain'


### PR DESCRIPTION
cc @jkreft-usgs 

Implements #312 

# Overview
In the spirit of https://mapserver.org/ogc/wms_server.html#index-21, this PR implements configurable OGC schema location for deployments wishing to serve local copies of the OGC schemas.

# Approach
- pygeoapi administrator downloads .zip or .tgz of http://schemas.opengis.net
- pygeoapi configuration sets `server.ogc_schemas_location` to one of:
  - local path (resulting URL is `server.url` + `server.ogc_schemas_location`)
  - base URL 
- if `server.ogc_schemas_location` is not set, default is `http://schemas.opengis.net`