### PR TITLE
Allow jobs to show parameters in the UI

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2006,6 +2006,7 @@ tiles/{{{}}}/{{{}}}/{{{}}}/{{{}}}?f=mvt'
                 'status': job_['status'],
                 'message': job_['message'],
                 'progress': job_['progress'],
+                'parameters': job_.get('parameters'),
                 'job_start_datetime': job_['job_start_datetime'],
                 'job_end_datetime': job_['job_end_datetime']
             }

--- a/pygeoapi/templates/processes/jobs/job.html
+++ b/pygeoapi/templates/processes/jobs/job.html
@@ -23,6 +23,12 @@
                 <h3>Message</h3>
                 <p>{{ data['jobs']['message'] }}</p>
               </div>
+              {% if data['jobs']['parameters'] %}
+              <div class="message">
+                <h3>Parameters</h3>
+                <pre>{{ data['jobs']['parameters'] | pprint }}</pre>
+              </div>
+              {% endif %}
               <div class="duration">
                 <h4><label for="progress">Progress</label></h4>
                 <progress id="progress" class="inline" value="{{ data['jobs']['progress']|int*10 }}" max="1000"></progress>

--- a/pygeoapi/templates/processes/jobs/job.html
+++ b/pygeoapi/templates/processes/jobs/job.html
@@ -26,8 +26,11 @@
               {% if data['jobs']['parameters'] %}
               <div class="message">
                 <h3>Parameters</h3>
-                <pre>{{ data['jobs']['parameters'] | pprint }}</pre>
+                <pre id="job-parameters"></pre>
               </div>
+              <script>
+                document.getElementById('job-parameters').innerHTML = JSON.stringify({{ data['jobs']['parameters']}}, undefined, 2);
+              </script>
               {% endif %}
               <div class="duration">
                 <h4><label for="progress">Progress</label></h4>


### PR DESCRIPTION
This is very useful when starting the same job multiple times with
different configurations.

This PR allows to show parameters as arbitrary data since jobs might use
any kind of data.

![Screenshot_2021-01-05_14-49-33](https://user-images.githubusercontent.com/357581/103653747-430abb00-4f65-11eb-8cee-e9b076689c50.png)
