### PR TITLE
indicate which attribute to use as label for an item

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -175,7 +175,8 @@ default.
                 name: CSV
                 data: tests/data/obs.csv  # required: the data filesystem path or URL, depending on plugin setup
                 id_field: id  # required for vector data, the field corresponding to the ID
-                time_field: datetimestamp  # optional field corresponding to the temporal propert of the dataset
+                time_field: datetimestamp  # optional field corresponding to the temporal property of the dataset
+                title_field: foo # optional field of which property to display as title/label on HTML pages
                 format:  # optional default format
                     name: GeoJSON  # required: format name
                     mimetype: application/json  # required: format mimetype

--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -151,6 +151,7 @@ resources:
               name: GeoJSON
               data: tests/data/ne_110m_lakes.geojson
               id_field: id
+              title_field: name
 
     gdps-temperature:
         type: collection

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -837,6 +837,7 @@ class API:
             return headers_, 400, to_json(exception, self.pretty_print)
 
         LOGGER.debug('Loading provider')
+
         try:
             p = load_plugin('provider', get_provider_by_type(
                 collections[dataset]['providers'], 'feature'))
@@ -1053,6 +1054,11 @@ class API:
             content['dataset_path'] = '/'.join(path_info.split('/')[:-1])
             content['collections_path'] = '/'.join(path_info.split('/')[:-2])
             content['startindex'] = startindex
+            prv = get_provider_by_type(collections[dataset]['providers'],
+                                       'feature')
+            if 'title_field' in prv:
+                content['title_field'] = prv['title_field']
+            content['id_field'] = prv['id_field']
 
             content = render_j2_template(self.config,
                                          'collections/items/index.html',
@@ -1120,6 +1126,7 @@ class API:
             return headers_, 400, to_json(exception, self.pretty_print)
 
         LOGGER.debug('Loading provider')
+
         try:
             p = load_plugin('provider', get_provider_by_type(
                 collections[dataset]['providers'], 'feature'))
@@ -1211,6 +1218,12 @@ class API:
             headers_['Content-Type'] = 'text/html'
 
             content['title'] = collections[dataset]['title']
+            prv = get_provider_by_type(collections[dataset]['providers'],
+                                       'feature')
+            content['id_field'] = prv['id_field']
+            if 'title_field' in prv:
+                content['title_field'] = prv['title_field']
+
             content = render_j2_template(self.config,
                                          'collections/items/item.html',
                                          content)

--- a/pygeoapi/templates/collections/items/index.html
+++ b/pygeoapi/templates/collections/items/index.html
@@ -74,10 +74,14 @@
             <thead>
             <tr>
                 <th>id</th>
-                {% for k, v in data['features'][0]['properties'].items() %}
-                {% if loop.index < 5 %}
-                <td>{{ k }}</td>
+                {% if data['title_field'] %}
+                  <th>{{ data['title_field'] }}</th>
                 {% endif %}
+                {% for k, v in data['features'][0]['properties'].items() %}
+                  {# start with id & title then take first 5 columns for table #}
+                  {% if loop.index < 5 and k != data['id_field'] and k != data['title_field'] %}
+                  <th>{{ k }}</th>
+                  {% endif %}
                 {% endfor %}
             </tr>
           </thead>
@@ -85,11 +89,14 @@
             {% for ft in data['features'] %}
               <tr>
                 <td data-label="id"><a href="{{ data['items_path']}}/{{ ft.id }}">{{ ft.id }}</a></td>
-                  {% for k, v in ft['properties'].items() %}
-                  {% if loop.index < 5 %}
+                {% if data['title_field'] %}
+                  <td data-label="name"><a href="{{ data['items_path']}}/{{ ft['id'] }}">{{ ft['properties'][data['title_field']] }}</a></td>
+                {% endif %}
+                {% for k, v in ft['properties'].items() %}
+                  {% if loop.index < 5 and k != data['id_field'] and k != data['title_field'] %}
                   <td data-label="{{ k }}">{{ v | urlize(20) }}</td>
                   {% endif %}
-                  {% endfor %}
+                {% endfor %}
               </tr>
             {% endfor %}
           </tbody>
@@ -118,7 +125,7 @@
     var items = new L.GeoJSON(geojson_data, {
         onEachFeature: function (feature, layer) {
             var url = '{{ data['items_path'] }}/' + feature.id + '?f=html';
-            var html = '<span><a href="' + url + '">' + feature.id + '</a></span>';
+            var html = '<span><a href="' + url + '">' + feature.id + '. ' + feature['properties']['{{ data['title_field'] }}'] + '</a></span>';
             layer.bindPopup(html);
         }
     });

--- a/pygeoapi/templates/collections/items/item.html
+++ b/pygeoapi/templates/collections/items/item.html
@@ -10,7 +10,7 @@
         {{ v | urlize() }}
     {% endif %}
 {%- endmacro %}
-{% block title %}{{ super() }} {{ data['title'] }} - {{ data['id'] }}{% endblock %}
+{% block title %}{{ super() }} {{ data['title'] }} - {{ data['id'] }}. {{ data['properties'][data['title_field']] }}{% endblock %}
 {% block crumbs %}{{ super() }}
 / <a href="../../../collections">Collections</a>
 {% for link in data['links'] %}
@@ -19,7 +19,7 @@
   {% endif %}
 {% endfor %}
 / <a href="../items">Items</a>
-/ <a href="./{{ data['id'] }}">Item {{ data['id'] }}</a>
+/ <a href="./{{ data['id'] }}">{{ data['id'] }}. {{ data['properties'][data['title_field']] }}</a>
 {% endblock %}
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
@@ -30,7 +30,7 @@
     <section id="item">
       <div class="row">
         <div class="col-sm">
-          <h2>Item {{ data['id'] }}</h2>
+          <h1>{{ data['id'] }}. {{ data['properties'][data['title_field']] }}</h1>
         </div>
       </div>
       <div class="row">
@@ -72,20 +72,22 @@
                 <td>{{ data.id }}</td>
               </tr>
               {% for k, v in data['properties'].items() %}
-              <tr>
-                <td>{{ k }}</td>
-                {% if k == 'links' %}
-                <td>
-                    <ul>
-                        {% for l in v %}
-                        <li><a href="{{ l['href'] }}">{{ l['title'] }}</a></li>
-                        {% endfor %}
-                    </ul>
-                </td>
-                {% else %}
-                  <td>{{ render_item_value(v, 80) }}</td>
+                {% if k != data['id_field'] %}
+                <tr>
+                  <td>{{ k }}</td>
+                  {% if k == 'links' %}
+                  <td>
+                      <ul>
+                          {% for l in v %}
+                          <li><a href="{{ l['href'] }}">{{ l['title'] }}</a></li>
+                          {% endfor %}
+                      </ul>
+                  </td>
+                  {% else %}
+                    <td>{{ render_item_value(v, 80) }}</td>
+                  {% endif %}
+                </tr>
                 {% endif %}
-              </tr>
               {% endfor %}
             </tbody>
             </table>


### PR DESCRIPTION
This is a proposal for optimizing #133, it also brings in an aspect of #100. I wanted to combine the two to see the full benefit of it. In config you can assign one attribute as being the label/name/title of the item. 

![image](https://user-images.githubusercontent.com/299829/104785893-ed67b700-578b-11eb-8acf-0d91658b6a1f.png)

This value is then used as label on the map and title of the item page

![image](https://user-images.githubusercontent.com/299829/104785941-083a2b80-578c-11eb-8ac1-06e69b166647.png)

![image](https://user-images.githubusercontent.com/299829/104785978-1be59200-578c-11eb-823d-e1955ac13010.png)

I also introduced the capability to set this value in a multilingual way

![image](https://user-images.githubusercontent.com/299829/104786035-3c155100-578c-11eb-8213-484790b85158.png)

In case you ask the french representation of the page, the french attribute will be used as label

![image](https://user-images.githubusercontent.com/299829/104786114-636c1e00-578c-11eb-8ec9-218a06d121e5.png)

This required a language to be taken from accept-language or url-override, which had quite impact on the code, i can image people may want to refactor that aspect, please make suggestions

I considered also an approach in which i would add this aspect as part of the context, maybe @alpha-beta-soup can provide some suggestion there, maybe both approaches can co-exist? 
