### PR TITLE
add schema.org/Dataset representation for items of ogc api records

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -46,8 +46,8 @@ from dateutil.parser import parse as dateparse
 import pytz
 
 from pygeoapi import __version__
-from pygeoapi.linked_data import (geojson2geojsonld, jsonldify,
-                                  jsonldify_collection)
+from pygeoapi.linked_data import (geojson2geojsonld, geojson2recordjsonld,
+                                  jsonldify, jsonldify_collection)
 from pygeoapi.log import setup_logger
 from pygeoapi.process.base import (
     ProcessorExecuteError
@@ -1028,7 +1028,11 @@ class API:
             return headers_, 200, content
         elif format_ == 'jsonld':
             headers_['Content-Type'] = 'application/ld+json'
-            content = geojson2geojsonld(self.config, content, dataset)
+            itemType = self.config['resources'][dataset].get('providers', [{}])[0].get('type','')
+            if itemType == 'record':
+                content = geojson2recordjsonld(self.config, content, dataset)
+            else:
+                content = geojson2geojsonld(self.config, content, dataset)
             return headers_, 200, content
 
         return headers_, 200, to_json(content, self.pretty_print)
@@ -1152,8 +1156,13 @@ class API:
             return headers_, 200, content
         elif format_ == 'jsonld':
             headers_['Content-Type'] = 'application/ld+json'
-            content = geojson2geojsonld(
-                self.config, content, dataset, identifier=identifier
+            itemType = self.config['resources'][dataset].get('providers', [{}])[0].get('type','')
+            if itemType == 'record':
+                content = geojson2recordjsonld(self.config, content, 
+                                               dataset, identifier=identifier)
+            else:
+                content = geojson2geojsonld(
+                    self.config, content, dataset, identifier=identifier
             )
             return headers_, 200, content
 


### PR DESCRIPTION
This PR adds a representation of the record schema of OGC API Records as json-ld.
Most of the field mappings are managed from the ld-context (and could probably be managed from the existing context configuration. However the 'properties' object of geojson itself, and the associations/distributions require specific changes. The frequent use of 'type' as a property name is not optimal for a ld conversion.

currently this is a work in progress
- [ ] finalization of the record schema (how will associations be constructed)
- [ ] populating more properties in record.yml, such as thumbnail, license, encodingformat, creator (contactPoint)
- [ ] tests and flake8
- [x] tested in GGL structured data testing tool and is functional (for jsonld as well as html encoding) 