### PR TITLE
Select correct process on GET /process/PROC_ID

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1892,7 +1892,12 @@ tiles/{{{}}}/{{{}}}/{{{}}}/{{{}}}?f=mvt'
                 return headers_, 404, to_json(exception, self.pretty_print)
 
         if processes_config:
-            for key, value in processes_config.items():
+            if process is not None:
+                relevant_processes = [(process, processes_config[process])]
+            else:
+                relevant_processes = processes_config.items()
+
+            for key, value in relevant_processes:
                 p = load_plugin('process',
                                 processes_config[key]['processor'])
 


### PR DESCRIPTION
Before, you would always get the first process in the config.

(Note the line below with `response = processes[0] `)