### PR TITLE
Fix format detection in execute_process

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1960,9 +1960,9 @@ tiles/{{{}}}/{{{}}}/{{{}}}/{{{}}}?f=mvt'
         :returns: tuple of headers, status code, content
         """
 
-        headers_ = HEADERS.copy()
+        format_ = check_format(args, headers)
 
-        format_ = check_format(args, headers_)
+        headers_ = HEADERS.copy()
 
         if format_ is not None and format_ not in FORMATS:
             exception = {
@@ -1997,7 +1997,7 @@ tiles/{{{}}}/{{{}}}/{{{}}}/{{{}}}?f=mvt'
 
         if method == 'GET' and process_id:
             jobs = sorted(self.manager.get_jobs(process_id), key=lambda k: k['process_start_datetime'], reverse=True)
-            if not format_ or format_ == 'html':
+            if format_ == 'html':
                 headers_['Content-Type'] = 'text/html'
                 response = render_j2_template(self.config, 'jobs.html', {'process': {'id': process_id, 'title': process.metadata['title']}, 'jobs': jobs})
                 return headers_, 200, response


### PR DESCRIPTION
Before, html was always selected. Now html is only returned if it's requested (as browsers do by default), otherwise json, which is also the behavior of other related views.