### PR TITLE
where implementation on resulttype=hits

### DIFF
--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -252,7 +252,7 @@ class PostgreSQLProvider(BaseProvider):
                 properties=properties, bbox=bbox)
 
             sql_query = SQL("DECLARE \"geo_cursor\" CURSOR FOR \
-             SELECT {},ST_AsGeoJSON({}) FROM {}{}").\
+             SELECT DISTINCT {},ST_AsGeoJSON({}) FROM {}{}").\
                 format(db.columns,
                        Identifier(self.geom),
                        Identifier(self.table),

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -252,7 +252,7 @@ class PostgreSQLProvider(BaseProvider):
                 properties=properties, bbox=bbox)
 
             sql_query = SQL("DECLARE \"geo_cursor\" CURSOR FOR \
-             SELECT DISTINCT {},ST_AsGeoJSON({}) FROM {}{}").\
+             SELECT {},ST_AsGeoJSON({}) FROM {}{}").\
                 format(db.columns,
                        Identifier(self.geom),
                        Identifier(self.table),
@@ -337,8 +337,8 @@ class PostgreSQLProvider(BaseProvider):
         with DatabaseConnection(self.conn_dic, self.table) as db:
             cursor = db.conn.cursor(cursor_factory=RealDictCursor)
 
-            sql_query = SQL("SELECT {},ST_AsGeoJSON({}) \
-            FROM {} WHERE {}=%s").format(db.columns,
+            sql_query = SQL("select {},ST_AsGeoJSON({}) \
+            from {} WHERE {}=%s").format(db.columns,
                                          Identifier(self.geom),
                                          Identifier(self.table),
                                          Identifier(self.id_field))

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -252,7 +252,7 @@ class PostgreSQLProvider(BaseProvider):
                 properties=properties, bbox=bbox)
 
             sql_query = SQL("DECLARE \"geo_cursor\" CURSOR FOR \
-             SELECT {},ST_AsGeoJSON({}) FROM {}{}").\
+             SELECT DISTINCT {},ST_AsGeoJSON({}) FROM {}{}").\
                 format(db.columns,
                        Identifier(self.geom),
                        Identifier(self.table),
@@ -337,8 +337,8 @@ class PostgreSQLProvider(BaseProvider):
         with DatabaseConnection(self.conn_dic, self.table) as db:
             cursor = db.conn.cursor(cursor_factory=RealDictCursor)
 
-            sql_query = SQL("select {},ST_AsGeoJSON({}) \
-            from {} WHERE {}=%s").format(db.columns,
+            sql_query = SQL("SELECT {},ST_AsGeoJSON({}) \
+            FROM {} WHERE {}=%s").format(db.columns,
                                          Identifier(self.geom),
                                          Identifier(self.table),
                                          Identifier(self.id_field))

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -252,7 +252,7 @@ class PostgreSQLProvider(BaseProvider):
                 properties=properties, bbox=bbox)
 
             sql_query = SQL("DECLARE \"geo_cursor\" CURSOR FOR \
-             SELECT DISTINCT {},ST_AsGeoJSON({}) FROM {}{}").\
+             SELECT {},ST_AsGeoJSON({}) FROM {}{}").\
                 format(db.columns,
                        Identifier(self.geom),
                        Identifier(self.table),

--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -1,4 +1,4 @@
 elasticsearch==7.1.0
 GDAL>=2.2,<3.0
-psycopg2-binary==2.7.6
+psycopg2==2.7.6
 pymongo

--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -1,4 +1,4 @@
 elasticsearch==7.1.0
 GDAL>=2.2,<3.0
-psycopg2==2.7.6
+psycopg2-binary==2.7.6
 pymongo

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -88,6 +88,20 @@ def test_query_with_property_filter(config):
     assert (len(other_features) != 0)
 
 
+def test_query_hits(config):
+    """Test query resulttype=hits with properties"""
+    psp = PostgreSQLProvider(config)
+    results = psp.query(resulttype="hits")
+    assert results["numberMatched"] == 14776
+
+    results = psp.query(
+        bbox=[29.3373, -3.4099, 29.3761, -3.3924], resulttype="hits")
+    assert results["numberMatched"] == 5
+
+    results = psp.query(properties=[("waterway", "stream")], resulttype="hits")
+    assert results["numberMatched"] == 13930
+
+
 def test_query_bbox(config):
     """Test query with a specified bounding box"""
     psp = PostgreSQLProvider(config)


### PR DESCRIPTION
Implements `where` clauses for postgresql dataprovider as generic private method that is the used accounting the `resulttype` request 

Closes: #299 