### PR TITLE
adds twitter and opengraph tags to html encoding

### DIFF
--- a/pygeoapi/templates/_base.html
+++ b/pygeoapi/templates/_base.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="{{ config['server']['encoding'] }}">
-    <title>{% block title %}{{ config['metadata']['identification']['title'] }} -{% endblock %}</title>
+    <title>{% block title %}{% endblock %}{% if not self.title() %}{{ config['metadata']['identification']['title'] }}{% endif %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="language" content="{{ config['server']['language'] }}">
     <meta name="description" content="{{ config['metadata']['identification']['title'] }}">
@@ -13,6 +13,17 @@
     <!--[if lt IE 9]>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
     <![endif]-->
+    <meta name="twitter:image:src"   content="{% block thumb %}{% endblock %}{% if not self.thumb() %}{{'{}/static/img/logo.png'.format(config['server']['url']) }}{% endif %}" />
+    <meta property="og:image"        content="{{ self.thumb() }}{% if not self.thumb() %}{{'{}/static/img/logo.png'.format(config['server']['url']) }}{% endif %}" />
+    <meta name="twitter:site"        content="{{ config['metadata']['identification']['title'] }}" />
+    <meta property="og:site_name"    content="{{ config['metadata']['identification']['title'] }}" />    
+    <meta name="twitter:card"        content="summary_large_image" />
+    <meta name="twitter:title"       content="{{ self.title() }}{% if not self.title() %}{{ config['metadata']['identification']['title'] }}{% endif %}" />
+    <meta property="og:title"        content="{{ self.title() }}{% if not self.title() %}{{ config['metadata']['identification']['title'] }}{% endif %}" />
+    <meta name="twitter:description" content="{{ config['metadata']['identification']['description']}}" />
+    <meta property="og:description"  content="{{ config['metadata']['identification']['description']}}" />
+
+    <meta property="og:type" content="website" />
     {% for link in data['links'] %}
       {% if (link['rel']=="self" and link['type']=="text/html") %}
       <link rel="canonical" href="{{ link['href'].split('?')[0] }}?f=html" />

--- a/pygeoapi/templates/_base.html
+++ b/pygeoapi/templates/_base.html
@@ -20,8 +20,8 @@
     <meta name="twitter:card"        content="summary_large_image" />
     <meta name="twitter:title"       content="{{ self.title() }}{% if not self.title() %}{{ config['metadata']['identification']['title'] }}{% endif %}" />
     <meta property="og:title"        content="{{ self.title() }}{% if not self.title() %}{{ config['metadata']['identification']['title'] }}{% endif %}" />
-    <meta name="twitter:description" content="{{ config['metadata']['identification']['description']}}" />
-    <meta property="og:description"  content="{{ config['metadata']['identification']['description']}}" />
+    <meta name="twitter:description" content="{{ config['metadata']['identification']['description'] }}" />
+    <meta property="og:description"  content="{{ config['metadata']['identification']['description'] }}" />
 
     <meta property="og:type" content="website" />
     {% for link in data['links'] %}

--- a/pygeoapi/templates/collections/collection.html
+++ b/pygeoapi/templates/collections/collection.html
@@ -1,5 +1,7 @@
 {% extends "_base.html" %}
 {% block title %}{{ super() }} {{ data['title'] }} {% endblock %}
+{% block desc %}{{ data.get('description','') | truncate(250) }}{% endblock %}
+{% block tags %}{{ data.get('keywords',[]) | join(',') }}{% endblock %}
 {% block crumbs %}{{ super() }}
 / <a href="{{ data['collections_path'] }}">{% trans %}Collections{% endtrans %}</a>
 / <a href="./{{ data['id'] }}">{{ data['title'] | truncate( 25 ) }}</a>

--- a/pygeoapi/templates/collections/items/item.html
+++ b/pygeoapi/templates/collections/items/item.html
@@ -1,5 +1,7 @@
 {% extends "_base.html" %}
 {% set ptitle = data['properties'][data['title_field']] or ("Item {}".format(data['id'])) %}
+{% block desc %}{{ data.get('properties',{}).get('description',{}) | string | truncate(250) }}{% endblock %}
+{% block tags %}{{ data['properties'].get('themes',[{}])[0].get('concepts',[]) | join(',') }}{% endblock %}
 {# Optionally renders an img element, otherwise standard value or link rendering #}
 {% macro render_item_value(v, width) -%}
     {% set val = v | string | trim %}
@@ -20,7 +22,7 @@
       {{ val | urlize() }}
     {% endif %}
 {%- endmacro %}
-{% block title %}{{ ptitle }} - {{ super() }}{% endblock %}
+{% block title %}{{ ptitle }}{% endblock %}
 {% block crumbs %}{{ super() }}
 / <a href="{{ data['collections_path'] }}">{% trans %}Collections{% endtrans %}</a>
 {% for link in data['links'] %}

--- a/pygeoapi/templates/collections/items/item.html
+++ b/pygeoapi/templates/collections/items/item.html
@@ -1,7 +1,7 @@
 {% extends "_base.html" %}
 {% set ptitle = data['properties'][data['title_field']] or ("Item {}".format(data['id'])) %}
-{% block desc %}{{ data.get('properties',{}).get('description',{}) | string | truncate(250) }}{% endblock %}
-{% block tags %}{{ data['properties'].get('themes',[{}])[0].get('concepts',[]) | join(',') }}{% endblock %}
+{% block desc %}{{ data.get('properties',{}).get('description', {}) | string | truncate(250) }}{% endblock %}
+{% block tags %}{{ data['properties'].get('themes', [{}])[0].get('concepts', []) | join(',') }}{% endblock %}
 {# Optionally renders an img element, otherwise standard value or link rendering #}
 {% macro render_item_value(v, width) -%}
     {% set val = v | string | trim %}


### PR DESCRIPTION
This brings in an aspect of improved vizualisation of pygeoapi items in social media.
Whenever you place a url in platforms such as linkedin, twitter, slack. The client heads out to find any microdata in that url so it can vizualize the url as a nice card. by default the settings are added from main config, unless you arrive at a collection or record endpoint, in that case the properties of the collection/record will be used to populate the microdata.

![image](https://user-images.githubusercontent.com/299829/109329062-71689080-785a-11eb-9dde-afe4ff8c8a60.png)
_example of rich snippet of INSPIRE portal in Mattermost client_