### PR TITLE
Date now handling

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2600,6 +2600,11 @@ def validate_datetime(resource_def, datetime_=None):
         if '/' in datetime_:  # envelope
             LOGGER.debug('detected time range')
             LOGGER.debug('Validating time windows')
+
+            # normalize "" to ".." (actually changes datetime_)
+            datetime_ = re.sub(r'^/', '../', datetime_)
+            datetime_ = re.sub(r'/$', '/..', datetime_)
+
             datetime_begin, datetime_end = datetime_.split('/')
             if datetime_begin != '..':
                 datetime_begin = dateparse_begin(datetime_begin)

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -68,14 +68,14 @@ def dategetter(date_property, collection):
     :param date_property: property representing the date
     :param collection: dictionary to check within
 
-    :returns: `str` (ISO8601) representing the date. ('..' if null,
-        allowing for an open interval).
+    :returns: `str` (ISO8601) representing the date. (allowing for an open interval
+        using null).
     """
 
     value = collection.get(date_property, None)
 
     if value is None:
-        return '..'
+        return None
 
     return value.isoformat()
 

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -68,13 +68,13 @@ def dategetter(date_property, collection):
     :param date_property: property representing the date
     :param collection: dictionary to check within
 
-    :returns: `str` (ISO8601) representing the date. ('..' if null or "now",
+    :returns: `str` (ISO8601) representing the date. ('..' if null,
         allowing for an open interval).
     """
 
     value = collection.get(date_property, None)
 
-    if value == 'now' or value is None:
+    if value is None:
         return '..'
 
     return value.isoformat()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1157,6 +1157,8 @@ def test_validate_datetime():
             '2001-10-30/2002-10-30')
     assert validate_datetime(config, '2004/..') == '2004/..'
     assert validate_datetime(config, '../2005') == '../2005'
+    assert validate_datetime(config, '2004/') == '2004/..'
+    assert validate_datetime(config, '/2005') == '../2005'
     assert validate_datetime(config, '2004-10/2005-10') == '2004-10/2005-10'
     assert (validate_datetime(config, '2001-10-30/2002-10-30') ==
             '2001-10-30/2002-10-30')


### PR DESCRIPTION
This PR contains minor changes to how open intervals are handled:

1. "now" is no longer supported in the config
2. null is returned instead of '..' for open intervals
3. Empty strings are supported for open interval queries