### PR TITLE
Fix HTML template for queryables

### DIFF
--- a/pygeoapi/templates/collections/queryables.html
+++ b/pygeoapi/templates/collections/queryables.html
@@ -16,8 +16,16 @@
       </p>
       <h3>Queryables</h3>
       <ul>
-      {% for queryable in data['queryables'] %}
-        <li>{{ queryable['queryable'] }} (<code>{{ queryable['type'] }}</code>)</li>
+      {% for qname, qinfo in data['properties'].items() %}
+        <li>{{ qname }} (<code>{{ qinfo['type'] }}</code>)
+        {% if 'enum' in qinfo %}
+          <ul>
+          {% for value in qinfo['enum'] %}
+            <li><i>{{ value }}</i></li>
+          {% endfor %}
+          </ul>
+        {% endif %}
+        </li>
       {% endfor %}
       </ul>
     </section>


### PR DESCRIPTION
Commit  e0003b06 has changed the data model for queryables, causing the HTML template for the Queryables page to no longer work (no items were displayed). This PR fixes that.