### PR TITLE
Multilingual support

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ pygeoapi |release| documentation
    data-publishing/index
    plugins
    html-templating
+   language
    development
    ogc-compliance
    contributing

--- a/docs/source/language.rst
+++ b/docs/source/language.rst
@@ -1,0 +1,216 @@
+.. _language:
+
+Multilingual support
+====================
+
+pygeoapi is language-aware and can handle multiple languages if these have been defined in pygeoapi's configuration (see `maintainer guide`_).
+Plugins (e.g. providers) can also handle multiple languages if configured. These may even be different from the languages that pygeoapi
+supports. Out-of-the-box, pygeoapi "speaks" English.
+
+The following sections provide more information how to use and set up languages in pygeoapi.
+
+End user guide
+--------------
+
+There are 2 ways to affect the language of the results returned by pygeoapi, both for the HTML and JSON(-LD) formats:
+
+1. After the requested pygeoapi URL, append a ``l=<code>`` query parameter, where ``<code>`` should be replaced by a well-known language code.
+   This can be an ISO 639-1 code (e.g. `de` for German), optionally accompanied by an ISO 3166-1 alpha-2 country code (e.g. `de-CH` for Swiss-German).
+   Please refer to this `W3C article <https://www.w3.org/International/articles/language-tags/>`_ for more information or
+   this `list of language codes <http://www.lingoes.net/en/translator/langcode.htm>`_ for more examples.
+   Another option is to send a complex definition with quality weights (e.g. `de-CH, de;q=0.9, en;q=0.8, fr;q=0.7, \*;q=0.5`).
+   pygeoapi will then figure out the best match for the requested language.
+
+   For example, to view the pygeoapi landing page in Canadian-French, you could use this URL:
+
+   https://demo.pygeoapi.io/master?l=fr-CA
+
+2. Alternatively, you can set an ``Accept-Language`` HTTP header for the requested pygeoapi URL. Language tags that are valid for
+   the ``l`` query parameter are also valid for this header value.
+   Please note that if your client application (e.g. browser) is configured for a certain language, it will likely set this
+   header by default, so the returned response should be translated to the language of your client app. If you don't want this,
+   you can either change the language of your client app or append the ``l`` parameter to the URL, which will override
+   any language defined in the ``Accept-Language`` header.
+
+
+Notes
+^^^^^
+
+- If pygeoapi cannot find a good match to the requested language, the response is returned in the default language (usually English).
+
+- Even if pygeoapi *itself* supports the requested language, provider plugins might not support that language or perhaps don't even
+  support (multiple) languages at all. In that case the provider will reply in its own default language, which may not be the same language
+  as the default pygeoapi server language.
+
+- If pygeoapi found a match to the requested language, the response will include a ``Content-Language`` HTTP header,
+  set to the best-matching server language code. This is the default behavior for all pygeoapi requests.
+
+- For HTML results returned from a **provider**, the ``Content-Language`` HTTP header will be set to the best match for the
+  provider language or the best-matching pygeoapi server language if the provider does not support languages.
+
+- For JSON(-LD) results that are returned by a **provider**, the ``Content-Language`` header will be **removed** if the provider
+  does not support any language. Otherwise, the header will be set to the best-matching provider language.
+
+
+Maintainer guide
+----------------
+
+Every pygeoapi instance needs to support at least 1 language. In the server configuration, there must be a ``language``
+or a ``languages`` (note the `s`) property. The property can be set to a single language tag or a list of tags respectively.
+
+If you wish to set up a multilingual pygeoapi instance, you will have to add more than 1 language to the
+server configuration YAML file (i.e. ``pygeoapi-config.yml``). First, you will have to add the supported language tags/codes
+as a list. For example, if you wish to support American English and Canadian French, you could do:
+
+.. code-block:: yaml
+
+   server:
+       bind: ...
+       url: ...
+       mimetype: ...
+       encoding: ...
+       languages:
+           - en-US
+           - fr-CA
+
+Next, you will have to provide translations for the configured languages. This involves 3 steps:
+
+1. `Add translations for configurable text values`_ in the server YAML file;
+
+2. Verify if there are any Jinja2 HTML template translations for the configured language(s);
+
+3. Make sure that the provider plugins you need can handle this language as well, if you are empowered to do so.
+   See the `developer guide`_ for more details.
+
+
+Notes
+^^^^^
+
+- The **first** language you define in the configuration determines the default language, i.e. the language that pygeoapi will
+  use if no other language was requested or no best match for the requested language could be found.
+
+- It is not possible to **disable** language support in pygeoapi. The functionality is always available. If results should always
+  be shown in a single language, you'd have to set that language only in the pygeoapi configuration.
+
+- Results returned by a provider may be in a different language than pygeoapi's own server language. The requested language
+  is always passed on to the provider, even if pygeoapi itself does not support it. For more information, see the `end user guide`_
+  and the `developer guide`_.
+
+
+Add translations for configurable text values
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For most of the text values in pygeoapi's server configuration where it makes sense, you can add translations.
+Consider the ``metadata`` section for example. The English-only version looks similar to this:
+
+.. code-block:: yaml
+
+   metadata:
+       identification:
+           title: pygeoapi default instance
+           description: pygeoapi provides an API to geospatial data
+           keywords:
+               - geospatial
+               - data
+               - api
+
+If you wish to make these text values available in English and French, you could use the following language struct:
+
+.. code-block:: yaml
+
+   metadata:
+       identification:
+           title:
+               en: pygeoapi default instance
+               fr: instance par défaut de pygeoapi
+           description:
+               en: pygeoapi provides an API to geospatial data
+               fr: pygeoapi fournit une API aux données géospatiales
+           keywords:
+               en:
+                   - geospatial
+                   - data
+                   - api
+               fr:
+                   - géospatiale
+                   - données
+                   - api
+
+In other words: each plain text value should be replaced by a dictionary, where the language code is the key and the translated text represents the matching value.
+For lists, this can be applied as well (see ``keywords`` example above), as long as you nest the entire list under a language key instead of each list item.
+
+Note that the example above uses generic language tags, but you can also supply more localized tags (with a country code) if required.
+pygeoapi should always be able find the best match to the requested language, i.e. if the user wants Swiss-French (`fr-CH`) but pygeoapi can only find `fr` tags,
+those values will be returned. However, if a `fr-CH` tag can also be found, that value will be returned and not the `fr` value.
+
+.. todo::   Add docs on HTML templating.
+
+
+Developer guide
+---------------
+
+If you are a developer who wishes to create a pygeoapi plugin (e.g. a provider) that "speaks" a certain language,
+you will have to fully implement this yourself. Needless to say, if your plugin depends on some backend, it will only make sense to implement language support if the backend
+can be queried in another language as well.
+
+You are free to set up the language support anyway you like, but there are a couple of steps you'll have to walk through:
+
+1. You will have to define the supported languages in the plugin configuration YAML. This can be done in a similar fashion
+   as the ``languages`` configuration for pygeoapi itself, as described in the `maintainer guide`_ section above.
+   For example, a provider that supports English and French could be set up like:
+
+   .. code-block:: yaml
+
+      canada-metadata:
+          type: collection
+          ..
+          providers:
+              - type: record
+                name: TinyDBCatalogue
+                data: ..
+                languages:
+                    - en
+                    - fr
+
+2. Your plugin must implement a plugin base class (e.g. ``BaseProvider``, ``BaseFormatter``, etc.).
+   The base class will handle the incoming language request and set a ``locale`` instance attribute.
+
+3. Besides the plugin definition, you will also have to pass an optional ``requested_locale`` argument to the
+   ``__init__`` function.
+
+4. The ``requested_locale`` argument mentioned above should be passed on to the base plugin in the ``super()`` call.
+
+An example Python code block for a custom provider should start similar to this:
+
+.. code-block:: python
+
+   class MyCustomProvider(BaseProvider):
+   """Custom Provider"""
+
+   def __init__(self, provider_def, requested_locale=None):
+       super().__init__(provider_def, requested_locale)
+
+The base class will make sure that the requested locale is available throughout the entire instance and can be obtained in
+each plugin method by the ``self.locale`` attribute. Within these methods, your code should decide what needs to be done with
+this locale and return results in the proper language. The pygeoapi API module will make sure that the correct HTTP ``Content-Language``
+headers are set on the response object.
+
+Notes
+^^^^^
+
+- **Steps 3 and 4 above apply to all plugin classes, even if your plugin does not provide language support.**
+
+- Contrary to the pygeoapi server configuration, adding a ``language`` or ``languages`` (both are supported) property to the
+  plugin definition is **not** required and may be omitted. In that case, the ``self.locale`` attribute of the plugin will be set to ``None``.
+  This results in the following behavior:
+
+  - HTML responses returned from **providers** will have the ``Content-Language`` header set to the best-matching pygeoapi server language.
+  - JSON(-LD) responses returned from providers will **not** have a ``Content-Language`` header if ``self.locale`` is ``None``.
+
+- If the plugin does provide language support, ``self.locale`` will be set to the best matching
+  `Babel Locale instance <http://babel.pocoo.org/en/latest/api/core.html#babel.core.Locale>`_.
+  Note that this may be the plugin default language if no proper match was found.
+  No matter the output format, **providers** will always return responses with a best-matching ``Content-Language`` header
+  if one ore more supported plugin languages were defined.
+
+- For general information about building plugins, please visit the :ref:`plugins` page.

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -55,10 +55,10 @@ The below template provides a minimal example (let's call the file ``mycoolvecto
    class MyCoolVectorDataProvider(BaseProvider):
        """My cool vector data provider"""
 
-       def __init__(self, provider_def):
+       def __init__(self, provider_def, requested_locale=None):
            """Inherit from parent class"""
 
-           super().__init__(provider_def)
+           super().__init__(provider_def, requested_locale)
 
        def get_fields(self):
 
@@ -97,6 +97,9 @@ as well as implement the ``get`` method accordingly.  As long as the plugin impl
 its base provider, all other functionality is left to the provider implementation.
 
 Each base class documents the functions, arguments and return types required for implementation.
+
+.. note::   You can add language support to your plugin using :ref:`these guides<language>`.
+
 
 Connecting to pygeoapi
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -34,7 +34,10 @@ server:
     url: http://localhost:5000
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
-    language: en-US
+    languages:
+        # First language is the default language
+        - en-US
+        - fr-CA
     # cors: true
     pretty_print: true
     limit: 10
@@ -56,12 +59,21 @@ logging:
 
 metadata:
     identification:
-        title: pygeoapi default instance
-        description: pygeoapi provides an API to geospatial data
+        title:
+            en: pygeoapi default instance
+            fr: instance par défaut de pygeoapi
+        description:
+            en: pygeoapi provides an API to geospatial data
+            fr: pygeoapi fournit une API aux données géospatiales
         keywords:
-            - geospatial
-            - data
-            - api
+            en:
+                - geospatial
+                - data
+                - api
+            fr:
+                - géospatiale
+                - données
+                - api
         keywords_type: theme
         terms_of_service: https://creativecommons.org/licenses/by/4.0/
         url: http://example.org
@@ -129,10 +141,19 @@ resources:
 
     lakes:
         type: collection
-        title: Large Lakes
-        description: lakes of the world, public domain
+        title:
+            en: Large Lakes
+            fr: Grands Lacs
+        description:
+            en: lakes of the world, public domain
+            fr: lacs du monde, domaine public
         keywords:
-            - lakes
+            en:
+                - lakes
+                - water bodies
+            fr:
+                - lacs
+                - plans d'eau
         links:
             - type: text/html
               rel: canonical
@@ -237,17 +258,32 @@ resources:
 
     canada-metadata:
         type: collection
-        title: Sample metadata records from open.canada.ca
-        description: Sample metadata records from open.canada.ca
+        title:
+            en: Open Canada sample data
+            fr: Exemple de donn\u00e9es Canada Ouvert
+        description:
+            en: Sample metadata records from open.canada.ca
+            fr: Exemples d'enregistrements de m\u00e9tadonn\u00e9es sur ouvert.canada.ca
         keywords:
-            - canada
-            - open data
+            en:
+                - canada
+                - open data
+            fr:
+                - canada
+                - donn\u00e9es ouvertes
         links:
-            - type: text/html
-              rel: canonical
-              title: information
-              href: https://open.canada.ca/en/open-data
-              hreflang: en-CA
+            en:
+                - type: text/html
+                  rel: canonical
+                  title: information
+                  href: https://open.canada.ca/en/open-data
+                  hreflang: en-CA
+            fr:
+                - type: text/html
+                  rel: canonical
+                  title: informations
+                  href: https://ouvert.canada.ca/fr/donnees-ouvertes
+                  hreflang: fr-CA
         extents:
             spatial:
                 bbox: [-180,-90,180,90]

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -459,11 +459,8 @@ class API:
                                         'type', 'stac-collection'):
                 fcm['stac'] = True
 
-            fcm['keywords'] = l10n.translate(
-                self.config['metadata']['identification']['keywords'],
-                request.locale)
-
-            content = render_j2_template(self.config, 'landing_page.html', fcm)
+            content = render_j2_template(self.config, 'landing_page.html', fcm,
+                                         request.locale)
             return headers, 200, content
 
         if request.format == 'jsonld':
@@ -492,7 +489,8 @@ class API:
             data = {
                 'openapi-document-path': path
             }
-            content = render_j2_template(self.config, 'openapi.html', data)
+            content = render_j2_template(self.config, 'openapi.html', data,
+                                         request.locale)
             return headers, 200, content
 
         headers['Content-Type'] = 'application/vnd.oai.openapi+json;version=3.0'  # noqa
@@ -522,7 +520,7 @@ class API:
         headers = request.get_response_headers()
         if request.format == 'html':  # render
             content = render_j2_template(self.config, 'conformance.html',
-                                         conformance)
+                                         conformance, request.locale)
             return headers, 200, content
 
         return headers, 200, to_json(conformance, self.pretty_print)
@@ -845,10 +843,11 @@ class API:
             if dataset is not None:
                 content = render_j2_template(self.config,
                                              'collections/collection.html',
-                                             fcm)
+                                             fcm, request.locale)
             else:
                 content = render_j2_template(self.config,
-                                             'collections/index.html', fcm)
+                                             'collections/index.html', fcm,
+                                             request.locale)
 
             return headers, 200, content
 
@@ -939,7 +938,7 @@ class API:
                 self.config['resources'][dataset]['title'], request.locale)
             content = render_j2_template(self.config,
                                          'collections/queryables.html',
-                                         queryables)
+                                         queryables, request.locale)
 
             return headers, 200, content
 
@@ -1244,7 +1243,7 @@ class API:
 
             content = render_j2_template(self.config,
                                          'collections/items/index.html',
-                                         content)
+                                         content, request.locale)
             return headers, 200, content
         elif request.format == 'csv':  # render
             formatter = load_plugin('formatter',
@@ -1393,7 +1392,7 @@ class API:
 
             content = render_j2_template(self.config,
                                          'collections/items/item.html',
-                                         content)
+                                         content, request.locale)
             return headers, 200, content
 
         elif request.format == 'jsonld':
@@ -1586,7 +1585,7 @@ class API:
                 self.config['resources'][dataset]['title'], request.locale)
             content = render_j2_template(self.config,
                                          'collections/coverage/domainset.html',
-                                         data)
+                                         data, request.locale)
             return headers, 200, content
         else:
             return self.get_format_exception(request)
@@ -1635,7 +1634,7 @@ class API:
                 self.config['resources'][dataset]['title'], request.locale)
             content = render_j2_template(self.config,
                                          'collections/coverage/rangetype.html',
-                                         data)
+                                         data, request.locale)
             return headers, 200, content
         else:
             return self.get_format_exception(request)
@@ -1736,7 +1735,8 @@ class API:
             tiles['maxzoom'] = p.options['zoom']['max']
 
             content = render_j2_template(self.config,
-                                         'collections/tiles/index.html', tiles)
+                                         'collections/tiles/index.html', tiles,
+                                         request.locale)
 
             return headers, 200, content
 
@@ -1891,7 +1891,7 @@ class API:
 
             content = render_j2_template(self.config,
                                          'collections/tiles/metadata.html',
-                                         metadata)
+                                         metadata, request.locale)
 
             return headers, 200, content
 
@@ -1981,10 +1981,11 @@ class API:
             if process is not None:
                 response = render_j2_template(self.config,
                                               'processes/process.html',
-                                              response)
+                                              response, request.locale)
             else:
                 response = render_j2_template(self.config,
-                                              'processes/index.html', response)
+                                              'processes/index.html', response,
+                                              request.locale)
 
             return headers, 200, response
 
@@ -2086,7 +2087,8 @@ class API:
                 'jobs': serialized_jobs,
                 'now': datetime.now(timezone.utc).strftime(DATETIME_FORMAT)
             }
-            response = render_j2_template(self.config, j2_template, data)
+            response = render_j2_template(self.config, j2_template, data,
+                                          request.locale)
             return headers, 200, response
 
         return headers, 200, to_json(serialized_jobs, self.pretty_print)
@@ -2284,8 +2286,9 @@ class API:
                     'job': {'id': job_id},
                     'result': job_output
                 }
-                content = render_j2_template(
-                    self.config, 'processes/jobs/results/index.html', data)
+                content = render_j2_template(self.config,
+                                             'processes/jobs/results/index.html',  # noqa
+                                             data, request.locale)
 
         return headers, 200, content
 
@@ -2444,8 +2447,9 @@ class API:
             headers['Content-Language'] = p.locale
 
         if request.format == 'html':  # render
-            content = render_j2_template(
-                self.config, 'collections/edr/query.html', data)
+            content = render_j2_template(self.config,
+                                         'collections/edr/query.html', data,
+                                         request.locale)
         else:
             content = to_json(data, self.pretty_print)
 
@@ -2501,7 +2505,7 @@ class API:
 
         if request.format == 'html':  # render
             content = render_j2_template(self.config, 'stac/collection.html',
-                                         content)
+                                         content, request.locale)
             return headers, 200, content
 
         return headers, 200, to_json(content, self.pretty_print)
@@ -2578,11 +2582,11 @@ class API:
                 if 'assets' in content:  # item view
                     content = render_j2_template(self.config,
                                                  'stac/item.html',
-                                                 content)
+                                                 content, request.locale)
                 else:
                     content = render_j2_template(self.config,
                                                  'stac/catalog.html',
-                                                 content)
+                                                 content, request.locale)
 
                 return headers, 200, content
 
@@ -2614,7 +2618,7 @@ class API:
         if format_ == 'html':
             headers['Content-Type'] = 'text/html'
             content = render_j2_template(
-                self.config, 'exception.html', exception)
+                self.config, 'exception.html', exception, self.default_locale)
         else:
             content = to_json(exception, self.pretty_print)
 

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -150,9 +150,8 @@ class APIRequest:
         self._path_info = request.headers.environ['PATH_INFO'].strip('/')
 
         # Extract locale from params or headers
-        # _l_param stores a boolean -> True if language was found in query str
-        self._raw_locale, self._locale, self._l_param = \
-            self._get_locale(request.headers, supported_locales)
+        self._raw_locale, self._locale = self._get_locale(request.headers,
+                                                          supported_locales)
 
         # Determine format
         self._format = self._get_format(request.headers)
@@ -174,18 +173,18 @@ class APIRequest:
         return {}
 
     def _get_locale(self, headers, supported_locales):
-        """ Detects locale from "l=<language>" or Accept-Language header.
-        Returns a tuple of (raw, locale, True) if found in the query params.
-        Returns a tuple of (raw, locale, False) if found in headers.
-        Returns a tuple of (raw, default locale, False) if not found.
+        """ Detects locale from "l=<language>" param or Accept-Language header.
+        Returns a tuple of (raw, locale) if found in params or headers.
+        Returns a tuple of (raw default, default locale) if not found.
 
         :param headers:             A dict with Request headers
         :param supported_locales:   List or set of supported Locale instances
-        :returns:                   A tuple of (Locale, bool)
+        :returns:                   A tuple of (str, Locale)
         """
         raw = None
         try:
             default_locale = l10n.str2locale(supported_locales[0])
+            default_str = l10n.locale2str(default_locale)
         except (TypeError, IndexError, l10n.LocaleError) as err:
             # This should normally not happen, since the API class already
             # loads the supported languages from the config, which raises
@@ -203,11 +202,11 @@ class APIRequest:
                     raw = loc_str
                 # Check of locale string is a good match for the UI
                 loc = l10n.best_match(loc_str, supported_locales)
-                precedence = func is l10n.locale_from_params
-                if loc != default_locale or precedence:
-                    return raw, loc, precedence
+                is_override = func is l10n.locale_from_params
+                if loc != default_locale or is_override:
+                    return raw, loc
 
-        return raw or supported_locales[0], default_locale, False
+        return raw or default_str, default_locale
 
     def _get_format(self, headers) -> Union[str, None]:
         """
@@ -782,7 +781,7 @@ class API:
                 try:
                     p = load_plugin('provider', get_provider_by_type(
                         self.config['resources'][dataset]['providers'],
-                        'edr'))
+                        'edr'), request.raw_locale)
                     parameters = p.get_fields()
                     if parameters:
                         collection['parameters'] = {}
@@ -2327,116 +2326,102 @@ class API:
         LOGGER.info(response)
         return {}, http_status, response
 
-    def get_collection_edr_query(self, headers, args, dataset, instance,
-                                 query_type):
+    @pre_process
+    def get_collection_edr_query(self, request: Union[APIRequest, Any],
+                                 dataset, instance, query_type):
         """
         Queries collection EDR
-        :param headers: dict of HTTP headers
-        :param args: dict of HTTP request parameters
+        :param request: APIRequest instance with query params
         :param dataset: dataset name
-        :param dataset: instance name
+        :param instance: instance name
         :param query_type: EDR query type
         :returns: tuple of headers, status code, content
         """
 
-        headers_ = HEADERS.copy()
-
-        query_args = {}
-        formats = FORMATS
-        formats.extend(f.lower() for f in PLUGINS['formatter'].keys())
+        if not request.is_valid(PLUGINS['formatter'].keys()):
+            return self.get_format_exception(request)
+        headers = request.get_response_headers()
 
         collections = filter_dict_by_key_value(self.config['resources'],
                                                'type', 'collection')
 
-        format_ = check_format(args, headers)
-
         if dataset not in collections.keys():
             msg = 'Invalid collection'
             return self.get_exception(
-                400, headers_, format_, 'InvalidParameterValue', msg)
-
-        if format_ is not None and format_ not in formats:
-            msg = 'Invalid format'
-            return self.get_exception(
-                400, headers_, format_, 'InvalidParameterValue', msg)
+                400, headers, request.format, 'InvalidParameterValue', msg)
 
         LOGGER.debug('Processing query parameters')
 
         LOGGER.debug('Processing datetime parameter')
-        datetime_ = args.get('datetime')
+        datetime_ = request.params.get('datetime')
         try:
             datetime_ = validate_datetime(collections[dataset]['extents'],
                                           datetime_)
         except ValueError as err:
             msg = str(err)
             return self.get_exception(
-                400, headers_, format_, 'InvalidParameterValue', msg)
+                400, headers, request.format, 'InvalidParameterValue', msg)
 
         LOGGER.debug('Processing parameter-name parameter')
-        parameternames = args.get('parameter-name', [])
-        if parameternames:
+        parameternames = request.params.get('parameter-name') or []
+        if isinstance(parameternames, str):
             parameternames = parameternames.split(',')
 
         LOGGER.debug('Processing coords parameter')
-        wkt = args.get('coords', None)
+        wkt = request.params.get('coords', None)
 
-        if wkt is None:
+        if not wkt:
             msg = 'missing coords parameter'
             return self.get_exception(
-                400, headers_, format_, 'InvalidParameterValue', msg)
+                400, headers, request.format, 'InvalidParameterValue', msg)
 
         try:
             wkt = shapely_loads(wkt)
         except WKTReadingError:
             msg = 'invalid coords parameter'
             return self.get_exception(
-                400, headers_, format_, 'InvalidParameterValue', msg)
+                400, headers, request.format, 'InvalidParameterValue', msg)
 
         LOGGER.debug('Processing z parameter')
-        z = args.get('z')
+        z = request.params.get('z')
 
         LOGGER.debug('Loading provider')
         try:
             p = load_plugin('provider', get_provider_by_type(
-                collections[dataset]['providers'], 'edr'))
+                collections[dataset]['providers'], 'edr'), request.raw_locale)
         except ProviderTypeError:
             msg = 'invalid provider type'
             return self.get_exception(
-                500, headers_, format_, 'NoApplicableCode', msg)
+                500, headers, request.format, 'NoApplicableCode', msg)
         except ProviderConnectionError:
             msg = 'connection error (check logs)'
             return self.get_exception(
-                500, headers_, format_, 'NoApplicableCode', msg)
+                500, headers, request.format, 'NoApplicableCode', msg)
         except ProviderQueryError:
             msg = 'query error (check logs)'
             return self.get_exception(
-                500, headers_, format_, 'NoApplicableCode', msg)
+                500, headers, request.format, 'NoApplicableCode', msg)
 
         if instance is not None and not p.get_instance(instance):
             msg = 'Invalid instance identifier'
             return self.get_exception(
-                400, headers_, format_, 'InvalidParameterValue', msg)
+                400, headers, request.format, 'InvalidParameterValue', msg)
 
         if query_type not in p.get_query_types():
             msg = 'Unsupported query type'
             return self.get_exception(
-                400, headers_, format_, 'InvalidParameterValue', msg)
+                400, headers, request.format, 'InvalidParameterValue', msg)
 
-        parametername_matches = list(
-            filter(
-                lambda p: p['id'] in parameternames, p.get_fields()['field']
-            )
-        )
-
-        if len(parametername_matches) < len(parameternames):
+        if parameternames and not any((fld['id'] in parameternames)
+                                      for fld in p.get_fields()['field']):
             msg = 'Invalid parameter-name'
             return self.get_exception(
-                400, headers_, format_, 'InvalidParameterValue', msg)
+                400, headers, request.format, 'InvalidParameterValue', msg)
 
         query_args = dict(
             query_type=query_type,
             instance=instance,
-            format_=format_,
+            format_=request.format,
             datetime_=datetime_,
             select_properties=parameternames,
             wkt=wkt,
@@ -2448,20 +2433,23 @@ class API:
         except ProviderNoDataError:
             msg = 'No data found'
             return self.get_exception(
-                204, headers_, format_, 'NoMatch', msg)
+                204, headers, request.format, 'NoMatch', msg)
         except ProviderQueryError:
             msg = 'query error (check logs)'
             return self.get_exception(
-                500, headers_, format_, 'NoApplicableCode', msg)
+                500, headers, request.format, 'NoApplicableCode', msg)
 
-        if format_ == 'html':  # render
-            headers_['Content-Type'] = 'text/html'
+        if p.locale:
+            # If provider supports locales, override/set response locale
+            headers['Content-Language'] = p.locale
+
+        if request.format == 'html':  # render
             content = render_j2_template(
                 self.config, 'collections/edr/query.html', data)
         else:
             content = to_json(data, self.pretty_print)
 
-        return headers_, 200, content
+        return headers, 200, content
 
     @pre_process
     @jsonldify

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -96,6 +96,20 @@ if (OGC_SCHEMAS_LOCATION is not None and
                                    mimetype=get_mimetype(basename_))
 
 
+def get_response(result: tuple):
+    """ Creates a Flask Response object and updates matching headers.
+
+    :param result:  The result of the API call.
+                    This should be a tuple of (headers, status, content).
+    :returns:       A Response instance.
+    """
+    headers, status, content = result
+    response = make_response(content, status)
+    if headers:
+        response.headers = headers
+    return response
+
+
 @BLUEPRINT.route('/')
 def landing_page():
     """
@@ -103,15 +117,7 @@ def landing_page():
 
     :returns: HTTP response
     """
-    headers, status_code, content = api_.landing_page(
-        request.headers, request.args)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.landing_page(request))
 
 
 @BLUEPRINT.route('/openapi')
@@ -121,22 +127,13 @@ def openapi():
 
     :returns: HTTP response
     """
-
     with open(os.environ.get('PYGEOAPI_OPENAPI'), encoding='utf8') as ff:
         if os.environ.get('PYGEOAPI_OPENAPI').endswith(('.yaml', '.yml')):
-            openapi = yaml_load(ff)
+            openapi_ = yaml_load(ff)
         else:  # JSON file, do not transform
-            openapi = ff
+            openapi_ = ff
 
-        headers, status_code, content = api_.openapi(
-            request.headers, request.args, openapi)
-
-        response = make_response(content, status_code)
-
-        if headers:
-            response.headers = headers
-
-        return response
+    return get_response(api_.openapi(request, openapi_))
 
 
 @BLUEPRINT.route('/conformance')
@@ -146,16 +143,7 @@ def conformance():
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.conformance(request.headers,
-                                                     request.args)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.conformance(request))
 
 
 @BLUEPRINT.route('/collections')
@@ -168,16 +156,7 @@ def collections(collection_id=None):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.describe_collections(
-        request.headers, request.args, collection_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.describe_collections(request, collection_id))
 
 
 @BLUEPRINT.route('/collections/<collection_id>/queryables')
@@ -189,16 +168,7 @@ def collection_queryables(collection_id=None):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_collection_queryables(
-        request.headers, request.args, collection_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_collection_queryables(request, collection_id))
 
 
 @BLUEPRINT.route('/collections/<collection_id>/items')
@@ -212,20 +182,10 @@ def collection_items(collection_id, item_id=None):
 
     :returns: HTTP response
     """
-
     if item_id is None:
-        headers, status_code, content = api_.get_collection_items(
-            request.headers, request.args, collection_id)
-    else:
-        headers, status_code, content = api_.get_collection_item(
-            request.headers, request.args, collection_id, item_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+        return get_response(api_.get_collection_items(request, collection_id))
+    return get_response(
+        api_.get_collection_item(request, collection_id, item_id))
 
 
 @BLUEPRINT.route('/collections/<collection_id>/coverage')
@@ -237,16 +197,7 @@ def collection_coverage(collection_id):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_collection_coverage(
-        request.headers, request.args, collection_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_collection_coverage(request, collection_id))
 
 
 @BLUEPRINT.route('/collections/<collection_id>/coverage/domainset')
@@ -258,16 +209,8 @@ def collection_coverage_domainset(collection_id):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_collection_coverage_domainset(
-        request.headers, request.args, collection_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_collection_coverage_domainset(
+        request, collection_id))
 
 
 @BLUEPRINT.route('/collections/<collection_id>/coverage/rangetype')
@@ -279,16 +222,8 @@ def collection_coverage_rangetype(collection_id):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_collection_coverage_rangetype(
-        request.headers, request.args, collection_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_collection_coverage_rangetype(
+        request, collection_id))
 
 
 @BLUEPRINT.route('/collections/<collection_id>/tiles')
@@ -300,16 +235,8 @@ def get_collection_tiles(collection_id=None):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_collection_tiles(
-        request.headers, request.args, collection_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_collection_tiles(
+        request, collection_id))
 
 
 @BLUEPRINT.route('/collections/<collection_id>/tiles/<tileMatrixSetId>/metadata')  # noqa
@@ -322,16 +249,8 @@ def get_collection_tiles_metadata(collection_id=None, tileMatrixSetId=None):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_collection_tiles_metadata(
-        request.headers, request.args, collection_id, tileMatrixSetId)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_collection_tiles_metadata(
+        request, collection_id, tileMatrixSetId))
 
 
 @BLUEPRINT.route('/collections/<collection_id>/tiles/\
@@ -349,17 +268,8 @@ def get_collection_tiles_data(collection_id=None, tileMatrixSetId=None,
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_collection_tiles_data(
-        request.headers, request.args, collection_id,
-        tileMatrixSetId, tileMatrix, tileRow, tileCol)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_collection_tiles_data(
+        request, collection_id, tileMatrixSetId, tileMatrix, tileRow, tileCol))
 
 
 @BLUEPRINT.route('/processes')
@@ -372,15 +282,7 @@ def get_processes(process_id=None):
 
     :returns: HTTP response
     """
-    headers, status_code, content = api_.describe_processes(
-        request.headers, request.args, process_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.describe_processes(request, process_id))
 
 
 @BLUEPRINT.route('/processes/<process_id>/jobs', methods=['GET', 'POST'])
@@ -395,28 +297,17 @@ def get_process_jobs(process_id=None, job_id=None):
 
     :returns: HTTP response
     """
-
     if job_id is None:
         if request.method == 'GET':  # list jobs
-            headers, status_code, content = api_.get_process_jobs(
-                request.headers, request.args, process_id)
+            return get_response(api_.get_process_jobs(request, process_id))
         elif request.method == 'POST':  # submit job
-            headers, status_code, content = api_.execute_process(
-                request.headers, request.args, request.data, process_id)
+            return get_response(api_.execute_process(request, process_id))
     else:
         if request.method == 'DELETE':  # dismiss job
-            headers, status_code, content = api_.delete_process_job(
-                process_id, job_id)
+            return get_response(api_.delete_process_job(process_id, job_id))
         else:  # Return status of a specific job
-            headers, status_code, content = api_.get_process_jobs(
-                request.headers, request.args, process_id, job_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+            return get_response(api_.get_process_jobs(
+                request, process_id, job_id))
 
 
 @APP.route('/processes/<process_id>/jobs/<job_id>/results', methods=['GET'])
@@ -429,16 +320,8 @@ def get_process_job_result(process_id=None, job_id=None):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_process_job_result(
-        request.headers, request.args, process_id, job_id)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_process_job_result(
+        request, process_id, job_id))
 
 
 @APP.route('/processes/<process_id>/jobs/<job_id>/results/<resource>',
@@ -453,16 +336,8 @@ def get_process_job_result_resource(process_id, job_id, resource):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_process_job_result_resource(
-        request.headers, request.args, process_id, job_id, resource)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_process_job_result_resource(
+        request, process_id, job_id, resource))
 
 
 @BLUEPRINT.route('/collections/<collection_id>/position')
@@ -505,16 +380,7 @@ def stac_catalog_root():
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_stac_root(
-        request.headers, request.args)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_stac_root(request))
 
 
 @BLUEPRINT.route('/stac/<path:path>')
@@ -526,16 +392,7 @@ def stac_catalog_path(path):
 
     :returns: HTTP response
     """
-
-    headers, status_code, content = api_.get_stac_path(
-        request.headers, request.args, path)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_stac_path(request, path))
 
 
 APP.register_blueprint(BLUEPRINT)

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -359,18 +359,9 @@ def get_collection_edr_query(collection_id, instance_id=None):
 
     :returns: HTTP response
     """
-
     query_type = request.path.split('/')[-1]
-
-    headers, status_code, content = api_.get_collection_edr_query(
-        request.headers, request.args, collection_id, instance_id, query_type)
-
-    response = make_response(content, status_code)
-
-    if headers:
-        response.headers = headers
-
-    return response
+    return get_response(api_.get_collection_edr_query(request, collection_id,
+                                                      instance_id, query_type))
 
 
 @BLUEPRINT.route('/stac')

--- a/pygeoapi/formatter/base.py
+++ b/pygeoapi/formatter/base.py
@@ -35,7 +35,7 @@ LOGGER = logging.getLogger(__name__)
 class BaseFormatter:
     """generic Formatter ABC"""
 
-    def __init__(self, formatter_def):
+    def __init__(self, formatter_def, **kwargs):
         """
         Initialize object
 

--- a/pygeoapi/formatter/base.py
+++ b/pygeoapi/formatter/base.py
@@ -28,6 +28,7 @@
 # =================================================================
 
 import logging
+from pygeoapi import l10n
 
 LOGGER = logging.getLogger(__name__)
 
@@ -35,11 +36,12 @@ LOGGER = logging.getLogger(__name__)
 class BaseFormatter:
     """generic Formatter ABC"""
 
-    def __init__(self, formatter_def, **kwargs):
+    def __init__(self, formatter_def, requested_locale: str = None):
         """
         Initialize object
 
-        :param formatter_def: formatter definition
+        :param formatter_def:       formatter definition
+        :param requested_locale:    requested formatter locale
 
         :returns: pygeoapi.formatter.base.BaseFormatter
         """
@@ -50,6 +52,9 @@ class BaseFormatter:
         self.name = formatter_def['name']
         if 'geom' in formatter_def:
             self.geom = formatter_def['geom']
+
+        # locale support
+        self.locale = l10n.get_plugin_locale(formatter_def, requested_locale)
 
     def write(self, options={}, data=None):
         """

--- a/pygeoapi/formatter/csv_.py
+++ b/pygeoapi/formatter/csv_.py
@@ -40,7 +40,7 @@ LOGGER = logging.getLogger(__name__)
 class CSVFormatter(BaseFormatter):
     """CSV formatter"""
 
-    def __init__(self, formatter_def):
+    def __init__(self, formatter_def, **kwargs):
         """
         Initialize object
 
@@ -53,7 +53,7 @@ class CSVFormatter(BaseFormatter):
         if 'geom' in formatter_def:
             geom = formatter_def['geom']
 
-        super().__init__({'name': 'csv', 'geom': geom})
+        super().__init__({'name': 'csv', 'geom': geom}, **kwargs)
         self.mimetype = 'text/csv'
 
     def write(self, options={}, data=None):

--- a/pygeoapi/formatter/csv_.py
+++ b/pygeoapi/formatter/csv_.py
@@ -40,7 +40,7 @@ LOGGER = logging.getLogger(__name__)
 class CSVFormatter(BaseFormatter):
     """CSV formatter"""
 
-    def __init__(self, formatter_def, **kwargs):
+    def __init__(self, formatter_def, requested_locale=None):
         """
         Initialize object
 
@@ -53,7 +53,7 @@ class CSVFormatter(BaseFormatter):
         if 'geom' in formatter_def:
             geom = formatter_def['geom']
 
-        super().__init__({'name': 'csv', 'geom': geom}, **kwargs)
+        super().__init__({'name': 'csv', 'geom': geom}, requested_locale)
         self.mimetype = 'text/csv'
 
     def write(self, options={}, data=None):

--- a/pygeoapi/l10n.py
+++ b/pygeoapi/l10n.py
@@ -1,0 +1,251 @@
+# =================================================================
+#
+# Authors: Sander Schaminee <sander.schaminee@geocat.net>
+#
+# Copyright (c) 2021 GeoCat BV
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+import logging
+from typing import Union
+from collections import OrderedDict
+
+from babel import Locale
+from babel import UnknownLocaleError as _UnknownLocaleError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class LocaleError(Exception):
+    """ General exception for any kind of locale parsing error. """
+    pass
+
+
+def str2locale(value, silent: bool = False) -> Union[Locale, None]:
+    """ Converts a web locale or language tag into a Babel Locale instance.
+
+    .. note::   If `value` already is a Locale, it is returned as-is.
+
+    :param value:   A string containing a (web) locale (e.g. 'fr-CH')
+                    or language tag (e.g. 'de').
+    :param silent:  If True (default = False), no errors will be raised
+                    when parsing failed. Instead, `None` will be returned.
+    :returns:       babel.core.Locale or None
+    :raises:        LocaleError
+    """
+    if isinstance(value, Locale):
+        return value
+    try:
+        return Locale.parse(value.strip().replace('-', '_'))
+    except (ValueError, AttributeError):
+        if not silent:
+            raise LocaleError(f"invalid locale '{value}'")
+    except _UnknownLocaleError as err:
+        if not silent:
+            raise LocaleError(err)
+    return None
+
+
+def locale2str(value: Locale) -> str:
+    """ Converts a Babel Locale instance into a web locale string.
+
+    :param value:   babel.core.Locale
+    :returns:       A string containing a web locale (e.g. 'fr-CH')
+                    or language tag (e.g. 'de').
+    :raises:        LocaleError
+    """
+    if not isinstance(value, Locale):
+        raise LocaleError(f"'{value}' is not of type {Locale.__name__}")
+    return str(value).replace('_', '-')
+
+
+def best_match(accept_languages, available_locales) -> Locale:
+    """ Takes an Accept-Languages string (from header or request query params)
+    and finds the best matching locale from a list of available locales.
+
+    This function provides a framework-independent alternative to the
+    `best_match()` function available in Flask/Werkzeug.
+
+    If no match can be found for the Accept-Languages,
+    the first available locale is returned.
+
+    This function always returns a Babel Locale instance. If you require the
+    web locale string, please use the :func:`locale2str` function.
+    If you only ever need the language part of the locale, use the `language`
+    property of the returned locale.
+
+    .. note::   Any tag in the `accept_languages` string that is an invalid
+                or unknown locale is ignored. However, if no
+                `available_locales` are specified, a `LocaleError` is raised.
+
+    :param accept_languages:    A Locale or string with one or more languages.
+                                This can be as simple as "de" for example,
+                                but it's also possible to include a territory
+                                (e.g. "en-US" or "fr_BE") or even a complex
+                                string with quality values, e.g.
+                                "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5".
+    :param available_locales:   A list containing the available locales.
+                                For example, a pygeoapi provider might only
+                                support ["de", "en"].
+                                Locales in the list can be specified as strings
+                                (e.g. "nl-NL") or `Locale` instances.
+    :returns:                   babel.core.Locale
+    :raises:                    LocaleError
+    """
+
+    def get_match(locale_, available_locales_):
+        """ Finds the first match of `locale` in `available_locales_`. """
+        if not locale_:
+            return None
+        territories_ = available_locales_.get(locale_.language, {})
+        if locale_.territory in territories_:
+            # Full match on language and territory
+            return locale_
+        if None in territories_:
+            # Match on language only (generic, no territory)
+            return Locale(locale_.language)
+        if territories_:
+            # Match on language but another territory (use first)
+            return Locale(locale_.language, territory=territories_[0])
+        # No match at all
+        return None
+
+    if not available_locales:
+        raise LocaleError('No available locales specified')
+
+    if isinstance(accept_languages, Locale):
+        # If a Babel Locale was used as input, transform back into a string
+        accept_languages = locale2str(accept_languages)
+    if not isinstance(accept_languages, str):
+        # If `accept_languages` is not a string, ignore it
+        LOGGER.debug(f"ignoring invalid accept-languages '{accept_languages}'")
+        accept_languages = ''
+
+    tags = accept_languages.split(',')
+    num_tags = len(tags)
+    req_locales = {}
+    for i, lang in enumerate(tags):
+        q_raw = None
+        q_out = None
+        if not lang:
+            continue
+
+        # Check if complex (i.e. with quality weights)
+        try:
+            lang, q_raw = (v.strip() for v in lang.split(';'))
+        except ValueError:
+            # Tuple unpacking failed: tag is not complex (or too complex :))
+            pass
+
+        # Validate locale tag
+        loc = str2locale(lang, True)
+        if not loc:
+            LOGGER.debug(f"ignoring invalid accept-language '{lang}'")
+            continue
+
+        # Validate quality weight (e.g. "q=0.7")
+        if q_raw:
+            try:
+                q_out = float([v.strip() for v in q_raw.split('=')][1])
+            except (ValueError, IndexError):
+                # Tuple unpacking failed: not a valid q tag
+                pass
+
+        # If there's no actual q, set one based on the language order
+        if not q_out:
+            q_out = num_tags - i
+
+        # Store locale
+        req_locales[q_out] = loc
+
+    # Process supported locales
+    prv_locales = OrderedDict()
+    for a in available_locales:
+        loc = str2locale(a)
+        prv_locales.setdefault(loc.language, []).append(loc.territory)
+
+    # Return best match from accepted languages
+    for _, loc in sorted(req_locales.items(), reverse=True):
+        match = get_match(loc, prv_locales)
+        if match:
+            LOGGER.debug(f"'{match}' matches requested '{accept_languages}'")
+            return match
+
+    # Nothing matched: return the first available locale
+    for lang, territories in prv_locales.items():
+        match = Locale(lang, territory=territories[0])
+        LOGGER.debug(f"no match for requested '{accept_languages}'; "
+                     f"using first available language '{match}'")
+        return match
+
+
+def translate(value, language):
+    """
+    If `value` is a language struct (where its keys are language codes
+    and its values are translations for each language), this function tries to
+    find and return the translation for the given `language`.
+
+    If the given `value` is not a dict, the original value is returned.
+    If the requested language does not exist in the struct,
+    the first language value is returned. If there are no valid language keys
+    in the struct, the original value is returned as well.
+
+    If `language` is not a string or Locale, a LocaleError is raised.
+
+    :param value:       A value to translate. Typically either a string or
+                        a language struct dictionary.
+    :param language:    A locale string (e.g. "en-US" or "en") or Babel Locale.
+    :returns:           A translated string or the original value.
+    :raises:            LocaleError
+    """
+    if not isinstance(value, dict):
+        # Perhaps use a translation service for strings at a later stage?
+        # For now just return the value as-is
+        return value
+
+    # Validate language key by type (do not check if parsable)
+    if not isinstance(language, (str, Locale)):
+        raise LocaleError('language is not a str or Locale')
+
+    # First try fast approach: directly fetch expected language key
+    translation = value.get(locale2str(language)
+                            if hasattr(language, 'language') else language)
+    if translation:
+        return translation
+
+    # Find valid locale keys in language struct
+    # Also maps Locale instances to actual key names
+    loc_items = OrderedDict()
+    for k in value.keys():
+        loc = str2locale(k, True)
+        if loc:
+            loc_items[loc] = k
+
+    if not loc_items:
+        # No valid locale keys found: return as-is
+        return value
+
+    # Find best language match and return value by its key
+    out_locale = best_match(language, loc_items)
+    return value[loc_items[out_locale]]

--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -50,11 +50,12 @@ def jsonldify(func):
     """
 
     def inner(*args, **kwargs):
-        format_ = args[2]
+        apireq = args[1]
+        format_ = getattr(apireq, 'format', None)
         if not format_ == 'jsonld':
             return func(*args, **kwargs)
-        # Function args have been pre-processed, so get language from kwargs
-        locale_ = kwargs.get('language')
+        # Function args have been pre-processed, so get locale from APIRequest
+        locale_ = getattr(apireq, 'locale', None)
         LOGGER.debug('Creating JSON-LD representation')
         cls = args[0]
         cfg = cls.config
@@ -70,7 +71,8 @@ def jsonldify(func):
           "name": l10n.translate(ident.get('title', None), locale_),
           "description": l10n.translate(
               ident.get('description', None), locale_),
-          "keywords": ident.get('keywords', None),
+          "keywords": l10n.translate(
+              ident.get('keywords', None), locale_),
           "termsOfService": l10n.translate(
               ident.get('terms_of_service', None), locale_),
           "license": meta.get('license', {}).get('url', None),
@@ -138,7 +140,7 @@ def jsonldify_collection(cls, collection, locale_):
         "name": l10n.translate(collection['title'], locale_),
         "description": l10n.translate(collection['description'], locale_),
         "license": cls.fcmld['license'],
-        "keywords": collection.get('keywords', None),
+        "keywords": l10n.translate(collection.get('keywords', None), locale_),
         "spatial": None if (not hascrs84 or not bbox) else [{
             "@type": "Place",
             "geo": {
@@ -160,7 +162,7 @@ def jsonldify_collection(cls, collection, locale_):
             "encodingFormat": link['type'],
             "description": l10n.translate(link['title'], locale_),
             "inLanguage": link.get(
-                'hreflang', cls.config.get('server', {}).get('language', None)
+                'hreflang', l10n.locale2str(cls.default_locale)
             ),
             "author": link['rel'] if link.get(
                 'rel', None

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -35,6 +35,7 @@ import click
 import yaml
 
 from pygeoapi import __version__
+from pygeoapi import l10n
 from pygeoapi.plugin import load_plugin
 from pygeoapi.provider.base import ProviderTypeError
 from pygeoapi.util import (filter_dict_by_key_value, get_provider_by_type,
@@ -124,6 +125,10 @@ def get_oas_30(cfg):
 
     paths = {}
 
+    # TODO: make openapi multilingual (default language only for now)
+    server_locales = l10n.get_locales(cfg)
+    locale_ = server_locales[0]
+
     osl = get_ogc_schemas_location(cfg['server'])
     OPENAPI_YAML['oapif'] = os.path.join(osl, 'ogcapi/features/part1/1.0/openapi/ogcapi-features-1.yaml')  # noqa
 
@@ -133,9 +138,9 @@ def get_oas_30(cfg):
         'tags': []
     }
     info = {
-        'title': cfg['metadata']['identification']['title'],
-        'description': cfg['metadata']['identification']['description'],
-        'x-keywords': cfg['metadata']['identification']['keywords'],
+        'title': l10n.translate(cfg['metadata']['identification']['title'], locale_),  # noqa
+        'description': l10n.translate(cfg['metadata']['identification']['description'], locale_),  # noqa
+        'x-keywords': l10n.translate(cfg['metadata']['identification']['keywords'], locale_),  # noqa
         'termsOfService':
             cfg['metadata']['identification']['terms_of_service'],
         'contact': {
@@ -153,7 +158,7 @@ def get_oas_30(cfg):
 
     oas['servers'] = [{
         'url': cfg['server']['url'],
-        'description': cfg['metadata']['identification']['description']
+        'description': l10n.translate(cfg['metadata']['identification']['description'], locale_)  # noqa
     }]
 
     paths['/'] = {
@@ -163,7 +168,8 @@ def get_oas_30(cfg):
             'tags': ['server'],
             'operationId': 'getLandingPage',
             'parameters': [
-                {'$ref': '#/components/parameters/f'}
+                {'$ref': '#/components/parameters/f'},
+                {'$ref': '#/components/parameters/l'}
             ],
             'responses': {
                 '200': {'$ref': '{}#/components/responses/LandingPage'.format(OPENAPI_YAML['oapif'])},  # noqa
@@ -180,7 +186,8 @@ def get_oas_30(cfg):
             'tags': ['server'],
             'operationId': 'getOpenapi',
             'parameters': [
-                {'$ref': '#/components/parameters/f'}
+                {'$ref': '#/components/parameters/f'},
+                {'$ref': '#/components/parameters/l'}
             ],
             'responses': {
                 '200': {'$ref': '#/components/responses/200'},
@@ -197,7 +204,8 @@ def get_oas_30(cfg):
             'tags': ['server'],
             'operationId': 'getConformanceDeclaration',
             'parameters': [
-                {'$ref': '#/components/parameters/f'}
+                {'$ref': '#/components/parameters/f'},
+                {'$ref': '#/components/parameters/l'}
             ],
             'responses': {
                 '200': {'$ref': '{}#/components/responses/ConformanceDeclaration'.format(OPENAPI_YAML['oapif'])},  # noqa
@@ -214,7 +222,8 @@ def get_oas_30(cfg):
             'tags': ['server'],
             'operationId': 'getCollections',
             'parameters': [
-                {'$ref': '#/components/parameters/f'}
+                {'$ref': '#/components/parameters/f'},
+                {'$ref': '#/components/parameters/l'}
             ],
             'responses': {
                 '200': {'$ref': '{}#/components/responses/Collections'.format(OPENAPI_YAML['oapif'])},  # noqa
@@ -226,7 +235,7 @@ def get_oas_30(cfg):
 
     oas['tags'].append({
             'name': 'server',
-            'description': cfg['metadata']['identification']['description'],
+            'description': l10n.translate(cfg['metadata']['identification']['description'], locale_),  # noqa
             'externalDocs': {
                 'description': 'information',
                 'url': cfg['metadata']['identification']['url']}
@@ -269,6 +278,17 @@ def get_oas_30(cfg):
                 },
                 'style': 'form',
                 'explode': False
+            },
+            'l': {
+                'name': 'l',
+                'in': 'query',
+                'description': 'The optional l parameter instructs the server to output text in a certain language, if supported.  If the language is not among the available values, the Accept-Language header will be used if that language is supported. If the header is missing, the default server language is used. Note that collection providers may only support a single language, that can be different from the server language.  Language strings can be written in a complex (e.g. "fr-CA,fr;q=0.9,en-US;q=0.8,en;q=0.7"), simple (e.g. "de") or locale-like (e.g. "de-CH" or "fr_BE") fashion.',  # noqa
+                'required': False,
+                'schema': {
+                    'type': 'string',
+                    'enum': [l10n.locale2str(sl) for sl in server_locales],
+                    'default': l10n.locale2str(locale_)
+                }
             },
             'properties': {
                 'name': 'properties',
@@ -366,19 +386,23 @@ def get_oas_30(cfg):
 
     items_f = deepcopy(oas['components']['parameters']['f'])
     items_f['schema']['enum'].append('csv')
+    items_l = deepcopy(oas['components']['parameters']['l'])
 
     LOGGER.debug('setting up datasets')
     collections = filter_dict_by_key_value(cfg['resources'],
                                            'type', 'collection')
 
     for k, v in collections.items():
+        name = l10n.translate(k, locale_)
+        title = l10n.translate(v['title'], locale_)
+        desc = l10n.translate(v['description'], locale_)
         collection_name_path = '/collections/{}'.format(k)
         tag = {
-            'name': k,
-            'description': v['description'],
+            'name': name,
+            'description': desc,
             'externalDocs': {}
         }
-        for link in v['links']:
+        for link in l10n.translate(v['links'], locale_):
             if link['type'] == 'information':
                 tag['externalDocs']['description'] = link['type']
                 tag['externalDocs']['url'] = link['url']
@@ -390,12 +414,13 @@ def get_oas_30(cfg):
 
         paths[collection_name_path] = {
             'get': {
-                'summary': 'Get collection metadata'.format(v['title']),  # noqa
-                'description': v['description'],
-                'tags': [k],
-                'operationId': 'describe{}Collection'.format(k.capitalize()),
+                'summary': 'Get {} metadata'.format(title),
+                'description': desc,
+                'tags': name,
+                'operationId': 'describe{}Collection'.format(name.capitalize()),  # noqa
                 'parameters': [
-                    {'$ref': '#/components/parameters/f'}
+                    {'$ref': '#/components/parameters/f'},
+                    {'$ref': '#/components/parameters/l'}
                 ],
                 'responses': {
                     '200': {'$ref': '{}#/components/responses/Collection'.format(OPENAPI_YAML['oapif'])},  # noqa
@@ -429,12 +454,13 @@ def get_oas_30(cfg):
 
             paths[items_path] = {
                 'get': {
-                    'summary': 'Get {} items'.format(v['title']),
-                    'description': v['description'],
-                    'tags': [k],
-                    'operationId': 'get{}Features'.format(k.capitalize()),
+                    'summary': 'Get {} items'.format(title),  # noqa
+                    'description': desc,
+                    'tags': [name],
+                    'operationId': 'get{}Features'.format(name.capitalize()),
                     'parameters': [
                         items_f,
+                        items_l,
                         {'$ref': '{}#/components/parameters/bbox'.format(OPENAPI_YAML['oapif'])},  # noqa
                         {'$ref': '{}#/components/parameters/limit'.format(OPENAPI_YAML['oapif'])},  # noqa
                         coll_properties,
@@ -459,13 +485,14 @@ def get_oas_30(cfg):
 
                 paths[queryables_path] = {
                     'get': {
-                        'summary': 'Get {} queryables'.format(v['title']),
-                        'description': v['description'],
-                        'tags': [k],
+                        'summary': 'Get {} queryables'.format(title),
+                        'description': desc,
+                        'tags': [name],
                         'operationId': 'get{}Queryables'.format(
-                            k.capitalize()),
+                            name.capitalize()),
                         'parameters': [
                             items_f,
+                            items_l
                         ],
                         'responses': {
                             '200': {'$ref': '#/components/responses/Queryables'},  # noqa
@@ -522,13 +549,14 @@ def get_oas_30(cfg):
 
             paths['{}/items/{{featureId}}'.format(collection_name_path)] = {
                 'get': {
-                    'summary': 'Get {} item by id'.format(v['title']),
-                    'description': v['description'],
-                    'tags': [k],
-                    'operationId': 'get{}Feature'.format(k.capitalize()),
+                    'summary': 'Get {} item by id'.format(title),
+                    'description': desc,
+                    'tags': [name],
+                    'operationId': 'get{}Feature'.format(name.capitalize()),
                     'parameters': [
                         {'$ref': '{}#/components/parameters/featureId'.format(OPENAPI_YAML['oapif'])},  # noqa
-                        {'$ref': '#/components/parameters/f'}
+                        {'$ref': '#/components/parameters/f'},
+                        {'$ref': '#/components/parameters/l'}
                     ],
                     'responses': {
                         '200': {'$ref': '{}#/components/responses/Feature'.format(OPENAPI_YAML['oapif'])},  # noqa
@@ -550,12 +578,13 @@ def get_oas_30(cfg):
 
             paths[coverage_path] = {
                 'get': {
-                    'summary': 'Get {} coverage'.format(v['title']),
-                    'description': v['description'],
-                    'tags': [k],
-                    'operationId': 'get{}Coverage'.format(k.capitalize()),
+                    'summary': 'Get {} coverage'.format(title),
+                    'description': desc,
+                    'tags': [name],
+                    'operationId': 'get{}Coverage'.format(name.capitalize()),
                     'parameters': [
                         items_f,
+                        # items_l  TODO: is this useful?
                     ],
                     'responses': {
                         '200': {'$ref': '{}#/components/responses/Features'.format(OPENAPI_YAML['oapif'])},  # noqa
@@ -571,13 +600,14 @@ def get_oas_30(cfg):
 
             paths[coverage_domainset_path] = {
                 'get': {
-                    'summary': 'Get {} coverage domain set'.format(v['title']),
-                    'description': v['description'],
-                    'tags': [k],
+                    'summary': 'Get {} coverage domain set'.format(title),
+                    'description': desc,
+                    'tags': [name],
                     'operationId': 'get{}CoverageDomainSet'.format(
-                        k.capitalize()),
+                        name.capitalize()),
                     'parameters': [
                         items_f,
+                        # items_l  TODO: is this useful?
                     ],
                     'responses': {
                         '200': {'$ref': '{}/schemas/cis_1.1/domainSet.yaml'.format(OPENAPI_YAML['oacov'])},  # noqa
@@ -593,13 +623,14 @@ def get_oas_30(cfg):
 
             paths[coverage_rangetype_path] = {
                 'get': {
-                    'summary': 'Get {} coverage range type'.format(v['title']),
-                    'description': v['description'],
-                    'tags': [k],
+                    'summary': 'Get {} coverage range type'.format(title),
+                    'description': desc,
+                    'tags': [name],
                     'operationId': 'get{}CoverageRangeType'.format(
-                        k.capitalize()),
+                        name.capitalize()),
                     'parameters': [
                         items_f,
+                        # items_l  TODO: is this useful?
                     ],
                     'responses': {
                         '200': {'$ref': '{}/schemas/cis_1.1/rangeType.yaml'.format(OPENAPI_YAML['oacov'])},  # noqa
@@ -671,12 +702,13 @@ def get_oas_30(cfg):
 
             paths[tiles_path] = {
                 'get': {
-                    'summary': 'Fetch a {} tiles description'.format(v['title']), # noqa
-                    'description': v['description'],
-                    'tags': [k],
-                    'operationId': 'describe{}Tiles'.format(k.capitalize()),
+                    'summary': 'Fetch a {} tiles description'.format(title), # noqa
+                    'description': desc,
+                    'tags': [name],
+                    'operationId': 'describe{}Tiles'.format(name.capitalize()),
                     'parameters': [
                         items_f,
+                        # items_l  TODO: is this useful?
                     ],
                     'responses': {
                         '200': {'$ref': '#/components/responses/Tiles'},
@@ -691,10 +723,10 @@ def get_oas_30(cfg):
 
             paths[tiles_data_path] = {
                 'get': {
-                    'summary': 'Get a {} tile'.format(v['title']),
-                    'description': v['description'],
-                    'tags': [k],
-                    'operationId': 'get{}Tiles'.format(k.capitalize()),
+                    'summary': 'Get a {} tile'.format(title),
+                    'description': desc,
+                    'tags': [name],
+                    'operationId': 'get{}Tiles'.format(name.capitalize()),
                     'parameters': [{
                         'name': 'f',
                         'in': 'query',
@@ -818,15 +850,17 @@ def get_oas_30(cfg):
         LOGGER.debug('setting up processes')
 
         for k, v in processes.items():
+            name = l10n.translate(k, locale_)
             p = load_plugin('process', v['processor'])
 
-            process_name_path = '/processes/{}'.format(k)
+            md_desc = l10n.translate(p.metadata['description'], locale_)
+            process_name_path = '/processes/{}'.format(name)
             tag = {
-                'name': k,
-                'description': p.metadata['description'],
+                'name': name,
+                'description': md_desc,  # noqa
                 'externalDocs': {}
             }
-            for link in p.metadata['links']:
+            for link in l10n.translate(p.metadata['links'], locale_):
                 if link['type'] == 'information':
                     tag['externalDocs']['description'] = link['type']
                     tag['externalDocs']['url'] = link['url']
@@ -839,9 +873,9 @@ def get_oas_30(cfg):
             paths[process_name_path] = {
                 'get': {
                     'summary': 'Get process metadata',
-                    'description': p.metadata['description'],
-                    'tags': [k],
-                    'operationId': 'describe{}Process'.format(k.capitalize()),
+                    'description': md_desc,
+                    'tags': [name],
+                    'operationId': 'describe{}Process'.format(name.capitalize()),  # noqa
                     'parameters': [
                         {'$ref': '#/components/parameters/f'}
                     ],
@@ -854,9 +888,9 @@ def get_oas_30(cfg):
             paths['{}/jobs'.format(process_name_path)] = {
                 'get': {
                     'summary': 'Retrieve job list for process',
-                    'description': p.metadata['description'],
-                    'tags': [k],
-                    'operationId': 'get{}Jobs'.format(k.capitalize()),
+                    'description': md_desc,
+                    'tags': [name],
+                    'operationId': 'get{}Jobs'.format(name.capitalize()),
                     'responses': {
                         '200': {'$ref': '#/components/responses/200'},
                         '404': {'$ref': '{}/responses/NotFound.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa
@@ -865,10 +899,10 @@ def get_oas_30(cfg):
                 },
                 'post': {
                     'summary': 'Process {} execution'.format(
-                        p.metadata['title']),
-                    'description': p.metadata['description'],
-                    'tags': [k],
-                    'operationId': 'execute{}Job'.format(k.capitalize()),
+                        l10n.translate(p.metadata['title'], locale_)),
+                    'description': md_desc,
+                    'tags': [name],
+                    'operationId': 'execute{}Job'.format(name.capitalize()),
                     'parameters': [{
                         'name': 'response',
                         'in': 'query',
@@ -919,12 +953,12 @@ def get_oas_30(cfg):
                     'get': {
                         'summary': 'Retrieve job details',
                         'description': '',
-                        'tags': [k],
+                        'tags': [name],
                         'parameters': [
                             name_in_path,
                             {'$ref': '#/components/parameters/f'}
                         ],
-                        'operationId': f'get{k.capitalize()}Job',
+                        'operationId': f'get{name.capitalize()}Job',
                         'responses': {
                             '200': {'$ref': '#/components/responses/200'},
                             '404': {'$ref': '{}/responses/NotFound.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa
@@ -934,11 +968,11 @@ def get_oas_30(cfg):
                     'delete': {
                         'summary': 'Cancel / delete job',
                         'description': '',
-                        'tags': [k],
+                        'tags': [name],
                         'parameters': [
                             name_in_path
                         ],
-                        'operationId': f'delete{k.capitalize()}Job',
+                        'operationId': f'delete{name.capitalize()}Job',
                         'responses': {
                             '204': {'$ref': '#/components/responses/204'},
                             '404': {'$ref': '{}/responses/NotFound.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa
@@ -951,12 +985,12 @@ def get_oas_30(cfg):
                     'get': {
                         'summary': 'Retrieve job results',
                         'description': '',
-                        'tags': [k],
+                        'tags': [name],
                         'parameters': [
                             name_in_path,
                             {'$ref': '#/components/parameters/f'}
                         ],
-                        'operationId': f'get{k.capitalize()}JobResults',
+                        'operationId': f'get{name.capitalize()}JobResults',
                         'responses': {
                             '200': {'$ref': '#/components/responses/200'},
                             '404': {'$ref': '{}/responses/NotFound.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa

--- a/pygeoapi/plugin.py
+++ b/pygeoapi/plugin.py
@@ -65,7 +65,7 @@ PLUGINS = {
 }
 
 
-def load_plugin(plugin_type, plugin_def):
+def load_plugin(plugin_type, plugin_def, **kwargs):
     """
     loads plugin by name
 
@@ -101,7 +101,7 @@ def load_plugin(plugin_type, plugin_def):
 
     module = importlib.import_module(packagename)
     class_ = getattr(module, classname)
-    plugin = class_(plugin_def)
+    plugin = class_(plugin_def, **kwargs)
 
     return plugin
 

--- a/pygeoapi/plugin.py
+++ b/pygeoapi/plugin.py
@@ -65,12 +65,13 @@ PLUGINS = {
 }
 
 
-def load_plugin(plugin_type, plugin_def, **kwargs):
+def load_plugin(plugin_type, plugin_def, locale=None):
     """
     loads plugin by name
 
     :param plugin_type: type of plugin (provider, formatter)
     :param plugin_def: plugin definition
+    :param locale: the optional requested locale
 
     :returns: plugin object
     """
@@ -101,7 +102,7 @@ def load_plugin(plugin_type, plugin_def, **kwargs):
 
     module = importlib.import_module(packagename)
     class_ = getattr(module, classname)
-    plugin = class_(plugin_def, **kwargs)
+    plugin = class_(plugin_def, locale)
 
     return plugin
 

--- a/pygeoapi/process/base.py
+++ b/pygeoapi/process/base.py
@@ -35,7 +35,7 @@ LOGGER = logging.getLogger(__name__)
 class BaseProcessor:
     """generic Processor ABC. Processes are inherited from this class"""
 
-    def __init__(self, processor_def, process_metadata):
+    def __init__(self, processor_def, process_metadata, **kwargs):
         """
         Initialize object
 

--- a/pygeoapi/process/base.py
+++ b/pygeoapi/process/base.py
@@ -29,25 +29,31 @@
 
 import logging
 
+from pygeoapi import l10n
+
 LOGGER = logging.getLogger(__name__)
 
 
 class BaseProcessor:
     """generic Processor ABC. Processes are inherited from this class"""
 
-    def __init__(self, processor_def, process_metadata, **kwargs):
+    def __init__(self, processor_def, process_metadata, requested_locale: str = None):  # noqa
         """
         Initialize object
 
-        :param processor_def: processor definition
-        :param process_metadata: process metadata `dict`
+        :param processor_def:       processor definition
+        :param process_metadata:    process metadata `dict`
+        :param requested_locale:    requested process locale
 
         :returns: pygeoapi.processor.base.BaseProvider
         """
         self.name = processor_def['name']
         self.metadata = process_metadata
 
-    def execute(self):
+        # locale support
+        self.locale = l10n.get_plugin_locale(processor_def, requested_locale)
+
+    def execute(self, data):
         """
         execute the process
 

--- a/pygeoapi/process/hello_world.py
+++ b/pygeoapi/process/hello_world.py
@@ -112,7 +112,7 @@ PROCESS_METADATA = {
 class HelloWorldProcessor(BaseProcessor):
     """Hello World Processor example"""
 
-    def __init__(self, processor_def):
+    def __init__(self, processor_def, **kwargs):
         """
         Initialize object
 
@@ -121,7 +121,7 @@ class HelloWorldProcessor(BaseProcessor):
         :returns: pygeoapi.process.hello_world.HelloWorldProcessor
         """
 
-        super().__init__(processor_def, PROCESS_METADATA)
+        super().__init__(processor_def, PROCESS_METADATA, **kwargs)
 
     def execute(self, data):
 

--- a/pygeoapi/process/hello_world.py
+++ b/pygeoapi/process/hello_world.py
@@ -112,7 +112,7 @@ PROCESS_METADATA = {
 class HelloWorldProcessor(BaseProcessor):
     """Hello World Processor example"""
 
-    def __init__(self, processor_def, **kwargs):
+    def __init__(self, processor_def, requested_locale=None):
         """
         Initialize object
 
@@ -121,7 +121,7 @@ class HelloWorldProcessor(BaseProcessor):
         :returns: pygeoapi.process.hello_world.HelloWorldProcessor
         """
 
-        super().__init__(processor_def, PROCESS_METADATA, **kwargs)
+        super().__init__(processor_def, PROCESS_METADATA, requested_locale)
 
     def execute(self, data):
 

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -35,6 +35,7 @@ from multiprocessing import dummy
 import os
 
 from pygeoapi.util import DATETIME_FORMAT, JobStatus
+from pygeoapi import l10n
 
 LOGGER = logging.getLogger(__name__)
 
@@ -42,11 +43,12 @@ LOGGER = logging.getLogger(__name__)
 class BaseManager:
     """generic Manager ABC"""
 
-    def __init__(self, manager_def, **kwargs):
+    def __init__(self, manager_def, requested_locale: str = None):
         """
         Initialize object
 
-        :param manager_def: manager definition
+        :param manager_def:         manager definition
+        :param requested_locale:    optional requested locale
 
         :returns: `pygeoapi.process.manager.base.BaseManager`
         """
@@ -55,6 +57,9 @@ class BaseManager:
         self.is_async = False
         self.connection = manager_def.get('connection', None)
         self.output_dir = manager_def.get('output_dir', None)
+
+        # locale support
+        self.locale = l10n.get_plugin_locale(manager_def, requested_locale)
 
     def get_jobs(self, process_id=None, status=None):
         """

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -42,7 +42,7 @@ LOGGER = logging.getLogger(__name__)
 class BaseManager:
     """generic Manager ABC"""
 
-    def __init__(self, manager_def):
+    def __init__(self, manager_def, **kwargs):
         """
         Initialize object
 

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -38,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
 class DummyManager(BaseManager):
     """generic Manager ABC"""
 
-    def __init__(self, manager_def):
+    def __init__(self, manager_def, **kwargs):
         """
         Initialize object
 
@@ -47,7 +47,7 @@ class DummyManager(BaseManager):
         :returns: `pygeoapi.process.manager.base.BaseManager`
         """
 
-        super().__init__(manager_def)
+        super().__init__(manager_def, **kwargs)
 
     def get_jobs(self, process_id=None, status=None):
         """

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -38,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
 class DummyManager(BaseManager):
     """generic Manager ABC"""
 
-    def __init__(self, manager_def, **kwargs):
+    def __init__(self, manager_def, locale=None):
         """
         Initialize object
 
@@ -47,7 +47,7 @@ class DummyManager(BaseManager):
         :returns: `pygeoapi.process.manager.base.BaseManager`
         """
 
-        super().__init__(manager_def, **kwargs)
+        super().__init__(manager_def, locale)
 
     def get_jobs(self, process_id=None, status=None):
         """

--- a/pygeoapi/process/manager/tinydb_.py
+++ b/pygeoapi/process/manager/tinydb_.py
@@ -43,7 +43,7 @@ LOGGER = logging.getLogger(__name__)
 class TinyDBManager(BaseManager):
     """TinyDB Manager"""
 
-    def __init__(self, manager_def, **kwargs):
+    def __init__(self, manager_def, locale=None):
         """
         Initialize object
 
@@ -52,7 +52,7 @@ class TinyDBManager(BaseManager):
         :returns: `pygeoapi.process.manager.base.BaseManager`
         """
 
-        super().__init__(manager_def, **kwargs)
+        super().__init__(manager_def, locale)
         self.is_async = True
 
     def _connect(self):

--- a/pygeoapi/process/manager/tinydb_.py
+++ b/pygeoapi/process/manager/tinydb_.py
@@ -43,7 +43,7 @@ LOGGER = logging.getLogger(__name__)
 class TinyDBManager(BaseManager):
     """TinyDB Manager"""
 
-    def __init__(self, manager_def):
+    def __init__(self, manager_def, **kwargs):
         """
         Initialize object
 
@@ -52,7 +52,7 @@ class TinyDBManager(BaseManager):
         :returns: `pygeoapi.process.manager.base.BaseManager`
         """
 
-        super().__init__(manager_def)
+        super().__init__(manager_def, **kwargs)
         self.is_async = True
 
     def _connect(self):

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -29,13 +29,15 @@
 
 import logging
 
+from pygeoapi import l10n
+
 LOGGER = logging.getLogger(__name__)
 
 
 class BaseProvider:
     """generic Provider ABC"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
 
@@ -51,12 +53,22 @@ class BaseProvider:
         except KeyError:
             raise RuntimeError('name/type/data are required')
 
+        # locale support
+        self.locale = None
+        locales = provider_def.get('languages', [])
+        if locales:
+            self.locale = l10n.best_match(kwargs.get('language'), locales)
+            LOGGER.info(f'{self.name} provider locale set to {self.locale}')
+        else:
+            LOGGER.info(f'{self.name} provider has no locale support')
+
         self.options = provider_def.get('options', None)
         self.id_field = provider_def.get('id_field', None)
         self.x_field = provider_def.get('x_field', None)
         self.y_field = provider_def.get('y_field', None)
         self.time_field = provider_def.get('time_field')
-        self.title_field = provider_def.get('title_field')
+        self.title_field = l10n.translate(provider_def.get('title_field'),
+                                          self.locale)
         self.properties = provider_def.get('properties', [])
         self.file_types = provider_def.get('file_types', [])
         self.fields = {}

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -37,11 +37,12 @@ LOGGER = logging.getLogger(__name__)
 class BaseProvider:
     """generic Provider ABC"""
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def: dict, requested_locale: str = None):
         """
         Initialize object
 
-        :param provider_def: provider definition
+        :param provider_def:        provider definition
+        :param requested_locale:    requested provider locale
 
         :returns: pygeoapi.provider.base.BaseProvider
         """
@@ -54,13 +55,7 @@ class BaseProvider:
             raise RuntimeError('name/type/data are required')
 
         # locale support
-        self.locale = None
-        locales = provider_def.get('languages', [])
-        if locales:
-            self.locale = l10n.best_match(kwargs.get('language'), locales)
-            LOGGER.info(f'{self.name} provider locale set to {self.locale}')
-        else:
-            LOGGER.info(f'{self.name} provider has no locale support')
+        self.locale = l10n.get_plugin_locale(provider_def, requested_locale)
 
         self.options = provider_def.get('options', None)
         self.id_field = provider_def.get('id_field', None)

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -41,7 +41,7 @@ LOGGER = logging.getLogger(__name__)
 class CSVProvider(BaseProvider):
     """CSV provider"""
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         Initialize object
 
@@ -50,7 +50,7 @@ class CSVProvider(BaseProvider):
         :returns: pygeoapi.provider.csv_.CSVProvider
         """
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
         self.geometry_x = provider_def['geometry']['x_field']
         self.geometry_y = provider_def['geometry']['y_field']
         self.fields = self.get_fields()

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -41,7 +41,7 @@ LOGGER = logging.getLogger(__name__)
 class CSVProvider(BaseProvider):
     """CSV provider"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
 
@@ -50,7 +50,7 @@ class CSVProvider(BaseProvider):
         :returns: pygeoapi.provider.csv_.CSVProvider
         """
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
         self.geometry_x = provider_def['geometry']['x_field']
         self.geometry_y = provider_def['geometry']['y_field']
         self.fields = self.get_fields()

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -45,7 +45,7 @@ LOGGER = logging.getLogger(__name__)
 class ElasticsearchProvider(BaseProvider):
     """Elasticsearch Provider"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
 
@@ -54,7 +54,7 @@ class ElasticsearchProvider(BaseProvider):
         :returns: pygeoapi.provider.elasticsearch_.ElasticsearchProvider
         """
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
 
         self.es_host, self.index_name = self.data.rsplit('/', 1)
 

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -45,7 +45,7 @@ LOGGER = logging.getLogger(__name__)
 class ElasticsearchProvider(BaseProvider):
     """Elasticsearch Provider"""
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         Initialize object
 
@@ -54,7 +54,7 @@ class ElasticsearchProvider(BaseProvider):
         :returns: pygeoapi.provider.elasticsearch_.ElasticsearchProvider
         """
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
 
         self.es_host, self.index_name = self.data.rsplit('/', 1)
 

--- a/pygeoapi/provider/filesystem.py
+++ b/pygeoapi/provider/filesystem.py
@@ -41,7 +41,7 @@ LOGGER = logging.getLogger(__name__)
 class FileSystemProvider(BaseProvider):
     """filesystem Provider"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
 
@@ -50,7 +50,7 @@ class FileSystemProvider(BaseProvider):
         :returns: pygeoapi.provider.filesystem.FileSystemProvider
         """
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
 
         if not os.path.exists(self.data):
             msg = 'Directory does not exist: {}'.format(self.data)

--- a/pygeoapi/provider/filesystem.py
+++ b/pygeoapi/provider/filesystem.py
@@ -41,7 +41,7 @@ LOGGER = logging.getLogger(__name__)
 class FileSystemProvider(BaseProvider):
     """filesystem Provider"""
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         Initialize object
 
@@ -50,7 +50,7 @@ class FileSystemProvider(BaseProvider):
         :returns: pygeoapi.provider.filesystem.FileSystemProvider
         """
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
 
         if not os.path.exists(self.data):
             msg = 'Directory does not exist: {}'.format(self.data)

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -63,10 +63,10 @@ class GeoJSONProvider(BaseProvider):
     * appropriate HTTP responses will be raised
     """
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """initializer"""
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
         self.fields = self.get_fields()
 
     def get_fields(self):

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -63,10 +63,10 @@ class GeoJSONProvider(BaseProvider):
     * appropriate HTTP responses will be raised
     """
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """initializer"""
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
         self.fields = self.get_fields()
 
     def get_fields(self):

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -45,7 +45,7 @@ class MongoProvider(BaseProvider):
     """Generic provider for Mongodb.
     """
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         MongoProvider Class constructor
 
@@ -58,7 +58,7 @@ class MongoProvider(BaseProvider):
         # Mongo id field is _id
         provider_def.setdefault('id_field', '_id')
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
 
         LOGGER.info('Mongo source config: {}'.format(self.data))
 

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -45,7 +45,7 @@ class MongoProvider(BaseProvider):
     """Generic provider for Mongodb.
     """
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         MongoProvider Class constructor
 
@@ -58,7 +58,7 @@ class MongoProvider(BaseProvider):
         # Mongo id field is _id
         provider_def.setdefault('id_field', '_id')
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
 
         LOGGER.info('Mongo source config: {}'.format(self.data))
 

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -45,7 +45,7 @@ LOGGER = logging.getLogger(__name__)
 class MVTProvider(BaseTileProvider):
     """MVT Provider"""
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         Initialize object
 
@@ -54,7 +54,7 @@ class MVTProvider(BaseTileProvider):
         :returns: pygeoapi.provider.MVT.MVTProvider
         """
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
 
         if is_url(self.data):
             url = urlparse(self.data)

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -45,7 +45,7 @@ LOGGER = logging.getLogger(__name__)
 class MVTProvider(BaseTileProvider):
     """MVT Provider"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
 
@@ -54,7 +54,7 @@ class MVTProvider(BaseTileProvider):
         :returns: pygeoapi.provider.MVT.MVTProvider
         """
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
 
         if is_url(self.data):
             url = urlparse(self.data)

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -75,7 +75,7 @@ class OGRProvider(BaseProvider):
     # Setting for traditional CRS axis order.
     OAMS_TRADITIONAL_GIS_ORDER = osgeo_osr.OAMS_TRADITIONAL_GIS_ORDER
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
 
@@ -110,7 +110,7 @@ class OGRProvider(BaseProvider):
         :returns: pygeoapi.provider.ogr.OGRProvider
         """
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
 
         self.ogr = osgeo_ogr
         # http://trac.osgeo.org/gdal/wiki/PythonGotchas

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -75,7 +75,7 @@ class OGRProvider(BaseProvider):
     # Setting for traditional CRS axis order.
     OAMS_TRADITIONAL_GIS_ORDER = osgeo_osr.OAMS_TRADITIONAL_GIS_ORDER
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         Initialize object
 
@@ -110,7 +110,7 @@ class OGRProvider(BaseProvider):
         :returns: pygeoapi.provider.ogr.OGRProvider
         """
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
 
         self.ogr = osgeo_ogr
         # http://trac.osgeo.org/gdal/wiki/PythonGotchas

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -137,7 +137,7 @@ class PostgreSQLProvider(BaseProvider):
     cursor (using support class DatabaseCursor)
     """
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         PostgreSQLProvider Class constructor
 
@@ -149,7 +149,7 @@ class PostgreSQLProvider(BaseProvider):
         :returns: pygeoapi.provider.base.PostgreSQLProvider
         """
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
 
         self.table = provider_def['table']
         self.id_field = provider_def['id_field']

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -137,7 +137,7 @@ class PostgreSQLProvider(BaseProvider):
     cursor (using support class DatabaseCursor)
     """
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         PostgreSQLProvider Class constructor
 
@@ -149,7 +149,7 @@ class PostgreSQLProvider(BaseProvider):
         :returns: pygeoapi.provider.base.PostgreSQLProvider
         """
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
 
         self.table = provider_def['table']
         self.id_field = provider_def['id_field']

--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -44,14 +44,14 @@ LOGGER = logging.getLogger(__name__)
 class RasterioProvider(BaseProvider):
     """Rasterio Provider"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
         :param provider_def: provider definition
         :returns: pygeoapi.provider.rasterio_.RasterioProvider
         """
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
 
         try:
             self._data = rasterio.open(self.data)

--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -44,14 +44,14 @@ LOGGER = logging.getLogger(__name__)
 class RasterioProvider(BaseProvider):
     """Rasterio Provider"""
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         Initialize object
         :param provider_def: provider definition
         :returns: pygeoapi.provider.rasterio_.RasterioProvider
         """
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
 
         try:
             self._data = rasterio.open(self.data)

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -52,7 +52,7 @@ class SQLiteGPKGProvider(BaseProvider):
     TODO: DELETE, UPDATE, CREATE
     """
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         SQLiteGPKGProvider Class constructor
 
@@ -61,7 +61,7 @@ class SQLiteGPKGProvider(BaseProvider):
 
         :returns: pygeoapi.provider.base.SQLiteProvider
         """
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
 
         self.table = provider_def['table']
         self.application_id = None

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -52,7 +52,7 @@ class SQLiteGPKGProvider(BaseProvider):
     TODO: DELETE, UPDATE, CREATE
     """
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         SQLiteGPKGProvider Class constructor
 
@@ -61,7 +61,7 @@ class SQLiteGPKGProvider(BaseProvider):
 
         :returns: pygeoapi.provider.base.SQLiteProvider
         """
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
 
         self.table = provider_def['table']
         self.application_id = None

--- a/pygeoapi/provider/tile.py
+++ b/pygeoapi/provider/tile.py
@@ -29,6 +29,7 @@
 
 import logging
 
+from pygeoapi import l10n
 from pygeoapi.provider.base import ProviderGenericError
 
 LOGGER = logging.getLogger(__name__)
@@ -37,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
 class BaseTileProvider:
     """generic Tile Provider ABC"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
 
@@ -45,13 +46,21 @@ class BaseTileProvider:
 
         :returns: pygeoapi.provider.tile.BaseTileProvider
         """
-
         self.name = provider_def['name']
         self.data = provider_def['data']
         self.format_type = provider_def['format']['name']
         self.mimetype = provider_def['format']['mimetype']
         self.options = provider_def.get('options', None)
         self.fields = {}
+
+        # locale support for providers that need it
+        self.locale = None
+        locales = provider_def.get('languages', [])
+        if locales:
+            self.locale = l10n.best_match(kwargs.get('language'), locales)
+            LOGGER.info(f'{self.name} provider locale set to {self.locale}')
+        else:
+            LOGGER.info(f'{self.name} provider has no locale support')
 
     def get_layer(self):
         """

--- a/pygeoapi/provider/tile.py
+++ b/pygeoapi/provider/tile.py
@@ -38,11 +38,12 @@ LOGGER = logging.getLogger(__name__)
 class BaseTileProvider:
     """generic Tile Provider ABC"""
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale: str = None):
         """
         Initialize object
 
-        :param provider_def: provider definition
+        :param provider_def:        provider definition
+        :param requested_locale:    requested provider locale
 
         :returns: pygeoapi.provider.tile.BaseTileProvider
         """
@@ -53,14 +54,8 @@ class BaseTileProvider:
         self.options = provider_def.get('options', None)
         self.fields = {}
 
-        # locale support for providers that need it
-        self.locale = None
-        locales = provider_def.get('languages', [])
-        if locales:
-            self.locale = l10n.best_match(kwargs.get('language'), locales)
-            LOGGER.info(f'{self.name} provider locale set to {self.locale}')
-        else:
-            LOGGER.info(f'{self.name} provider has no locale support')
+        # locale support
+        self.locale = l10n.get_plugin_locale(provider_def, requested_locale)
 
     def get_layer(self):
         """

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -42,7 +42,7 @@ LOGGER = logging.getLogger(__name__)
 class TinyDBCatalogueProvider(BaseProvider):
     """TinyDB Catalogue Provider"""
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         Initialize object
 
@@ -55,7 +55,7 @@ class TinyDBCatalogueProvider(BaseProvider):
             '_metadata-anytext',
         ]
 
-        BaseProvider.__init__(self, provider_def, **kwargs)
+        BaseProvider.__init__(self, provider_def, requested_locale)
 
         LOGGER.debug('Connecting to TinyDB db at {}'.format(self.data))
 

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -42,7 +42,7 @@ LOGGER = logging.getLogger(__name__)
 class TinyDBCatalogueProvider(BaseProvider):
     """TinyDB Catalogue Provider"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
 
@@ -55,7 +55,7 @@ class TinyDBCatalogueProvider(BaseProvider):
             '_metadata-anytext',
         ]
 
-        BaseProvider.__init__(self, provider_def)
+        BaseProvider.__init__(self, provider_def, **kwargs)
 
         LOGGER.debug('Connecting to TinyDB db at {}'.format(self.data))
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -47,14 +47,14 @@ LOGGER = logging.getLogger(__name__)
 class XarrayProvider(BaseProvider):
     """Xarray Provider"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, **kwargs):
         """
         Initialize object
         :param provider_def: provider definition
         :returns: pygeoapi.provider.xarray_.XarrayProvider
         """
 
-        super().__init__(provider_def)
+        super().__init__(provider_def, **kwargs)
 
         try:
             if provider_def['data'].endswith('.zarr'):

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -47,14 +47,14 @@ LOGGER = logging.getLogger(__name__)
 class XarrayProvider(BaseProvider):
     """Xarray Provider"""
 
-    def __init__(self, provider_def, **kwargs):
+    def __init__(self, provider_def, requested_locale=None):
         """
         Initialize object
         :param provider_def: provider definition
         :returns: pygeoapi.provider.xarray_.XarrayProvider
         """
 
-        super().__init__(provider_def, **kwargs)
+        super().__init__(provider_def, requested_locale)
 
         try:
             if provider_def['data'].endswith('.zarr'):

--- a/pygeoapi/provider/xarray_edr.py
+++ b/pygeoapi/provider/xarray_edr.py
@@ -38,7 +38,7 @@ LOGGER = logging.getLogger(__name__)
 class XarrayEDRProvider(XarrayProvider):
     """EDR Provider"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def, requested_locale=None):
         """
         Initialize object
 
@@ -47,7 +47,7 @@ class XarrayEDRProvider(XarrayProvider):
         :returns: pygeoapi.provider.rasterio_.RasterioProvider
         """
 
-        XarrayProvider.__init__(self, provider_def)
+        XarrayProvider.__init__(self, provider_def, requested_locale)
         self.instances = []
 
     def get_fields(self):

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -398,18 +398,9 @@ async def get_collection_edr_query(request: Request, collection_id=None, instanc
     if 'instance_id' in request.path_params:
         instance_id = request.path_params['instance_id']
 
-    query_type = request.path.split('/')[-1]
-
-    headers, status_code, content = api_.get_collection_edr_query(
-        request.headers, request.query_params, collection_id, instance_id,
-        query_type)
-
-    response = Response(content=content, status_code=status_code)
-
-    if headers:
-        response.headers.update(headers)
-
-    return response
+    query_type = request.path.split('/')[-1]  # noqa
+    return get_response(api_.get_collection_edr_query(request, collection_id,
+                                                      instance_id, query_type))
 
 
 @app.route('/stac')

--- a/pygeoapi/templates/landing_page.html
+++ b/pygeoapi/templates/landing_page.html
@@ -8,11 +8,11 @@
   <div class="col-md-8 col-sm-12">
 
   <section id="identification">
-    <h1>{{ config['metadata']['identification']['title'] }}</h1>
-    <p>{{ config['metadata']['identification']['description'] }}</p>
+    <h1>{{ data['title'] }}</h1>
+    <p>{{ data['description'] }}</p>
 
     <p>
-        {% for kw in config['metadata']['identification']['keywords'] %}
+        {% for kw in data['keywords'] %}
           <mark class="tag">{{ kw }}</mark>
         {% endfor %}
     </p>

--- a/pygeoapi/templates/landing_page.html
+++ b/pygeoapi/templates/landing_page.html
@@ -8,11 +8,11 @@
   <div class="col-md-8 col-sm-12">
 
   <section id="identification">
-    <h1>{{ data['title'] }}</h1>
-    <p>{{ data['description'] }}</p>
+    <h1>{{ config['metadata']['identification']['title'] }}</h1>
+    <p>{{ config['metadata']['identification']['description'] }}</p>
 
     <p>
-        {% for kw in data['keywords'] %}
+        {% for kw in config['metadata']['identification']['keywords'] %}
           <mark class="tag">{{ kw }}</mark>
         {% endfor %}
     </p>

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -310,7 +310,7 @@ def render_j2_template(config, template, data, locale_=None):
         else:
             raise
 
-    return template.render(config=l10n.translate_dict(config, locale_, True),
+    return template.render(config=l10n.translate_struct(config, locale_, True),
                            data=data, version=__version__)
 
 

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -43,6 +43,7 @@ from urllib.request import urlopen
 from urllib.parse import urlparse
 
 import dateutil.parser
+# from babel.support import Translations
 from jinja2 import Environment, FileSystemLoader
 from jinja2.exceptions import TemplateNotFound
 import yaml
@@ -258,6 +259,7 @@ def is_url(urlstring):
         return False
 
 
+# TODO: add locale as function argument
 def render_j2_template(config, template, data):
     """
     render Jinja2 template
@@ -272,11 +274,13 @@ def render_j2_template(config, template, data):
     custom_templates = False
     try:
         templates_path = config['server']['templates']['path']
-        env = Environment(loader=FileSystemLoader(templates_path))
+        env = Environment(loader=FileSystemLoader(templates_path),
+                          extensions=['jinja2.ext.i18n'])
         custom_templates = True
         LOGGER.debug('using custom templates: {}'.format(templates_path))
     except (KeyError, TypeError):
-        env = Environment(loader=FileSystemLoader(TEMPLATES))
+        env = Environment(loader=FileSystemLoader(TEMPLATES),
+                          extensions=['jinja2.ext.i18n'])
         LOGGER.debug('using default templates: {}'.format(TEMPLATES))
 
     env.filters['to_json'] = to_json
@@ -293,13 +297,15 @@ def render_j2_template(config, template, data):
     env.filters['filter_dict_by_key_value'] = filter_dict_by_key_value
     env.globals.update(filter_dict_by_key_value=filter_dict_by_key_value)
 
+    # TODO: insert Babel Translation stuff here
     try:
         template = env.get_template(template)
     except TemplateNotFound as err:
         if custom_templates:
             LOGGER.debug(err)
             LOGGER.debug('Custom template not found; using default')
-            env = Environment(loader=FileSystemLoader(TEMPLATES))
+            env = Environment(loader=FileSystemLoader(TEMPLATES),
+                              extensions=['jinja2.ext.i18n'])
             template = env.get_template(template)
         else:
             raise

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -259,14 +259,14 @@ def is_url(urlstring):
         return False
 
 
-# TODO: add locale as function argument
-def render_j2_template(config, template, data):
+def render_j2_template(config, template, data, locale_=None):
     """
     render Jinja2 template
 
     :param config: dict of configuration
     :param template: template (relative path)
     :param data: dict of data
+    :param locale_: the requested output Locale
 
     :returns: string of rendered template
     """
@@ -310,7 +310,8 @@ def render_j2_template(config, template, data):
         else:
             raise
 
-    return template.render(config=config, data=data, version=__version__)
+    return template.render(config=l10n.translate_dict(config, locale_, True),
+                           data=data, version=__version__)
 
 
 def get_mimetype(filename):

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -48,6 +48,7 @@ from jinja2.exceptions import TemplateNotFound
 import yaml
 
 from pygeoapi import __version__
+from pygeoapi import l10n
 from pygeoapi.provider.base import ProviderTypeError
 
 LOGGER = logging.getLogger(__name__)
@@ -234,6 +235,8 @@ def json_serial(obj):
             return base64.b64encode(obj)
     elif isinstance(obj, Decimal):
         return float(obj)
+    elif isinstance(obj, l10n.Locale):
+        return l10n.locale2str(obj)
 
     msg = '{} type {} not serializable'.format(obj, type(obj))
     LOGGER.error(msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyYAML
 rasterio
 shapely
 unicodecsv
+Babel

--- a/tests/pygeoapi-test-config.yml
+++ b/tests/pygeoapi-test-config.yml
@@ -34,7 +34,10 @@ server:
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
-    language: en-US
+    languages:
+        # First language is the default language
+        - en-US
+        - fr-CA
     cors: true
     pretty_print: true
     limit: 10
@@ -52,12 +55,21 @@ logging:
 
 metadata:
     identification:
-        title: pygeoapi default instance
-        description: pygeoapi provides an API to geospatial data
+        title:
+            en: pygeoapi default instance
+            fr: instance par défaut de pygeoapi
+        description:
+            en: pygeoapi provides an API to geospatial data
+            fr: pygeoapi fournit une API aux données géospatiales
         keywords:
-            - geospatial
-            - data
-            - api
+            en:
+                - geospatial
+                - data
+                - api
+            fr:
+                - géospatiale
+                - données
+                - api
         keywords_type: theme
         terms_of_service: https://creativecommons.org/licenses/by/4.0/
         url: http://example.org

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,10 +36,16 @@ from pyld import jsonld
 import pytest
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
-from pygeoapi.api import API, check_format, validate_bbox, validate_datetime
+from werkzeug.datastructures import ImmutableMultiDict
+from pygeoapi.api import (
+    API, APIRequest, FORMATS, validate_bbox, validate_datetime
+)
 from pygeoapi.util import yaml_load
 
 LOGGER = logging.getLogger(__name__)
+
+ROUTE_OBS = '/collections/obs/items'
+ROUTE_LAKES = '/collections/lakes/items'
 
 
 def get_test_file_path(filename):
@@ -49,6 +55,17 @@ def get_test_file_path(filename):
         return filename
     else:
         return 'tests/{}'.format(filename)
+
+
+def make_request(route: str, params: dict, data=None, **headers):
+    if isinstance(data, dict):
+        environ = create_environ(route, 'http://localhost:5000/', json=data)
+    else:
+        environ = create_environ(route, 'http://localhost:5000/', data=data)
+    environ.update(headers)
+    request = Request(environ)
+    request.args = ImmutableMultiDict(params.items())
+    return request
 
 
 def make_req_headers(**kwargs):
@@ -84,38 +101,147 @@ def api_(config):
     return API(config)
 
 
+def test_apirequest(api_):
+    # Test without (valid) locales
+    with pytest.raises(ValueError):
+        req = make_request(ROUTE_OBS, {})
+        APIRequest(req, [])
+        APIRequest(req, None)
+        APIRequest(req, ['zz'])
+
+    # Test all supported formats from query args
+    for f, mt in FORMATS.items():
+        req = make_request(ROUTE_OBS, {'f': f})
+        apireq = APIRequest(req, api_.locales)
+        assert apireq.is_valid()
+        assert apireq.format == f
+        assert apireq.get_response_headers()['Content-Type'] == mt
+
+    # Test all supported formats from Accept header
+    for f, mt in FORMATS.items():
+        req = make_request(ROUTE_OBS, {}, HTTP_ACCEPT=mt)
+        apireq = APIRequest(req, api_.locales)
+        assert apireq.is_valid()
+        assert apireq.format == f
+        assert apireq.get_response_headers()['Content-Type'] == mt
+
+    # Test nonsense format
+    req = make_request(ROUTE_OBS, {'f': 'foo'})
+    apireq = APIRequest(req, api_.locales)
+    assert not apireq.is_valid()
+    assert apireq.format == 'foo'
+    assert apireq.is_valid(('foo',))
+    assert apireq.get_response_headers()['Content-Type'] == FORMATS['json']
+
+    # Test without format
+    req = make_request(ROUTE_OBS, {})
+    apireq = APIRequest(req, api_.locales)
+    assert apireq.is_valid()
+    assert apireq.format is None
+    assert apireq.get_response_headers()['Content-Type'] == FORMATS['json']
+
+    # Test complex format string
+    hh = 'text/html,application/xhtml+xml,application/xml;q=0.9,'
+    req = make_request(ROUTE_OBS, {}, HTTP_ACCEPT=hh)
+    apireq = APIRequest(req, api_.locales)
+    assert apireq.is_valid()
+    assert apireq.format == 'html'
+    assert apireq.get_response_headers()['Content-Type'] == FORMATS['html']
+
+    # Overrule HTTP content negotiation
+    req = make_request(ROUTE_OBS, {'f': 'html'}, HTTP_ACCEPT='application/json')  # noqa
+    apireq = APIRequest(req, api_.locales)
+    assert apireq.is_valid()
+    assert apireq.format == 'html'
+    assert apireq.get_response_headers()['Content-Type'] == FORMATS['html']
+
+    # Test data
+    for d in (None, '', 'test', {'key': 'value'}):
+        req = make_request(ROUTE_OBS, {}, d)
+        apireq = APIRequest(req, api_.locales)
+        if not d:
+            assert apireq.data is None
+        elif isinstance(d, dict):
+            assert d == json.loads(apireq.data)
+        else:
+            assert apireq.data == d.encode()
+
+    # Test multilingual
+    test_lang = {
+        'nl': ('en', 'en-US'),
+        'en-US': ('en', 'en-US'),
+        'de_CH': ('en', 'en-US'),
+        'fr-CH, fr;q=0.9, en;q=0.8': ('fr', 'fr-CA'),
+        'fr-CH, fr-BE;q=0.9': ('fr', 'fr-CA'),
+    }
+    sup_lang = ('en-US', 'fr_CA')
+    for lang_in, (lang_out, cl_out) in test_lang.items():
+        # Using l query parameter
+        req = make_request(ROUTE_OBS, {'l': lang_in})
+        apireq = APIRequest(req, sup_lang)
+        assert apireq.raw_locale == lang_in
+        assert apireq.locale.language == lang_out
+        assert apireq.get_response_headers()['Content-Language'] == cl_out
+
+        # Using Accept-Language header
+        req = make_request(ROUTE_OBS, {}, HTTP_ACCEPT_LANGUAGE=lang_in)
+        apireq = APIRequest(req, sup_lang)
+        assert apireq.raw_locale == lang_in
+        assert apireq.locale.language == lang_out
+        assert apireq.get_response_headers()['Content-Language'] == cl_out
+
+    # Test language override
+    req = make_request(ROUTE_OBS, {'l': 'fr'}, HTTP_ACCEPT_LANGUAGE='en_US')
+    apireq = APIRequest(req, sup_lang)
+    assert apireq.raw_locale == 'fr'
+    assert apireq.locale.language == 'fr'
+    assert apireq.get_response_headers()['Content-Language'] == 'fr-CA'
+
+    # Test locale territory
+    req = make_request(ROUTE_OBS, {'l': 'en-GB'})
+    apireq = APIRequest(req, sup_lang)
+    assert apireq.raw_locale == 'en-GB'
+    assert apireq.locale.language == 'en'
+    assert apireq.locale.territory == 'US'
+    assert apireq.get_response_headers()['Content-Language'] == 'en-US'
+
+    # Test without user language setting (should use default)
+    req = make_request(ROUTE_OBS, {})
+    apireq = APIRequest(req, api_.locales)
+    assert apireq.raw_locale is None
+    assert apireq.locale.language == api_.default_locale.language
+    assert 'Content-Language' not in apireq.get_response_headers()
+
+
 def test_api(config, api_, openapi):
     assert api_.config == config
     assert isinstance(api_.config, dict)
 
-    req_headers = make_req_headers(HTTP_CONTENT_TYPE='application/json')
-    rsp_headers, code, response = api_.openapi(req_headers, {}, openapi)
-    assert rsp_headers['Content-Type'] ==\
-        'application/vnd.oai.openapi+json;version=3.0'
+    req = make_request(ROUTE_OBS, {}, HTTP_CONTENT_TYPE='application/json')
+    rsp_headers, code, response = api_.openapi(req, openapi)
+    assert rsp_headers['Content-Type'] == 'application/vnd.oai.openapi+json;version=3.0'  # noqa
     root = json.loads(response)
-
     assert isinstance(root, dict)
 
     a = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
-    req_headers = make_req_headers(HTTP_ACCEPT=a)
-    rsp_headers, code, response = api_.openapi(req_headers, {}, openapi)
+    req = make_request(ROUTE_OBS, {}, HTTP_ACCEPT=a)
+    rsp_headers, code, response = api_.openapi(req, openapi)
     assert rsp_headers['Content-Type'] == 'text/html'
 
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.openapi(req_headers, {'f': 'foo'},
-                                               openapi)
+    req = make_request(ROUTE_LAKES, {'f': 'foo'})
+    rsp_headers, code, response = api_.openapi(req, openapi)
     assert code == 400
 
 
 def test_api_exception(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.landing_page(req_headers, {'f': 'foo'})
+    req = make_request(ROUTE_OBS, {'f': 'foo'})
+    rsp_headers, code, response = api_.landing_page(req)
     assert code == 400
 
 
 def test_root(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.landing_page(req_headers, {})
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.landing_page(req)
     root = json.loads(response)
 
     assert rsp_headers['Content-Type'] == 'application/json'
@@ -136,14 +262,14 @@ def test_root(config, api_):
     assert 'description' in root
     assert root['description'] == 'pygeoapi provides an API to geospatial data'
 
-    rsp_headers, code, response = api_.landing_page(req_headers, {'f': 'html'})
+    req = make_request(ROUTE_OBS, {'f': 'html'})
+    rsp_headers, code, response = api_.landing_page(req)
     assert rsp_headers['Content-Type'] == 'text/html'
 
 
 def test_root_structured_data(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.landing_page(
-        req_headers, {"f": "jsonld"})
+    req = make_request(ROUTE_OBS, {"f": "jsonld"})
+    rsp_headers, code, response = api_.landing_page(req)
     root = json.loads(response)
 
     assert rsp_headers['Content-Type'] == 'application/ld+json'
@@ -171,47 +297,47 @@ def test_root_structured_data(config, api_):
 
 
 def test_conformance(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.conformance(req_headers, {})
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.conformance(req)
     root = json.loads(response)
 
     assert isinstance(root, dict)
     assert 'conformsTo' in root
     assert len(root['conformsTo']) == 17
 
-    rsp_headers, code, response = api_.conformance(req_headers, {'f': 'foo'})
+    req = make_request(ROUTE_OBS, {'f': 'foo'})
+    rsp_headers, code, response = api_.conformance(req)
     assert code == 400
 
-    rsp_headers, code, response = api_.conformance(req_headers, {'f': 'html'})
+    req = make_request(ROUTE_OBS, {'f': 'html'})
+    rsp_headers, code, response = api_.conformance(req)
     assert rsp_headers['Content-Type'] == 'text/html'
 
 
 def test_describe_collections(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {'f': 'foo'})
+    req = make_request(ROUTE_OBS, {"f": "foo"})
+    rsp_headers, code, response = api_.describe_collections(req)
     assert code == 400
 
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {'f': 'html'})
+    req = make_request(ROUTE_OBS, {"f": "html"})
+    rsp_headers, code, response = api_.describe_collections(req)
     assert rsp_headers['Content-Type'] == 'text/html'
 
-    rsp_headers, code, response = api_.describe_collections(req_headers, {})
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.describe_collections(req)
     collections = json.loads(response)
 
     assert len(collections) == 2
     assert len(collections['collections']) == 5
     assert len(collections['links']) == 3
 
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {}, 'foo')
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.describe_collections(req, 'foo')
     collection = json.loads(response)
-
     assert code == 400
 
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {}, 'obs')
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.describe_collections(req, 'obs')
     collection = json.loads(response)
 
     assert collection['id'] == 'obs'
@@ -231,12 +357,13 @@ def test_describe_collections(config, api_):
         }
     }
 
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {'f': 'html'}, 'obs')
+    req = make_request(ROUTE_OBS, {'f': 'html'})
+    rsp_headers, code, response = api_.describe_collections(req, 'obs')
     assert rsp_headers['Content-Type'] == 'text/html'
 
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {}, 'gdps-temperature')
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.describe_collections(req,
+                                                            'gdps-temperature')
     collection = json.loads(response)
 
     assert collection['id'] == 'gdps-temperature'
@@ -244,18 +371,17 @@ def test_describe_collections(config, api_):
 
 
 def test_get_collection_queryables(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.get_collection_queryables(
-        req_headers, {}, 'notfound')
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.get_collection_queryables(req,
+                                                                 'notfound')
     assert code == 400
 
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.get_collection_queryables(
-        req_headers, {'f': 'html'}, 'obs')
+    req = make_request(ROUTE_OBS, {'f': 'html'})
+    rsp_headers, code, response = api_.get_collection_queryables(req, 'obs')
     assert rsp_headers['Content-Type'] == 'text/html'
 
-    rsp_headers, code, response = api_.get_collection_queryables(
-        req_headers, {'f': 'json'}, 'obs')
+    req = make_request(ROUTE_OBS, {'f': 'json'})
+    rsp_headers, code, response = api_.get_collection_queryables(req, 'obs')
     queryables = json.loads(response)
 
     assert 'properties' in queryables
@@ -264,8 +390,8 @@ def test_get_collection_queryables(config, api_):
     # test with provider filtered properties
     api_.config['resources']['obs']['providers'][0]['properties'] = ['stn_id']
 
-    rsp_headers, code, response = api_.get_collection_queryables(
-        req_headers, {'f': 'json'}, 'obs')
+    req = make_request(ROUTE_OBS, {'f': 'json'})
+    rsp_headers, code, response = api_.get_collection_queryables(req, 'obs')
     queryables = json.loads(response)
 
     assert 'properties' in queryables
@@ -273,9 +399,8 @@ def test_get_collection_queryables(config, api_):
 
 
 def test_describe_collections_json_ld(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_collections(
-        req_headers, {'f': 'jsonld'}, 'obs')
+    req = make_request(ROUTE_OBS, {'f': 'jsonld'})
+    rsp_headers, code, response = api_.describe_collections(req, 'obs')
     collection = json.loads(response)
 
     assert '@context' in collection
@@ -306,55 +431,53 @@ def test_describe_collections_json_ld(config, api_):
 
 
 def test_get_collection_items(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {}, 'foo')
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.get_collection_items(req, 'foo')
+    features = json.loads(response)
+    assert code == 400
+
+    req = make_request(ROUTE_OBS, {'f': 'foo'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'f': 'foo'}, 'obs')
+    req = make_request(ROUTE_OBS, {'bbox': '1,2,3'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'bbox': '1,2,3'}, 'obs')
-    features = json.loads(response)
+    req = make_request(ROUTE_OBS, {'bbox': '1,2,3,4c'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'bbox': '1,2,3,4c'}, 'obs')
-
-    assert code == 400
-
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'f': 'html'}, 'obs')
+    req = make_request(ROUTE_OBS, {'f': 'html'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     assert rsp_headers['Content-Type'] == 'text/html'
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {}, 'obs')
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
     assert len(features['features']) == 5
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'resulttype': 'hits'}, 'obs')
+    req = make_request(ROUTE_OBS, {'resulttype': 'hits'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
     assert len(features['features']) == 0
 
     # Invalid limit
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'limit': 0}, 'obs')
+    req = make_request(ROUTE_OBS, {'limit': 0})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'limit': 2}, 'obs')
+    req = make_request(ROUTE_OBS, {'limit': 2})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
     assert len(features['features']) == 2
@@ -374,14 +497,14 @@ def test_get_collection_items(config, api_):
     assert links[4]['rel'] == 'collection'
 
     # Invalid startindex
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'startindex': -1}, 'obs')
+    req = make_request(ROUTE_OBS, {'startindex': -1})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'startindex': 2}, 'obs')
+    req = make_request(ROUTE_OBS, {'startindex': 2})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
     assert len(features['features']) == 3
@@ -400,12 +523,12 @@ def test_get_collection_items(config, api_):
     assert '/collections/obs' in links[4]['href']
     assert links[4]['rel'] == 'collection'
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {
-            'startindex': 1,
-            'limit': 1,
-            'bbox': '-180,90,180,90'
-        }, 'obs')
+    req = make_request(ROUTE_OBS, {
+        'startindex': 1,
+        'limit': 1,
+        'bbox': '-180,90,180,90'
+    })
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
     assert len(features['features']) == 1
@@ -430,102 +553,98 @@ def test_get_collection_items(config, api_):
     assert '/collections/obs' in links[5]['href']
     assert links[5]['rel'] == 'collection'
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {
-            'sortby': 'bad-property',
-            'stn_id': '35'
-        }, 'obs')
+    req = make_request(ROUTE_OBS, {
+        'sortby': 'bad-property',
+        'stn_id': '35'
+    })
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'sortby': 'stn_id'}, 'obs')
+    req = make_request(ROUTE_OBS, {'sortby': 'stn_id'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
     assert code == 200
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'sortby': '+stn_id'}, 'obs')
+    req = make_request(ROUTE_OBS, {'sortby': '+stn_id'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
     assert code == 200
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'sortby': '-stn_id'}, 'obs')
+    req = make_request(ROUTE_OBS, {'sortby': '-stn_id'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
     assert code == 200
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'f': 'csv'}, 'obs')
+    req = make_request(ROUTE_OBS, {'f': 'csv'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert rsp_headers['Content-Type'] == 'text/csv; charset=utf-8'
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2003'}, 'obs')
+    req = make_request(ROUTE_OBS, {'datetime': '2003'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 200
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '1999'}, 'obs')
+    req = make_request(ROUTE_OBS, {'datetime': '1999'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2010-04-22'}, 'obs')
+    req = make_request(ROUTE_OBS, {'datetime': '2010-04-22'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2001-11-11/2003-12-18'}, 'obs')
+    req = make_request(ROUTE_OBS, {'datetime': '2001-11-11/2003-12-18'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 200
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '../2003-12-18'}, 'obs')
+    req = make_request(ROUTE_OBS, {'datetime': '../2003-12-18'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 200
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2001-11-11/..'}, 'obs')
+    req = make_request(ROUTE_OBS, {'datetime': '2001-11-11/..'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 200
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '1999/2005-04-22'}, 'obs')
+    req = make_request(ROUTE_OBS, {'datetime': '1999/2005-04-22'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 400
-
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2002/2014-04-22'}, 'obs')
 
     api_.config['resources']['obs']['extents'].pop('temporal')
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2002/2014-04-22'}, 'obs')
+    req = make_request(ROUTE_OBS, {'datetime': '2002/2014-04-22'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 200
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'datetime': '2005-04-22'}, 'lakes')
+    req = make_request(ROUTE_OBS, {'datetime': '2005-04-22'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'lakes')
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'skipGeometry': 'true'}, 'obs')
+    req = make_request(ROUTE_OBS, {'skipGeometry': 'true'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert json.loads(response)['features'][0]['geometry'] is None
 
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {'properties': 'foo,bar'}, 'obs')
+    req = make_request(ROUTE_OBS, {'properties': 'foo,bar'})
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == 400
 
 
 def test_get_collection_items_json_ld(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.get_collection_items(
-        req_headers, {
-            'f': 'jsonld',
-            'limit': 2
-        }, 'obs')
+    req = make_request(ROUTE_OBS, {
+        'f': 'jsonld',
+        'limit': 2
+    })
+    rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     assert rsp_headers['Content-Type'] == 'application/ld+json'
     collection = json.loads(response)
 
@@ -557,43 +676,42 @@ def test_get_collection_items_json_ld(config, api_):
 
 
 def test_get_collection_item(config, api_):
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {'f': 'foo'})
+    rsp_headers, code, response = api_.get_collection_item(req, 'obs', '371')
+
+    assert code == 400
+
+    req = make_request(ROUTE_OBS, {'f': 'json'})
     rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {'f': 'foo'}, 'obs', '371')
+        req, 'gdps-temperature', '371')
+
+    assert code == 400
+
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.get_collection_item(req, 'foo', '371')
 
     assert code == 400
 
     rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {'f': 'json'}, 'gdps-temperature', '371')
-
-    assert code == 400
-
-    rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {}, 'foo', '371')
-
-    assert code == 400
-
-    rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {}, 'obs', 'notfound')
+        req, 'obs', 'notfound')
 
     assert code == 404
 
-    rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {'f': 'html'}, 'obs', '371')
+    req = make_request(ROUTE_OBS, {'f': 'html'})
+    rsp_headers, code, response = api_.get_collection_item(req, 'obs', '371')
 
     assert rsp_headers['Content-Type'] == 'text/html'
 
-    rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {}, 'obs', '371')
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.get_collection_item(req, 'obs', '371')
     feature = json.loads(response)
 
     assert feature['properties']['stn_id'] == '35'
 
 
 def test_get_collection_item_json_ld(config, api_):
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.get_collection_item(
-        req_headers, {'f': 'jsonld'}, 'obs', '371')
+    req = make_request(ROUTE_OBS, {'f': 'jsonld'})
+    rsp_headers, code, response = api_.get_collection_item(req, 'obs', '371')
     assert rsp_headers['Content-Type'] == 'application/ld+json'
     feature = json.loads(response)
     assert '@context' in feature
@@ -616,14 +734,14 @@ def test_get_collection_item_json_ld(config, api_):
 
 
 def test_get_coverage_domainset(config, api_):
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {})
     rsp_headers, code, response = api_.get_collection_coverage_domainset(
-        req_headers, {}, 'obs')
+        req, 'obs')
 
     assert code == 500
 
     rsp_headers, code, response = api_.get_collection_coverage_domainset(
-        req_headers, {}, 'gdps-temperature')
+        req, 'gdps-temperature')
 
     domainset = json.loads(response)
 
@@ -635,14 +753,14 @@ def test_get_coverage_domainset(config, api_):
 
 
 def test_get_collection_coverage_rangetype(config, api_):
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {})
     rsp_headers, code, response = api_.get_collection_coverage_rangetype(
-        req_headers, {}, 'obs')
+        req, 'obs')
 
     assert code == 500
 
     rsp_headers, code, response = api_.get_collection_coverage_rangetype(
-        req_headers, {}, 'gdps-temperature')
+        req, 'gdps-temperature')
 
     rangetype = json.loads(response)
 
@@ -654,29 +772,33 @@ def test_get_collection_coverage_rangetype(config, api_):
 
 
 def test_get_collection_coverage(config, api_):
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {})
     rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {}, 'obs')
+        req, 'obs')
 
     assert code == 400
 
+    req = make_request(ROUTE_OBS, {'rangeSubset': '12'})
     rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {'rangeSubset': '12'}, 'gdps-temperature')
+        req, 'gdps-temperature')
 
     assert code == 400
 
+    req = make_request(ROUTE_OBS, {'subset': 'bad_axis(10:20)'})
     rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {'subset': 'bad_axis(10:20)'}, 'gdps-temperature')
+        req, 'gdps-temperature')
 
     assert code == 400
 
+    req = make_request(ROUTE_OBS, {'f': 'blah'})
     rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {'f': 'blah'}, 'gdps-temperature')
+        req, 'gdps-temperature')
 
     assert code == 400
 
+    req = make_request(ROUTE_OBS, {'subset': 'Lat(5:10),Long(5:10)'})
     rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {'subset': 'Lat(5:10),Long(5:10)'}, 'gdps-temperature')
+        req, 'gdps-temperature')
 
     assert code == 200
     content = json.loads(response)
@@ -687,8 +809,9 @@ def test_get_collection_coverage(config, api_):
     assert 'TMP' in content['ranges']
     assert content['ranges']['TMP']['axisNames'] == ['y', 'x']
 
+    req = make_request(ROUTE_OBS, {'bbox': '-79,45,-75,49'})
     rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {'bbox': '-79,45,-75,49'}, 'gdps-temperature')
+        req, 'gdps-temperature')
 
     assert code == 200
     content = json.loads(response)
@@ -698,64 +821,63 @@ def test_get_collection_coverage(config, api_):
     assert content['domain']['axes']['y']['start'] == 49.0
     assert content['domain']['axes']['y']['stop'] == 45.0
 
+    req = make_request(ROUTE_OBS, {
+        'subset': 'Lat(5:10),Long(5:10)',
+        'f': 'GRIB'
+    })
     rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {'subset': 'Lat(5:10),Long(5:10)', 'f': 'GRIB'},
-        'gdps-temperature')
+        req, 'gdps-temperature')
 
     assert code == 200
     assert isinstance(response, bytes)
 
-    rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {'subset': 'time("2006-07-01T06:00:00":"2007-07-01T06:00:00")'}, 'cmip5')  # noqa
+    req = make_request(ROUTE_OBS, {
+        'subset': 'time("2006-07-01T06:00:00":"2007-07-01T06:00:00")'
+    })
+    rsp_headers, code, response = api_.get_collection_coverage(req, 'cmip5')
 
     assert code == 200
     assert isinstance(json.loads(response), dict)
 
-    rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {'subset': 'lat(1:2'}, 'cmip5')
+    req = make_request(ROUTE_OBS, {'subset': 'lat(1:2'})
+    rsp_headers, code, response = api_.get_collection_coverage(req, 'cmip5')
 
     assert code == 400
 
-    rsp_headers, code, response = api_.get_collection_coverage(
-        req_headers, {'subset': 'lat(1:2)'}, 'cmip5')
+    req = make_request(ROUTE_OBS, {'subset': 'lat(1:2)'})
+    rsp_headers, code, response = api_.get_collection_coverage(req, 'cmip5')
 
     assert code == 204
 
 
 def test_get_collection_tiles(config, api_):
-    req_headers = make_lakes_req_headers()
-    rsp_headers, code, response = api_.get_collection_tiles(
-        req_headers, {}, 'obs')
+    req = make_request(ROUTE_LAKES, {})
+    rsp_headers, code, response = api_.get_collection_tiles(req, 'obs')
 
     assert code == 400
 
-    req_headers = make_lakes_req_headers()
-    rsp_headers, code, response = api_.get_collection_tiles(
-        req_headers, {}, 'lakes')
+    rsp_headers, code, response = api_.get_collection_tiles(req, 'lakes')
 
     assert code == 200
 
 
 def test_describe_processes(config, api_):
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {})
 
     # Test for undefined process
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {}, 'foo')
+    rsp_headers, code, response = api_.describe_processes(req, 'foo')
     data = json.loads(response)
     assert code == 404
     assert data['code'] == 'NoSuchProcess'
 
     # Test for description of all processes
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {})
+    rsp_headers, code, response = api_.describe_processes(req)
     data = json.loads(response)
     assert code == 200
     assert len(data['processes']) == 1
 
-    # Test for particular, defined procss
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {}, 'hello-world')
+    # Test for particular, defined process
+    rsp_headers, code, response = api_.describe_processes(req, 'hello-world')
     process = json.loads(response)
     assert code == 200
     assert rsp_headers['Content-Type'] == 'application/json'
@@ -772,37 +894,32 @@ def test_describe_processes(config, api_):
     assert 'async-execute' in process['jobControlOptions']
 
     # Check HTML response when requested in headers
-    req_headers = make_req_headers(HTTP_ACCEPT='text/html')
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {}, 'hello-world')
+    req = make_request(ROUTE_OBS, {}, HTTP_ACCEPT='text/html')
+    rsp_headers, code, response = api_.describe_processes(req, 'hello-world')
     assert code == 200
     assert rsp_headers['Content-Type'] == 'text/html'
 
     # Check JSON response when requested in headers
-    req_headers = make_req_headers(HTTP_ACCEPT='application/json')
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {}, 'hello-world')
+    req = make_request(ROUTE_OBS, {}, HTTP_ACCEPT='application/json')
+    rsp_headers, code, response = api_.describe_processes(req, 'hello-world')
     assert code == 200
     assert rsp_headers['Content-Type'] == 'application/json'
 
     # Check HTML response when requested with query parameter
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {'f': 'html'}, 'hello-world')
+    req = make_request(ROUTE_OBS, {'f': 'html'})
+    rsp_headers, code, response = api_.describe_processes(req, 'hello-world')
     assert code == 200
     assert rsp_headers['Content-Type'] == 'text/html'
 
     # Check JSON response when requested with query parameter
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {'f': 'json'}, 'hello-world')
+    req = make_request(ROUTE_OBS, {'f': 'json'})
+    rsp_headers, code, response = api_.describe_processes(req, 'hello-world')
     assert code == 200
     assert rsp_headers['Content-Type'] == 'application/json'
 
     # Test for undefined process
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.describe_processes(
-        req_headers, {}, 'goodbye-world')
+    req = make_request(ROUTE_OBS, {})
+    rsp_headers, code, response = api_.describe_processes(req, 'goodbye-world')
     data = json.loads(response)
     assert code == 404
     assert data['code'] == 'NoSuchProcess'
@@ -810,7 +927,6 @@ def test_describe_processes(config, api_):
 
 
 def test_execute_process(config, api_):
-    req_headers = make_req_headers()
     req_body = {
         'inputs': [{
             'id': 'name',
@@ -861,24 +977,23 @@ def test_execute_process(config, api_):
     cleanup_jobs = set()
 
     # Test posting empty payload to existing process
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, '', 'hello-world')
+    req = make_request(ROUTE_OBS, {}, '')
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     data = json.loads(response)
     assert code == 400
     assert 'Location' not in rsp_headers
     assert data['code'] == 'MissingParameterValue'
 
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body), 'foo')
+    req = make_request(ROUTE_OBS, {}, req_body)
+    rsp_headers, code, response = api_.execute_process(req, 'foo')
 
     data = json.loads(response)
     assert code == 404
     assert 'Location' not in rsp_headers
     assert data['code'] == 'NoSuchProcess'
 
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body), 'hello-world')
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     data = json.loads(response)
     assert code == 200
@@ -890,8 +1005,8 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body_2), 'hello-world')
+    req = make_request(ROUTE_OBS, {}, req_body_2)
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     data = json.loads(response)
     assert code == 200
@@ -901,8 +1016,8 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body_3), 'hello-world')
+    req = make_request(ROUTE_OBS, {}, req_body_3)
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     data = json.loads(response)
     assert code == 200
@@ -912,8 +1027,8 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body_4), 'hello-world')
+    req = make_request(ROUTE_OBS, {}, req_body_4)
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     data = json.loads(response)
     assert code == 200
@@ -922,20 +1037,8 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body_5), 'hello-world')
-    data = json.loads(response)
-    assert code == 200
-    assert 'Location' in rsp_headers
-    assert data['code'] == 'InvalidParameterValue'
-    assert data['description'] == 'Error updating job'
-
-    cleanup_jobs.add(tuple(['hello-world',
-                            rsp_headers['Location'].split('/')[-1]]))
-
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body_6), 'hello-world')
-
+    req = make_request(ROUTE_OBS, {}, req_body_5)
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
     data = json.loads(response)
     assert code == 200
     assert 'Location' in rsp_headers
@@ -945,8 +1048,20 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body_7), 'hello-world')
+    req = make_request(ROUTE_OBS, {}, req_body_6)
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
+
+    data = json.loads(response)
+    assert code == 200
+    assert 'Location' in rsp_headers
+    assert data['code'] == 'InvalidParameterValue'
+    assert data['description'] == 'Error updating job'
+
+    cleanup_jobs.add(tuple(['hello-world',
+                            rsp_headers['Location'].split('/')[-1]]))
+
+    req = make_request(ROUTE_OBS, {}, req_body_7)
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     data = json.loads(response)
     assert code == 400
@@ -954,8 +1069,8 @@ def test_execute_process(config, api_):
     assert data['code'] == 'InvalidParameterValue'
     assert data['description'] == 'invalid request data'
 
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body_8), 'hello-world')
+    req = make_request(ROUTE_OBS, {}, req_body_8)
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     data = json.loads(response)
     assert code == 400
@@ -963,18 +1078,15 @@ def test_execute_process(config, api_):
     assert data['code'] == 'InvalidParameterValue'
     assert data['description'] == 'invalid request data'
 
-    # req_headers = make_req_headers()
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body), 'goodbye-world')
+    req = make_request(ROUTE_OBS, {}, req_body)
+    rsp_headers, code, response = api_.execute_process(req, 'goodbye-world')
 
     response = json.loads(response)
     assert code == 404
     assert 'Location' not in rsp_headers
     assert response['code'] == 'NoSuchProcess'
 
-    req_headers = make_req_headers()
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body), 'hello-world')
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     response = json.loads(response)
     assert code == 200
@@ -982,16 +1094,13 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    req_headers = make_req_headers()
-
     req_body['mode'] = 'async'
-    rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body), 'hello-world')
+    req = make_request(ROUTE_OBS, {}, req_body)
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     assert 'Location' in rsp_headers
     response = json.loads(response)
     assert isinstance(response, dict)
-
     assert code == 201
 
     cleanup_jobs.add(tuple(['hello-world',
@@ -1005,72 +1114,12 @@ def test_execute_process(config, api_):
         assert code == 200
 
 
-def test_check_format():
-    args = {'f': 'html'}
-
-    req_headers = {}
-
-    assert check_format({}, req_headers) is None
-
-    assert check_format(args, req_headers) == 'html'
-
-    args['f'] = 'json'
-    assert check_format(args, req_headers) == 'json'
-
-    args['f'] = 'jsonld'
-    assert check_format(args, req_headers) == 'jsonld'
-
-    args['f'] = 'html'
-    assert check_format(args, req_headers) == 'html'
-
-    req_headers['Accept'] = 'text/html'
-    assert check_format({}, req_headers) == 'html'
-
-    req_headers['Accept'] = 'application/json'
-    assert check_format({}, req_headers) == 'json'
-
-    req_headers['Accept'] = 'application/ld+json'
-    assert check_format({}, req_headers) == 'jsonld'
-
-    req_headers['accept'] = 'text/html'
-    assert check_format({}, req_headers) == 'html'
-
-    hh = 'text/html,application/xhtml+xml,application/xml;q=0.9,'
-
-    req_headers['Accept'] = hh
-    assert check_format({}, req_headers) == 'html'
-
-    req_headers['accept'] = hh
-    assert check_format({}, req_headers) == 'html'
-
-    req_headers = make_req_headers(HTTP_ACCEPT=hh)
-    assert check_format({}, req_headers) == 'html'
-
-    req_headers = make_req_headers(HTTP_ACCEPT='text/html')
-    assert check_format({}, req_headers) == 'html'
-
-    req_headers = make_req_headers(HTTP_ACCEPT='application/json')
-    assert check_format({}, req_headers) == 'json'
-
-    req_headers = make_req_headers(HTTP_ACCEPT='application/ld+json')
-    assert check_format({}, req_headers) == 'jsonld'
-
-    # Overrule HTTP content negotiation
-    args['f'] = 'html'
-    assert check_format(args, req_headers) == 'html'
-
-    req_headers = make_req_headers(HTTP_ACCEPT='text/html')
-    args['f'] = 'json'
-    assert check_format(args, req_headers) == 'json'
-
-
 def test_delete_process_job(api_):
     rsp_headers, code, response = api_.delete_process_job(
         'does-not-exist', 'does-not-exist')
 
     assert code == 404
 
-    req_headers = make_req_headers()
     req_body_sync = {
         'inputs': [{
             'id': 'name',
@@ -1086,8 +1135,9 @@ def test_delete_process_job(api_):
         }]
     }
 
+    req = make_request(ROUTE_OBS, {}, req_body_sync)
     rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body_sync), 'hello-world')
+        req, 'hello-world')
 
     data = json.loads(response)
     assert code == 200
@@ -1104,8 +1154,9 @@ def test_delete_process_job(api_):
         'hello-world', job_id)
     assert code == 404
 
+    req = make_request(ROUTE_OBS, {}, req_body_async)
     rsp_headers, code, response = api_.execute_process(
-        req_headers, {}, json.dumps(req_body_async), 'hello-world')
+        req, 'hello-world')
 
     assert code == 201
     assert 'Location' in rsp_headers

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -208,9 +208,9 @@ def test_apirequest(api_):
     # Test without user language setting (should use default)
     req = make_request(ROUTE_OBS, {})
     apireq = APIRequest(req, api_.locales)
-    assert apireq.raw_locale is None
+    assert apireq.raw_locale == 'en-US'
     assert apireq.locale.language == api_.default_locale.language
-    assert 'Content-Language' not in apireq.get_response_headers()
+    assert apireq.get_response_headers()['Content-Language'] == 'en-US'
 
 
 def test_api(config, api_, openapi):
@@ -1174,37 +1174,35 @@ def test_delete_process_job(api_):
 
 def test_get_collection_edr_query(config, api_):
     # no coords parameter
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {})
     rsp_headers, code, response = api_.get_collection_edr_query(
-        req_headers, {}, 'icoads-sst', instance=None, query_type='position')
+        req, 'icoads-sst', None, 'position')
     assert code == 400
 
     # bad query type
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {'coords': 'POINT(11 11)'})
     rsp_headers, code, response = api_.get_collection_edr_query(
-        req_headers, {'coords': 'POINT(11 11)'}, 'icoads-sst', instance=None,
-        query_type='corridor')
+        req, 'icoads-sst', None, 'corridor')
     assert code == 400
 
     # bad coords parameter
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {'coords': 'gah'})
     rsp_headers, code, response = api_.get_collection_edr_query(
-        req_headers, {'coords': 'gah'}, 'icoads-sst', instance=None,
-        query_type='position')
+        req, 'icoads-sst', None, 'position')
     assert code == 400
 
     # bad parameter-name parameter
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {
+        'coords': 'POINT(11 11)', 'parameter-name': 'bad'
+    })
     rsp_headers, code, response = api_.get_collection_edr_query(
-        req_headers, {'coords': 'POINT(11 11)', 'parameter-name': 'bad'},
-        'icoads-sst', instance=None, query_type='position')
+        req, 'icoads-sst', None, 'position')
     assert code == 400
 
     # all parameters
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {'coords': 'POINT(11 11)'})
     rsp_headers, code, response = api_.get_collection_edr_query(
-        req_headers, {'coords': 'POINT(11 11)'}, 'icoads-sst', instance=None,
-        query_type='position')
+        req, 'icoads-sst', None, 'position')
     assert code == 200
 
     data = json.loads(response)
@@ -1225,10 +1223,11 @@ def test_get_collection_edr_query(config, api_):
     assert parameters == ['AIRT', 'SST', 'UWND', 'VWND']
 
     # single parameter
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {
+        'coords': 'POINT(11 11)', 'parameter-name': 'SST'
+    })
     rsp_headers, code, response = api_.get_collection_edr_query(
-        req_headers, {'coords': 'POINT(11 11)', 'parameter-name': 'SST'},
-        'icoads-sst', instance=None, query_type='position')
+        req, 'icoads-sst', None, 'position')
     assert code == 200
 
     data = json.loads(response)
@@ -1237,25 +1236,20 @@ def test_get_collection_edr_query(config, api_):
     assert list(data['parameters'].keys())[0] == 'SST'
 
     # some data
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {
+        'coords': 'POINT(11 11)', 'datetime': '2000-01-16'
+    })
     rsp_headers, code, response = api_.get_collection_edr_query(
-        req_headers, {'coords': 'POINT(11 11)', 'datetime': '2000-01-16'},
-        'icoads-sst', instance=None, query_type='position')
+        req, 'icoads-sst', None, 'position')
     assert code == 200
 
     # no data
-    req_headers = make_req_headers()
+    req = make_request(ROUTE_OBS, {
+        'coords': 'POINT(11 11)', 'datetime': '2000-01-17'
+    })
     rsp_headers, code, response = api_.get_collection_edr_query(
-        req_headers, {'coords': 'POINT(11 11)', 'datetime': '2000-01-17'},
-        'icoads-sst', instance=None, query_type='position')
+        req, 'icoads-sst', None, 'position')
     assert code == 204
-
-    # no data
-#    req_headers = make_req_headers()
-#    rsp_headers, code, response = api_.get_collection_edr_query(
-#        req_headers, {'coords': 'POINT(11 11)', 'datetime': '2000-01-15'},
-#        'icoads-sst', instance=None, query_type='position')
-#    assert code == 204
 
 
 def test_validate_bbox():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -68,22 +68,6 @@ def make_request(route: str, params: dict, data=None, **headers):
     return request
 
 
-def make_req_headers(**kwargs):
-    environ = create_environ('/collections/obs/items',
-                             'http://localhost:5000/')
-    environ.update(kwargs)
-    request = Request(environ)
-    return request.headers
-
-
-def make_lakes_req_headers(**kwargs):
-    environ = create_environ('/collections/lakes/items',
-                             'http://localhost:5000/')
-    environ.update(kwargs)
-    request = Request(environ)
-    return request.headers
-
-
 @pytest.fixture()
 def config():
     with open(get_test_file_path('pygeoapi-test-config.yml')) as fh:

--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -1,0 +1,126 @@
+# =================================================================
+#
+# Authors: Sander Schaminee <sander.schaminee@geocat.net>
+#
+# Copyright (c) 2021 GeoCat BV
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from babel import Locale
+from pygeoapi import l10n
+
+import pytest
+
+
+def test_str2locale():
+    us_locale = Locale.parse('en_US')
+    assert l10n.str2locale('en') == Locale.parse('en')
+    assert l10n.str2locale('en_US') == us_locale
+    assert l10n.str2locale('en-US') == us_locale
+    assert l10n.str2locale('eng_CA') == Locale.parse('en_CA')
+    assert l10n.str2locale(' fr-CH ') == Locale.parse('fr_CH')
+    assert l10n.str2locale(us_locale) is us_locale
+
+    assert l10n.str2locale(None, True) is None
+    assert l10n.str2locale(42, True) is None
+    assert l10n.str2locale('is_BS', True) is None
+
+    with pytest.raises(l10n.LocaleError):
+        for v in ('', None, 1, 42.0, 'is_BS', 'eng;CAN'):
+            l10n.str2locale(v)
+
+
+def test_locale2str():
+    assert l10n.locale2str(Locale.parse('en_US')) == 'en-US'
+    assert l10n.locale2str(Locale.parse('fr')) == 'fr'
+
+    with pytest.raises(l10n.LocaleError):
+        for v in (None, 1, 42.0, 'is_BS', object()):
+            l10n.locale2str(v)  # noqa
+
+
+def test_bestmatch():
+    assert l10n.best_match('de', ('en',)) == Locale('en')
+    assert l10n.best_match(None, ['en', 'de']) == Locale('en')  # noqa
+    assert l10n.best_match('', ['en', 'de']) == Locale('en')
+    assert l10n.best_match('de-DE', ['en', 'de']) == Locale('de')
+    assert l10n.best_match('de-DE, en', ['en', 'de']) == Locale('de')
+    assert l10n.best_match('de, en', ['en_US', 'de-DE']) == Locale.parse('de_DE')  # noqa
+
+    assert l10n.best_match(Locale('de'), ['nl', 'de']) == Locale('de')
+
+    accept = "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5"
+    assert l10n.best_match(accept, ['fr', 'en']) == Locale('fr')
+    assert l10n.best_match(accept, ['it', 'de']) == Locale('de')
+    assert l10n.best_match(accept, ['fr-BE', 'fr']) == Locale('fr')
+    assert l10n.best_match(accept, ['fr-BE', 'fr-FR']) == Locale.parse('fr_BE')
+    assert l10n.best_match(accept, ['fr-BE', 'fr-FR']) == Locale.parse('fr_BE')
+    assert l10n.best_match(accept, ['it', 'es']) == Locale('it')
+    assert l10n.best_match(accept, ['it', 'es']) == Locale('it')
+    assert l10n.best_match(accept, ('it', 'es')) == Locale('it')
+
+    with pytest.raises(l10n.LocaleError):
+        l10n.best_match(accept, [])
+        l10n.best_match(accept, None)
+        l10n.best_match(accept, 42)
+        l10n.best_match(accept, ['is_BS'])
+
+
+@pytest.fixture()
+def language_struct():
+    return {k: Locale.parse(k).display_name for k in (
+        'en', 'fr', 'en_US', 'fr_BE', 'alb', 'nl_BE'
+    )}
+
+
+@pytest.fixture()
+def nonlanguage_struct():
+    return {
+        None: 'empty key',
+        42: 'numeric key',
+        'fla': 'non-language key'
+    }
+
+
+def test_translate(language_struct, nonlanguage_struct):
+    assert l10n.translate({}, 'en-US') == {}
+    assert l10n.translate(42, 'fr') == 42
+    assert l10n.translate(None, 'de') is None
+
+    assert l10n.translate(nonlanguage_struct, 'fr') == nonlanguage_struct
+    assert l10n.translate(nonlanguage_struct, 'fla') == 'non-language key'
+
+    assert l10n.translate(language_struct, 'en') == 'English'
+    assert l10n.translate(language_struct, 'en-US') == 'English (United States)'  # noqa
+    assert l10n.translate(language_struct, 'sq_AL') == Locale.parse('alb').display_name  # noqa
+    assert l10n.translate(language_struct, 'fr_CH') == Locale.parse('fr').display_name  # noqa
+    assert l10n.translate(language_struct, 'nl') == Locale.parse('nl_BE').display_name  # noqa
+    assert l10n.translate(language_struct, 'de') == 'English'
+
+    assert l10n.translate(language_struct, Locale('en')) == 'English'
+    assert l10n.translate(language_struct, Locale.parse('en_US')) == 'English (United States)'  # noqa
+
+    with pytest.raises(l10n.LocaleError):
+        l10n.translate(language_struct, None)
+        l10n.translate(language_struct, 42)


### PR DESCRIPTION
Enables multilingual support for pygeoapi (core and plugins). Refer to issue #100 for discussion.

### Work done
- [x] Server-independent language check (from request `l` parameter or `Accept-Language` header)
- [x] Make providers, processes and formatters language-aware
- [x] Add translate functionality for JSON language structs based on the current language setting (best match)
- [x] Support responses with `Content-Language` header
- [x] Multilingual metadata in configuration
- [x] Add documentation 
- [ ] Handle `hreflang` in links in configuration

I've decided to push the last item to a next PR. This PR is already big enough...
The generation/processing of all API links should be done in a separate function, imho (see "Upcoming PRs" below).

### What does it do?
Users can now append a `l=fr` parameter to a pygeoapi URL and pygeoapi will return the requested page in French (for example). If the user connects to pygeoapi using a browser where the language has been set to French, the requested page will automatically be rendered in French (without the `l=fr` parameter), because the browser sent an `Accept-Language` header along with the request. However, this can always be overridden again using the `l` query parameter.

### Remarks
- This PR is quite large and mainly impacts the API core (and not so much the plugins). Most of the language support stuff revolves around the new `l10n` (localization) module, which turns the requested language (e.g. "fr", "fr-CH" or "fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5" into a best matching Babel `Locale` object. These `Locale` objects integrate well with Jinja2 templates using the `i18n` extension;
- The only text that is translatable at this moment, are the text strings (names, titles, descriptions, etc.) in the server configuration. The `pygeoapi-config.yaml` now contains some example language structs for US English and Canadian French (more translations coming up);
- In order to efficiently pass on language settings, I decided to make all API method calls more consistent, so `api.py` has undergone quite a lot of refactoring. All methods that require `Request` object data are now decorated by the `@pre_process` function, which converts the incoming Flask/Starlette `Request` into a (newly introduced) `APIRequest` instance. This class processes headers and query parameters to extract the required properties for the API methods. This results in less boilerplate and cleaner API method signatures, while still being explicit;
- Developers of third-party providers and other plugins should add a `requested_locale=None` argument to the `__init__` method of their plugin, and pass the `requested_locale` to the `super().__init__()` call as a second argument. This is all that needs to be done to make the plugin work again and to make it language-aware. However, it is up to the developer to implement the logic to query/process data and return it in the requested language. Please refer to the provided [Sphinx documentation](https://github.com/GeoSander/pygeoapi/blob/multilingual/docs/source/language.rst) for more info.

### Follow-ups
This PR provides the foundation to make pygeoapi language-aware. However, for full language support, there are still some things that need to be done.

Upcoming PRs should address:
- Links generated by pygeoapi: the links underneath each collection item (for example) should become language-aware, i.e. internal link URLs should be appended with a `l=<language>` query parameter if the current page also was requested using that parameter (note: the `add_locale` function in the `l10n` module can be used for that.
Internal links should also set the `hreflang` property to the user-specified language. For external links, this only applies if the server speaks that language (hard to figure out).
- HTML templates: all hard-coded translatable strings in the templates need to be stored in separate files and processed by `pybabel`. so they can be managed by a translation tool (e.g. Transifex);
- The Jinja2 `i18n` extension needs to be configured and the HTML templates need to be modified so that Jinja2 and Babel/gettext can inject the translations;
- All core plugins (e.g. providers) are now language-aware, but the ones that *can* support multiple languages (i.e. the plugin backend supports it) should still implement functionality for it. The `l10n` module provides the necessary tools to do so;
- Other suggestions...?

Some useful links concerning Jinja2/Babel/Transifex:
- https://www.mattlayman.com/blog/2015/i18n/
- https://phrase.com/blog/posts/i18n-advantages-babel-python/#Integration_with_Jinja2_templates
- https://jinja.palletsprojects.com/en/2.11.x/templates/#i18n-in-templates