### PR TITLE
Issue 329: Add GeoPackage Support

### DIFF
--- a/pygeoapi/gpkg.py
+++ b/pygeoapi/gpkg.py
@@ -1,0 +1,53 @@
+# import gdal
+from osgeo import gdal
+import json
+import logging
+from os import remove
+from tempfile import NamedTemporaryFile
+
+LOGGER = logging.getLogger(__name__)
+
+
+def format_handler(**kwargs):
+    """
+    Handle GeoPackage format and convert GeoJSON to GeoPackage
+    with GDAL Python bindings
+
+    :param kwargs: headers_, dataset, content, json_serial
+
+    :returns: tuple of headers, status code, content
+    """
+
+    headers_ = kwargs["headers_"]
+    dataset = kwargs["dataset"]
+    geojson = json.dumps(kwargs["content"], default=kwargs["json_serial"])
+    headers_["Content-Type"] = "application/x-sqlite3"
+    headers_["Content-Disposition"] = \
+        'attachment; filename="{}.gpkg'.format(dataset)
+    content = geojson2gpkg(geojson, dataset)
+    return headers_, 200, content
+
+
+def geojson2gpkg(geojson, tablename="items"):
+    """
+    Convert GeoJSON to GeoPackage content
+
+    :param geojson: string
+    :param tablename: string GeoPackage SQLite table name
+
+    :returns: content
+    """
+
+    dsi = gdal.OpenEx(geojson)
+    layer = dsi.GetLayer()
+    tempfile_instance = NamedTemporaryFile("r", suffix="gpkg")
+    temp_filename = tempfile_instance.name
+    tempfile_instance.close()
+    drv = gdal.GetDriverByName("GPKG")
+    gpkg_filename = temp_filename + ".gpkg"
+    dso = drv.Create(gpkg_filename, 0, 0, 0, gdal.GDT_Unknown)
+    dso.CopyLayer(layer, tablename)
+    gpkg_file = open(gpkg_filename, "rb")
+    content = gpkg_file.read()
+    remove(gpkg_filename)
+    return content

--- a/pygeoapi/templates/base.html
+++ b/pygeoapi/templates/base.html
@@ -40,6 +40,7 @@
         <a href="{{ config['server']['url'] }}">Home</a>
         {% endblock %}
         <span style="float:right">
+          <a href="{{ data['links'] | map(rel='self') | attr('href') }}?f=geopackage">GEOPACKAGE</a>
           <a href="{{ data['links'] | map(rel='self') | attr('href') }}?f=json">JSON</a>
           <a href="{{ data['links'] | map(rel='self') | attr('href') }}?f=jsonld">JSON-LD</a>
         </span>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -122,7 +122,7 @@ def test_root(config, api_):
                for l in root['links'])
     assert any(l['href'].endswith('f=html') and l['rel'] == 'alternate'
                for l in root['links'])
-    assert len(root['links']) == 7
+    assert len(root['links']) == 8
     assert 'title' in root
     assert root['title'] == 'pygeoapi default instance'
     assert 'description' in root


### PR DESCRIPTION
This PR allows GeoPackage download with a standard Accept headers of
application/geopackage+sqlite3
or
application/x-sqlite3
and with the ?f=geopackage URL parameter.

Currently only normal filters work. One cannot download the whole datasource, at least not efficiently. However, for us it is more important that all filters work with GeoPackage.