### PR TITLE
implements hit results with filtering on Sqlite/geopackage dataprovier

### DIFF
--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -230,7 +230,7 @@ class PostgreSQLProvider(BaseProvider):
 
                 where_clause = self.__get_where_clauses(
                     properties=properties, bbox=bbox)
-                sql_query = SQL("select count(*) as hits from {} {}").\
+                sql_query = SQL("SELECT COUNT(*) as hits from {} {}").\
                     format(Identifier(self.table), where_clause)
                 try:
                     cursor.execute(sql_query)
@@ -337,7 +337,7 @@ class PostgreSQLProvider(BaseProvider):
         with DatabaseConnection(self.conn_dic, self.table) as db:
             cursor = db.conn.cursor(cursor_factory=RealDictCursor)
 
-            sql_query = SQL("select {},ST_AsGeoJSON({}) \
+            sql_query = SQL("SELECT {},ST_AsGeoJSON({}) \
             from {} WHERE {}=%s").format(db.columns,
                                          Identifier(self.geom),
                                          Identifier(self.table),

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -106,7 +106,7 @@ class SQLiteGPKGProvider(BaseProvider):
         :param properties: list of tuples (name, value)
         :param bbox: bounding box [minx,miny,maxx,maxy]
 
-        :returns: str, tupple
+        :returns: str, tuple
         """
 
         where_values = tuple()

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -271,7 +271,7 @@ class SQLiteGPKGProvider(BaseProvider):
 
         if resulttype == 'hits':
 
-            sql_query = "select count(*) as hits from {} {} ".format(
+            sql_query = "SELECT COUNT(*) as hits FROM {} {} ".format(
                 self.table, where_clause)
 
             res = self.cursor.execute(sql_query, where_values)
@@ -279,7 +279,7 @@ class SQLiteGPKGProvider(BaseProvider):
             hits = res.fetchone()["hits"]
             return self.__response_feature_hits(hits)
 
-        sql_query = "select {} from \
+        sql_query = "SELECT DISTINCT {} from \
             {} {} limit ? offset ?".format(
                 self.columns, self.table, where_clause)
 
@@ -315,8 +315,8 @@ class SQLiteGPKGProvider(BaseProvider):
 
         LOGGER.debug('Get item from SQLite/GPKG')
 
-        sql_query = 'select {} from \
-            {} where {}==?;'.format(
+        sql_query = 'SELECT {} FROM \
+            {} WHERE {}==?;'.format(
                 self.columns, self.table, self.id_field)
 
         LOGGER.debug('SQL Query: {}'.format(sql_query))

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -95,6 +95,39 @@ class SQLiteGPKGProvider(BaseProvider):
                 ) for item in results]
         return self.fields
 
+    def __get_where_clauses(self, properties=[], bbox=[]):
+        """
+        Generarates WHERE conditions to be implemented in query.
+        Private method mainly associated with query method.
+
+        Method returns part of the SQL query, plus tupple to be used
+        in the sqlite query method
+
+        :param properties: list of tuples (name, value)
+        :param bbox: bounding box [minx,miny,maxx,maxy]
+
+        :returns: str, tupple
+        """
+
+        where_values = tuple()
+        where_clause = " WHERE " if (properties or bbox) else ""
+        if not where_clause:
+            return where_clause, where_values
+
+        if properties:
+            where_clause += " AND ".join(
+                ["{}=?".format(k) for k, v in properties])
+            where_values += where_values + tuple((v for k, v in properties))
+
+        if bbox:
+            if properties:
+                where_clause += " AND "
+            where_clause += " Intersects({}, \
+                BuildMbr(?,?,?,?)) ".format(self.geom_col)
+            where_values += tuple(bbox)
+        # WHERE continent=? <class 'tuple'>: ('Europe',)
+        return where_clause, where_values
+
     def __response_feature(self, row_data):
         """
         Assembles GeoJSON output from DB query
@@ -153,7 +186,8 @@ class SQLiteGPKGProvider(BaseProvider):
         # conn.set_trace_callback(LOGGER.debug)
         cursor = conn.cursor()
         try:
-            cursor.execute(f"SELECT load_extension('{SPATIALITE_EXTENSION}')")
+            cursor.execute("SELECT load_extension('{}')".format(
+                SPATIALITE_EXTENSION))
         except sqlite3.OperationalError as err:
             LOGGER.error('Extension loading error: {}'.format(err))
             raise ProviderConnectionError()
@@ -232,32 +266,22 @@ class SQLiteGPKGProvider(BaseProvider):
         """
         LOGGER.debug('Querying SQLite/GPKG')
 
+        where_clause, where_values = self.__get_where_clauses(
+            properties=properties, bbox=bbox)
+
         if resulttype == 'hits':
-            res = self.cursor.execute(
-                "select count(*) as hits from {};".format(self.table))
+
+            sql_query = "select count(*) as hits from {} {} ".format(
+                self.table, where_clause)
+
+            res = self.cursor.execute(sql_query, where_values)
 
             hits = res.fetchone()["hits"]
             return self.__response_feature_hits(hits)
 
-        where_syntax = " where " if (properties or bbox) else ""
-        where_values = tuple()
-
-        if properties:
-            where_syntax += " and ".join(
-                ["{}=?".format(k) for k, v in properties])
-            where_values += where_values + tuple((v for k, v in properties))
-
-        if bbox:
-            if properties:
-                where_syntax += " and "
-            # TODO: check name of geometry column
-            where_syntax += " Intersects({}, \
-                BuildMbr(?,?,?,?)) ".format(self.geom_col)
-            where_values += tuple(bbox)
-
         sql_query = "select {} from \
             {} {} limit ? offset ?".format(
-                self.columns, self.table, where_syntax)
+                self.columns, self.table, where_clause)
 
         end_index = startindex + limit
 

--- a/tests/test_sqlite_geopackage_provider.py
+++ b/tests/test_sqlite_geopackage_provider.py
@@ -87,7 +87,19 @@ def test_query_geopackage(config_geopackage):
     assert geometry is not None
 
 
-def test_query_with_property_filter_sqlite(config_sqlite):
+def test_query_hits_sqlite_geopackage(config_sqlite):
+    """Testing hits results type for sqlite/geopackage"""
+
+    p = SQLiteGPKGProvider(config_sqlite)
+    results = p.query(resulttype="hits")
+    assert results["numberMatched"] == 177
+    results = p.query(
+        bbox=[28.3373, -5.4099, 32.3761, -3.3924],
+        properties=[("continent", "Africa")], resulttype="hits")
+    assert results["numberMatched"] == 3
+
+
+def test_query_with_property_filter_sqlite_geopackage(config_sqlite):
     """Test query  valid features when filtering by property"""
 
     p = SQLiteGPKGProvider(config_sqlite)
@@ -97,18 +109,7 @@ def test_query_with_property_filter_sqlite(config_sqlite):
     assert len(features) == 39
 
 
-def test_query_with_property_filter_geopackage(config_geopackage):
-    """Test query  valid features when filtering by property"""
-
-    p = SQLiteGPKGProvider(config_geopackage)
-    feature_collection = p.query(properties=[
-        ("fclass", "cafe")], limit=10000)
-    features = feature_collection.get('features', None)
-
-    assert len(features) == 823
-
-
-def test_query_with_property_filter_bbox_sqlite(config_sqlite):
+def test_query_with_property_filter_bbox_sqlite_geopackage(config_sqlite):
     """Test query  valid features when filtering by property"""
     p = SQLiteGPKGProvider(config_sqlite)
     feature_collection = p.query(properties=[("continent", "Europe")],
@@ -117,21 +118,7 @@ def test_query_with_property_filter_bbox_sqlite(config_sqlite):
     assert len(features) == 0
 
 
-def test_query_with_property_filter_bbox_geopackage(config_geopackage):
-    """Test query  valid features when filtering by property"""
-    p = SQLiteGPKGProvider(config_geopackage)
-    feature_collection = p.query(properties=[("fclass", "cafe")],
-                                 bbox=[
-                                     -16.3991310876,
-                                     33.0063015781,
-                                     -16.3366454278,
-                                     33.0560854323
-                                     ])
-    features = feature_collection.get('features', None)
-    assert len(features) == 0
-
-
-def test_query_bbox_sqlite(config_sqlite):
+def test_query_bbox_sqlite_geopackage(config_sqlite):
     """Test query with a specified bounding box"""
 
     psp = SQLiteGPKGProvider(config_sqlite)
@@ -142,17 +129,6 @@ def test_query_bbox_sqlite(config_sqlite):
     assert len(boxed_feature_collection['features']) == 1
     assert 'Burundi' in \
         boxed_feature_collection['features'][0]['properties']['name']
-
-
-def test_query_bbox_geopackage(config_geopackage):
-    """Test query with a specified bounding box"""
-
-    psp = SQLiteGPKGProvider(config_geopackage)
-    boxed_feature_collection = psp.query(
-        bbox=[-16.3991310876, 33.0063015781, -16.3366454278, 33.0560854323]
-    )
-
-    assert len(boxed_feature_collection['features']) == 5
 
 
 def test_get_sqlite(config_sqlite):


### PR DESCRIPTION
Implements sqlite3/gpkg filtering on hits just like posgresql

- private method `__get_where_clauses` to generate where clauses
- removal of pytest that where redundant, since they would call same code for sqlite/gpkg

 