### PR TITLE
Extend process UI to complex data types

### DIFF
--- a/pygeoapi/templates/processes/process.html
+++ b/pygeoapi/templates/processes/process.html
@@ -36,7 +36,15 @@
                   {{ input_.title|striptags|truncate }}
                 </td>
                 <td itemprop="name" data-label="Title">
-                  {{ input_.input.literalDataDomain.dataType }}
+                  {% with literalDataDomain = input_.input.literalDataDomain %}
+                    {% if literalDataDomain %}
+                      {{ literalDataDomain.dataType }}
+                    {% else %}
+                      {% for format in input_.input.formats %}
+                        {{ format.mimeType }}{% if not loop.last %},{% endif %}
+                      {% endfor %}
+                    {% endif %}
+                  {% endwith %}
                 </td>
                 <td itemprop="description" data-label="Description">
                   {{ input_.abstract }}


### PR DESCRIPTION
Previously, it crashed if the input data wasn't a literal data type.
Now it shows all mime types of complex data types.

https://raw.githubusercontent.com/opengeospatial/ogcapi-processes/master/core/openapi/schemas/inputDescription.yaml