### PR TITLE
Fix job submission form in case server url is relative

### DIFF
--- a/pygeoapi/static/js/postJob.js
+++ b/pygeoapi/static/js/postJob.js
@@ -75,7 +75,8 @@ function _completion_ui(xhr) {
 }
 
 function submitJob(url) {
-  let parsedUrl = new URL(url);
+  // NOTE: need to pass base in case url is relative
+  let parsedUrl = new URL(url, document.location.origin);
   if (JobExecution.SYNC_EXECUTE) {
     parsedUrl.searchParams.set('sync-execute', 'True');
   } else {


### PR DESCRIPTION
`new URL()` fails if the first argument isn't a complete url