### PR TITLE
adds metadata properties for stac items

### DIFF
--- a/pygeoapi/provider/filesystem.py
+++ b/pygeoapi/provider/filesystem.py
@@ -220,11 +220,11 @@ def _describe_file(filepath):
     }
 
     try:
-        from datetime import datetime
+        from datetime import datetime as dt
         t = os.path.getmtime(filepath)
         s = os.path.getsize(filepath)
-        format = "%Y-%m-%d %H:%M"
-        content['properties']['datetime'] = datetime.fromtimestamp(t).strftime(format)
+        f = "%Y-%m-%d %H:%M"
+        content['properties']['datetime'] = dt.fromtimestamp(t).strftime(f)
         if s > 0:
             content['properties']['size'] = str(round(s/100)/10)
     except ValueError as err:
@@ -286,7 +286,7 @@ def _describe_file(filepath):
                     [d.bounds[0], d.bounds[1]]
                 ]]
             }
-        
+
         model = {}
         for k, v in d.schema['properties'].items():
             model[k] = v

--- a/pygeoapi/provider/filesystem.py
+++ b/pygeoapi/provider/filesystem.py
@@ -220,10 +220,11 @@ def _describe_file(filepath):
     }
 
     try:
-        import datetime
+        from datetime import datetime
         t = os.path.getmtime(filepath)
         s = os.path.getsize(filepath)
-        content['properties']['datetime'] = datetime.datetime.fromtimestamp(t)
+        format = "%Y-%m-%d %H:%M"
+        content['properties']['datetime'] = datetime.fromtimestamp(t).strftime(format)
         if s > 0:
             content['properties']['size'] = str(round(s/100)/10)
     except ValueError as err:

--- a/tests/data/obs.md.yml
+++ b/tests/data/obs.md.yml
@@ -1,0 +1,7 @@
+title: My cool observations
+description: Sample CSV data from mapserver project
+license: https://opendefinition.org/licenses/cc-by/
+providers:
+  name: Mapserver
+  roles: ContactPoint
+  url: https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv


### PR DESCRIPTION
Metadata items added:
- datetime
- filesize
- some attributes from an optional metadata file: {basename}.md.yml
- for vector files, moves columnnames to a property 'model'

This is an initial response to #562

Potential improvements:
- if md file already lists a property (size/date/title, use that in stead of the one extracted from file)
- properties do incidentally contain array/object, html visualization does not properly manage this yet
- the name of the collection should be added as property (is that property stored somewhere, or should be extracted from path?)

example md.yml file included for obs.csv

![image](https://user-images.githubusercontent.com/299829/97503991-5baf9100-1976-11eb-8ca0-59fa30e6a920.png)
