### PR TITLE
Update example vector provider plugin query arguments.

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -68,8 +68,9 @@ The below template provides a minimal example (let's call the file ``mycoolvecto
                'field2': 'string'
            }
 
-       def query(self, startindex=0, limit=10, resulttype='results',
-                 bbox=[], datetime=None, properties=[], sortby=[]):
+       def query(self,startindex=0, limit=10, resulttype='results',
+                 bbox=[], datetime_=None, properties=[], sortby=[],
+                 select_properties=[], skip_geometry=False):
 
            # open data file (self.data) and process, return
            return {


### PR DESCRIPTION
The `datetime` parameter is incorrectly documented. This threw an error when trying to implement a custom provider. I referenced the query arguments defined on the core `csv` provider's `query` method which fixed the problem.

Including the additional `select_properties` and `skip_geometry` arguments which were missing from the docs too.