### PR TITLE
Improvements in .gitignore and installation docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,7 @@ ENV/
 
 
 .DS_Store
+
+# example configs
+
+example-*

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,9 +20,8 @@ For developers and the truly impatient
 
 .. code-block:: bash
 
-   python -m venv pygeoapi
-   cd pygeoapi
-   . bin/activate
+   python -m venv pygeoapi-env
+   source pygeoapi-env/bin/activate
    git clone https://github.com/geopython/pygeoapi.git
    cd pygeoapi
    pip install -r requirements.txt


### PR DESCRIPTION
1. Example configs generated as mentioned in installation docs are tracked by git
2. Current directory structure if quick installation docs is followed is as follows
```
pygeoapi/
└── <env related directories>
└──pygeoapi
         └──<project related directories>
```

With the change in installation docs the directories would be structured as follows
```
pygeoapi-env/
└── <env related directories>
pygeoapi
└──<project related directories>
```
 3. Also `source` removes the additional overhead to make `bin/activate` executable