### PR TITLE
Add missing build dependencies libpython3-dev and libgdal-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ ENV TZ=${TIMEZONE} \
 	DEBIAN_FRONTEND="noninteractive" \
 	DEB_BUILD_DEPS="tzdata build-essential libpython3-dev libgdal-dev python3-pip apt-utils curl git unzip" \
 	DEB_PACKAGES="locales libgdal27 python3-distutils python3-gdal libsqlite3-mod-spatialite ${ADD_DEB_PACKAGES}" \
-	PIP_PACKAGES="setuptools==49.3.1 greenlet==0.4.16 gunicorn==20.0.4 gevent==1.5.0 wheel==0.33.4 ${ADD_PIP_PACKAGES}"
+	PIP_PACKAGES="setuptools==49.3.1 greenlet==0.4.17 gunicorn==20.0.4 gevent==20.9.0 wheel==0.33.4 ${ADD_PIP_PACKAGES}"
 
 RUN mkdir -p /pygeoapi/pygeoapi
 # Add files required for pip/setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ ARG ADD_PIP_PACKAGES=""
 ENV TZ=${TIMEZONE} \
 	DEBIAN_FRONTEND="noninteractive" \
 	DEB_BUILD_DEPS="tzdata build-essential libpython3-dev libgdal-dev python3-pip apt-utils curl git unzip" \
-	DEB_PACKAGES="locales libgdal27 python3-distutils python3-gdal libsqlite3-mod-spatialite ${ADD_DEB_PACKAGES}" \
+	DEB_PACKAGES="locales libgdal28 python3-distutils python3-gdal libsqlite3-mod-spatialite ${ADD_DEB_PACKAGES}" \
 	PIP_PACKAGES="setuptools==49.3.1 greenlet==0.4.17 gunicorn==20.0.4 gevent==20.9.0 wheel==0.33.4 ${ADD_PIP_PACKAGES}"
 
 RUN mkdir -p /pygeoapi/pygeoapi

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ARG ADD_PIP_PACKAGES=""
 # ENV settings
 ENV TZ=${TIMEZONE} \
 	DEBIAN_FRONTEND="noninteractive" \
-	DEB_BUILD_DEPS="tzdata build-essential python3-pip apt-utils curl git unzip" \
+	DEB_BUILD_DEPS="tzdata build-essential libpython3-dev libgdal-dev python3-pip apt-utils curl git unzip" \
 	DEB_PACKAGES="locales libgdal27 python3-distutils python3-gdal libsqlite3-mod-spatialite ${ADD_DEB_PACKAGES}" \
 	PIP_PACKAGES="setuptools==49.3.1 greenlet==0.4.16 gunicorn==20.0.4 gevent==1.5.0 wheel==0.33.4 ${ADD_PIP_PACKAGES}"
 


### PR DESCRIPTION
I'm not sure why these are required now, apparently some update changed some dependencies. At first glance it doesn't seem directly related to #584, but the temporal proximity is suspicious.

These were the error message I got while building:

```
copying src/gevent/tests/tests_that_dont_do_leakchecks.txt -> build/lib.linux-x86_64-3.9/gevent/tests
  copying src/gevent/tests/server.key -> build/lib.linux-x86_64-3.9/gevent/tests
  copying src/gevent/tests/test_server.key -> build/lib.linux-x86_64-3.9/gevent/tests
  creating build/lib.linux-x86_64-3.9/gevent/testing/coveragesite
  copying src/gevent/testing/coveragesite/sitecustomize.py -> build/lib.linux-x86_64-3.9/gevent/testing/coveragesite
  running build_ext
  generating cffi module 'build/temp.linux-x86_64-3.9/gevent.libuv._corecffi.c'
  creating build/temp.linux-x86_64-3.9
  Running '(cd  "/tmp/pip-install-doios8nv/gevent_5935bf4ce4024a1d89216659b4333548/deps/libev"  && sh ./configure -C > configure-output.txt )' in /tmp/pip-install-doios8nv/gevent_5935bf4ce4024a1d89216659b4333548
  ./configure: line 6475: /usr/bin/file: No such file or directory
  generating cffi module 'build/temp.linux-x86_64-3.9/gevent.libev._corecffi.c'
  Not configuring libev, 'config.h' already exists
  Not configuring libev, 'config.h' already exists
  building 'gevent.libev.corecext' extension
  creating build/temp.linux-x86_64-3.9/src
  creating build/temp.linux-x86_64-3.9/src/gevent
  creating build/temp.linux-x86_64-3.9/src/gevent/libev
  x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DLIBEV_EMBED=1 -DEV_COMMON= -DEV_CLEANUP_ENABLE=0 -DEV_EMBED_ENABLE=0 -DEV_PERIODIC_ENABLE=0 -Isrc/gevent/libev -I/usr/include/python3.9 -I/tmp/pip-install-doios8nv/gevent_5935bf4ce4024a1d89216659b4333548/deps -I/tmp/pip-install-doios8nv/gevent_5935bf4ce4024a1d89216659b4333548/src/gevent/libev -I/tmp/pip-install-doios8nv/gevent_5935bf4ce4024a1d89216659b4333548/deps/libev -Isrc/gevent -Isrc/gevent/libev -Isrc/gevent/resolver -I. -I/usr/include/python3.9 -c src/gevent/libev/callbacks.c -o build/temp.linux-x86_64-3.9/src/gevent/libev/callbacks.o
  src/gevent/libev/callbacks.c:3:10: fatal error: Python.h: No such file or directory
      3 | #include "Python.h"
        |          ^~~~~~~~~~
  compilation terminated.
  error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
  ----------------------------------------
  ERROR: Failed building wheel for gevent
```


```
Collecting rasterio
  Downloading rasterio-1.1.8.tar.gz (2.1 MB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 /usr/local/lib/python3.9/dist-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpmvy0iiij
       cwd: /tmp/pip-install-esormpv9/rasterio_fe3dcb767161460ca67807864fd71f76
  Complete output (2 lines):
  WARNING:root:Failed to get options via gdal-config: [Errno 2] No such file or directory: 'gdal-config'
  ERROR: A GDAL API version must be specified. Provide a path to gdal-config using a GDAL_CONFIG environment variable or use a GDAL_VERSION environment variable.
```