### PR TITLE
fix raw output for OAProc

### DIFF
--- a/docs/source/data-publishing/ogcapi-processes.rst
+++ b/docs/source/data-publishing/ogcapi-processes.rst
@@ -29,6 +29,12 @@ Processing examples
   - http://localhost:5000/processes
 - describe the ``hello-world`` process
   - http://localhost:5000/processes/hello-world
+- show all jobs for the ``hello-world`` process
+  - http://localhost:5000/processes/hello-world/jobs
+- execute a job for the ``hello-world`` process
+  - ``curl -X POST "http://localhost:5000/processes/hello-world/jobs" -H "Content-Type: application/json" -d "{\"inputs\":[{\"id\":\"name\",\"type\":\"text/plain\",\"value\":\"hi there2\"}]}"``
+- execute a job for the ``hello-world`` process with a raw response
+  - ``curl -X POST "http://localhost:5000/processes/hello-world/jobs?response=raw" -H "Content-Type: application/json" -d "{\"inputs\":[{\"id\":\"name\",\"type\":\"text/plain\",\"value\":\"hi there2\"}]}"``
 
 
 .. todo:: add more examples once OAPIP implementation is complete

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -48,7 +48,7 @@ from pygeoapi.provider.base import (
     ProviderGenericError, ProviderConnectionError, ProviderNotFoundError,
     ProviderQueryError, ProviderItemNotFoundError)
 from pygeoapi.util import (dategetter, filter_dict_by_key_value, json_serial,
-                           render_j2_template, str2bool, TEMPLATES)
+                           render_j2_template, TEMPLATES, to_json)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1320,13 +1320,17 @@ class API:
         try:
             outputs = p.execute(data_dict)
             m = p.metadata
-            if 'raw' in args and str2bool(args['raw']):
+            if 'response' in args and args['response'] == 'raw':
                 headers_['Content-Type'] = \
                     m['outputs'][0]['output']['formats'][0]['mimeType']
-                response = outputs
+                if 'json' in headers_['Content-Type']:
+                    response = to_json(outputs)
+                else:
+                    response = outputs
             else:
                 response['outputs'] = outputs
-            return headers_, 201, json.dumps(response)
+                response = to_json(response)
+            return headers_, 200, response
         except Exception as err:
             exception = {
                 'code': 'InvalidParameterValue',

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -515,7 +515,7 @@ def get_oas_30(cfg):
                 {'$ref': '#/components/parameters/f'}
             ],
             'responses': {
-                '200': {'$ref': '#/components/responses/200'},
+                '200': {'$ref': '{}/responses/ProcessCollection.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa
                 'default': {'$ref': '#/components/responses/default'}
             }
         }
@@ -566,6 +566,7 @@ def get_oas_30(cfg):
                     'operationId': 'get{}Jobs'.format(k.capitalize()),
                     'responses': {
                         '200': {'$ref': '#/components/responses/200'},
+                        '404': {'$ref': '{}/responses/NotFound.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa
                         'default': {'$ref': '#/components/responses/default'}
                     }
                 },
@@ -575,9 +576,22 @@ def get_oas_30(cfg):
                     'description': p.metadata['description'],
                     'tags': [k],
                     'operationId': 'execute{}Job'.format(k.capitalize()),
-                    'parameters': [],
+                    'parameters': [{
+                        'name': 'response',
+                        'in': 'query',
+                        'description': 'Response type',
+                        'required': False,
+                        'schema': {
+                            'type': 'string',
+                            'enum': ['raw', 'document'],
+                            'default': 'document'
+                        }
+                    }],
                     'responses': {
                         '200': {'$ref': '#/components/responses/200'},
+                        '201': {'$ref': '{}/responses/ExecuteAsync.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa
+                        '404': {'$ref': '{}/responses/NotFound.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa
+                        '500': {'$ref': '{}/responses/ServerError.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa
                         'default': {'$ref': '#/components/responses/default'}
                     },
                     'requestBody': {

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -29,6 +29,7 @@
 
 """Generic util functions used in the code"""
 
+import base64
 from datetime import date, datetime, time
 from decimal import Decimal
 import json
@@ -175,6 +176,13 @@ def json_serial(obj):
 
     if isinstance(obj, (datetime, date, time)):
         return obj.isoformat()
+    elif isinstance(obj, bytes):
+        try:
+            LOGGER.debug('Returning as UTF-8 decoded bytes')
+            return obj.decode('utf-8')
+        except UnicodeDecodeError:
+            LOGGER.debug('Returning as base64 encoded JSON object')
+            return base64.b64encode(obj)
     elif isinstance(obj, Decimal):
         return float(obj)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2019 Tom Kralidis
+# Copyright (c) 2020 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -642,6 +642,14 @@ def test_execute_process(config, api_):
     response = json.loads(response)
 
     assert response['outputs'][0]['value'] == 'test'
+
+    args = {'response': 'raw'}
+    rsp_headers, code, response = api_.execute_process(req_headers, args,
+                                                       json.dumps(req_body),
+                                                       'hello-world')
+    response = json.loads(response)
+
+    assert response[0]['value'] == 'test'
 
     api_.config['resources'] = {}
 


### PR DESCRIPTION
This PR fixes OAProc raw output for non-JSON representations.  Other changes:

- updates OAProc OpenAPI defs
- changes `raw=true` to `document=raw` for raw output
- changes execute HTTP status to 200 (201 is now only for asynchronous)

cc @RousseauLambertLP