### PR TITLE
Corrections to docstrings for delete method in providers

### DIFF
--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -109,7 +109,7 @@ class BaseProvider:
         raise NotImplementedError()
 
     def delete(self, identifier):
-        """Updates an existing feature id with new_feature
+        """Deletes an existing feature
 
         :param identifier: feature id
         """

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -188,7 +188,7 @@ class GeoJSONProvider(BaseProvider):
             dst.write(json.dumps(all_data))
 
     def delete(self, identifier):
-        """Updates an existing feature id with new_feature
+        """Deletes an existing feature
 
         :param identifier: feature id
         """

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -172,7 +172,7 @@ class MongoProvider(BaseProvider):
             {'_id': ObjectId(identifier)}, {"$set": data})
 
     def delete(self, identifier):
-        """Delets an existing feature
+        """Deletes an existing feature
 
         :param identifier: feature id
         """


### PR DESCRIPTION
Correct typo in mongo.py provider's `delete` method and use corrected version to replace incorrect description in geojson.py and base.py