### PR TITLE
Show elapsed time for currently running jobs

### DIFF
--- a/pygeoapi/templates/job.html
+++ b/pygeoapi/templates/job.html
@@ -50,7 +50,13 @@
                 <h4><label for="progress">Progress</label></h4>
                 <progress id="progress" class="inline" value="{{data.job.progress|int*10}}" max="1000"></progress>
                 <h4><label for="runtime">Runtime</label></h4>
-                <p><span id="runtime">{{ data.job.process_start_datetime|duration(data.job.process_end_datetime) }}</span></p>
+                <p><span id="runtime">
+                  {% if data.job.status == 'running' %}
+                    {{ data.job.process_start_datetime|duration(data.now) }}
+                  {% else %}
+                    {{ data.job.process_start_datetime|duration(data.job.process_end_datetime) }}
+                  {% endif %}
+                </span></p>
                 <h4><label for="starttime">Started processing</label></h4>
                 <p><span id="starttime">{{ data.job.process_start_datetime|datetime }}</span></p>
                 <h4><label for="endtime">Finished processing</label></h4>

--- a/pygeoapi/templates/jobs.html
+++ b/pygeoapi/templates/jobs.html
@@ -36,7 +36,11 @@
                   {{ job.process_start_datetime|datetime }}
                 </td>
                 <td>
-                  {{ job.process_start_datetime|duration(job.process_end_datetime) }}
+                  {% if job.status == 'running' %}
+                    {{ job.process_start_datetime|duration(data.now) }}
+                  {% else %}
+                    {{ job.process_start_datetime|duration(job.process_end_datetime) }}
+                  {% endif %}
                 </td>
                 <td>
                   <progress class="inline" value="{{job.progress|int*10}}" max="1000"></progress>


### PR DESCRIPTION
This change is useful for long-running jobs because it helps users to see how far along the job probably is.