### PR TITLE
include local setup of OGC schemas for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 #          Just van den Broecke <justb4@gmail.com>
 #          Francesco Bartoli <xbartolone@gmail.com>
 #
-# Copyright (c) 2019 Tom Kralidis
+# Copyright (c) 2020 Tom Kralidis
 # Copyright (c) 2019 Just van den Broecke
 # Copyright (c) 2020 Francesco Bartoli
 #
@@ -62,8 +62,8 @@ ARG ADD_PIP_PACKAGES=""
 # ENV settings
 ENV TZ=${TIMEZONE} \
 	DEBIAN_FRONTEND="noninteractive" \
-	DEB_BUILD_DEPS="tzdata build-essential python3-setuptools python3-pip apt-utils git" \
-	DEB_PACKAGES="locales libgdal26 python3-gdal libsqlite3-mod-spatialite curl ${ADD_DEB_PACKAGES}" \
+	DEB_BUILD_DEPS="tzdata build-essential python3-setuptools python3-pip apt-utils curl git unzip" \
+	DEB_PACKAGES="locales libgdal26 python3-gdal libsqlite3-mod-spatialite ${ADD_DEB_PACKAGES}" \
 	PIP_PACKAGES="gunicorn==19.9.0 gevent==1.5a4 wheel==0.33.4 ${ADD_PIP_PACKAGES}"
 
 ADD . /pygeoapi
@@ -90,6 +90,10 @@ RUN \
 	&& pip3 install -r requirements-dev.txt \
 	&& pip3 install -r requirements-provider.txt \
 	&& pip3 install -e . \
+	# OGC schemas local setup
+	&& mkdir /schemas.opengis.net \
+	&& curl -O http://schemas.opengis.net/SCHEMAS_OPENGIS_NET.zip \
+	&& unzip ./SCHEMAS_OPENGIS_NET.zip "ogcapi/*" -d /schemas.opengis.net \
 	# Cleanup TODO: remove unused Locales and TZs
 	&& pip3 uninstall --yes wheel \
 	&& apt-get remove --purge ${DEB_BUILD_DEPS} -y \
@@ -101,4 +105,3 @@ COPY ./docker/entrypoint.sh /entrypoint.sh
 
 WORKDIR /pygeoapi
 ENTRYPOINT ["/entrypoint.sh"]
-

--- a/docker/default.config.yml
+++ b/docker/default.config.yml
@@ -49,6 +49,7 @@ server:
     map:
         url: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
         attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+    ogc_schemas_location: /schemas.opengis.net
 
 logging:
     level: ERROR


### PR DESCRIPTION
This pull request implements local OGC schemas as part of pygeoapi's default Docker image.

The Docker setup installs the http://schemas.opengis.net schemas .zip file into `/schemas.opengis.net` in the Docker image and updates the configuration to use local schemas.

Note: any downstream Docker image that uses `pygeoapi:latest` and wants to leverage the local schemas needs to update their config as per `docker/default.config.yml` in this PR.
Fixes: #399 