### PR TITLE
change irc notifications to #pygeoapi-activity channel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,5 +67,5 @@ after_success:
 notifications:
   irc:
     channels:
-      - "irc.freenode.org#pygeoapi"
+      - "irc.freenode.org#pygeoapi-activity"
     use_notice: true


### PR DESCRIPTION
- some think notifications flood the discussion channel
- so this method is used by a few other projects: send notifications to a separate channel #pygeoapi-activity
  - the new channel has been registered