### PR TITLE
Improve signal handling in entry point

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -93,7 +93,7 @@ case ${entry_cmd} in
 		[[ "${SCRIPT_NAME}" = '/' ]] && export SCRIPT_NAME="" && echo "make SCRIPT_NAME empty from /"
 
 		echo "Start gunicorn name=${CONTAINER_NAME} on ${CONTAINER_HOST}:${CONTAINER_PORT} with ${WSGI_WORKERS} workers and SCRIPT_NAME=${SCRIPT_NAME}"
-		gunicorn --workers ${WSGI_WORKERS} \
+		exec gunicorn --workers ${WSGI_WORKERS} \
 				--worker-class=${WSGI_WORKER_CLASS} \
 				--timeout ${WSGI_WORKER_TIMEOUT} \
 				--name=${CONTAINER_NAME} \


### PR DESCRIPTION
Currently gunicorn is started in the entrypoint as subprocess. This
means that the entrypoint stays as process with PID 1 and eats the
signals that e.g. kubernetes sends to it. Thus when trying to update
the container, kubernetes must terminate the process ungracefully.

See e.g. this resources for a more detailed explanation:
https://hynek.me/articles/docker-signals/

This change replaces the entrypoint-shellscript with gunicorn, such that
signals are directly forwarded to gunicorn, where they are then handled.

One drawback of this approach is that lines after `exec gunicorn` are
not executed anymore. This currently affects `echo "END /entrypoint.sh"`.

A different approach would be to use `tini` to handle the system (see
link above). To do this, we would need to install tini.