### PR TITLE
reproject dataset bounds to 4326 while analyzing stac content

### DIFF
--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -201,6 +201,8 @@ resources:
                   - .sqlite
                   - .csv
                   - .grib2
+                  - .tif
+                  - .shp
 
     hello-world:
         type: process

--- a/pygeoapi/provider/filesystem.py
+++ b/pygeoapi/provider/filesystem.py
@@ -260,7 +260,8 @@ def _describe_file(filepath):
         LOGGER.debug('Testing vector data detection')
         d = fiona.open(filepath)
         tcrs = CRS.from_epsg(4326)
-        bnds = transform_bounds(CRS(d.crs),tcrs,d.bounds[0],d.bounds[1],d.bounds[2],d.bounds[3])
+        bnds = transform_bounds(CRS(d.crs), tcrs, 
+            d.bounds[0], d.bounds[1], d.bounds[2], d.bounds[3])
         if d.schema['geometry'] not in [None, 'None']:
             content['bbox'] = [
                 bnds[0],
@@ -278,14 +279,14 @@ def _describe_file(filepath):
                     [bnds[0], bnds[1]]
                 ]]
             }
-        content['properties']['projection'] = d.crs['init']  
+        content['properties']['projection'] = d.crs['init']
         for k, v in d.schema['properties'].items():
             content['properties'][k] = v
 
         if d.driver == 'ESRI Shapefile':
             id_ = os.path.splitext(os.path.basename(filepath))[0]
             content['assets'] = {}
-            for suffix in ['shx', 'dbf', 'prj']:
+            for suffix in ['shx', 'dbf', 'prj', 'shp.xml']:
                 content['assets'][suffix] = {
                     'href': './{}.{}'.format(id_, suffix)
                 }

--- a/pygeoapi/provider/filesystem.py
+++ b/pygeoapi/provider/filesystem.py
@@ -259,13 +259,13 @@ def _describe_file(filepath):
     except rasterio.errors.RasterioIOError:
         LOGGER.debug('Testing vector data detection')
         d = fiona.open(filepath)
-        s = CRS(d.crs)
-        if s.to_epsg() is not None and s.to_epsg() != 4326:
+        scrs = CRS(d.crs)
+        if scrs.to_epsg() is not None and scrs.to_epsg() != 4326:
             tcrs = CRS.from_epsg(4326)
-            bnds = transform_bounds(CRS(d.crs), tcrs,
+            bnds = transform_bounds(scrs, tcrs,
                                     d.bounds[0], d.bounds[1],
                                     d.bounds[2], d.bounds[3])
-            content['properties']['projection'] = d.crs['init']
+            content['properties']['projection'] = scrs.to_epsg()
         else:
             bnds = d.bounds
 

--- a/pygeoapi/provider/filesystem.py
+++ b/pygeoapi/provider/filesystem.py
@@ -260,8 +260,9 @@ def _describe_file(filepath):
         LOGGER.debug('Testing vector data detection')
         d = fiona.open(filepath)
         tcrs = CRS.from_epsg(4326)
-        bnds = transform_bounds(CRS(d.crs), tcrs, 
-            d.bounds[0], d.bounds[1], d.bounds[2], d.bounds[3])
+        bnds = transform_bounds(CRS(d.crs), tcrs,
+                                d.bounds[0], d.bounds[1],
+                                d.bounds[2], d.bounds[3])
         if d.schema['geometry'] not in [None, 'None']:
             content['bbox'] = [
                 bnds[0],


### PR DESCRIPTION
map viewer (and i assume geojson in general) expects geometry to be in 4326, with this reprojection the bounds look fine on map (before were covering full earth)
also added original projection as additional property
adds shp and tif to stac supported filetypes

![image](https://user-images.githubusercontent.com/299829/97354664-069c4e00-1896-11eb-8d54-8152410ca0b0.png)
