### PR TITLE
add support for OpenAPI document as JSON

### DIFF
--- a/docs/source/administration.rst
+++ b/docs/source/administration.rst
@@ -27,6 +27,15 @@ This will dump the OpenAPI document as YAML to your system's ``stdout``.  To sav
 
    pygeoapi generate-openapi-document -c /path/to/my-pygeoapi-config.yml > /path/to/my-pygeoapi-openapi.yml
 
+To generate the OpenAPI document as JSON, run:
+
+.. code-block:: bash
+
+   pygeoapi generate-openapi-document -c /path/to/my-pygeoapi-config.yml -f json > /path/to/my-pygeoapi-openapi.json
+
+.. note::
+   Generate as YAML or JSON?  If your OpenAPI YAML definition is slow to render as JSON,
+   saving as JSON to disk will help with performance at run-time.
 
 .. note::
    The OpenAPI document provides detailed information on query parameters, and dataset
@@ -49,6 +58,13 @@ the Python one-liner per below:
    python -c 'import yaml, sys; yaml.safe_load(sys.stdin)' < /path/to/my-pygeoapi-config.yml
    python -c 'import yaml, sys; yaml.safe_load(sys.stdin)' < /path/to/my-pygeoapi-openapi.yml
 
+To ensure your OpenAPI JSON is correctly formatted, you can use any JSON validator, or try
+the Python one-liner per below:
+
+.. code-block:: bash
+
+   cat /path/to/my-pygeoapi-openapi.json | python -m json.tool
+
 
 Setting system environment variables
 ------------------------------------
@@ -61,6 +77,8 @@ In UNIX:
 
     export PYGEOAPI_CONFIG=/path/to/my-pygeoapi-config.yml
     export PYGEOAPI_OPENAPI=/path/to/my-pygeoapi-openapi.yml
+    # or if OpenAPI JSON
+    export PYGEOAPI_OPENAPI=/path/to/my-pygeoapi-openapi.json
 
 In Windows:
 
@@ -68,6 +86,9 @@ In Windows:
 
     set PYGEOAPI_CONFIG=/path/to/my-pygeoapi-config.yml
     set PYGEOAPI_OPENAPI=/path/to/my-pygeoapi-openapi.yml
+    # or if OpenAPI JSON
+    set PYGEOAPI_OPENAPI=/path/to/my-pygeoapi-openapi.json
+
 
 Summary
 -------

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -272,9 +272,9 @@ class API:
             return self.get_exception(
                 400, headers_, format_, 'InvalidParameterValue', msg)
 
-        path = '/'.join([self.config['server']['url'].rstrip('/'), 'openapi'])
-
         if format_ == 'html':
+            path = '/'.join([self.config['server']['url'].rstrip('/'),
+                            'openapi'])
             data = {
                 'openapi-document-path': path
             }
@@ -285,7 +285,10 @@ class API:
         headers_['Content-Type'] = \
             'application/vnd.oai.openapi+json;version=3.0'
 
-        return headers_, 200, to_json(openapi, self.pretty_print)
+        if isinstance(openapi, dict):
+            return headers_, 200, to_json(openapi, self.pretty_print)
+        else:
+            return headers_, 200, openapi.read()
 
     @pre_process
     def conformance(self, headers_, format_):

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -121,18 +121,22 @@ def openapi():
 
     :returns: HTTP response
     """
+
     with open(os.environ.get('PYGEOAPI_OPENAPI'), encoding='utf8') as ff:
-        openapi = yaml_load(ff)
+        if os.environ.get('PYGEOAPI_OPENAPI').endswith(('.yaml', '.yml')):
+            openapi = yaml_load(ff)
+        else:  # JSON file, do not transform
+            openapi = ff
 
-    headers, status_code, content = api_.openapi(request.headers, request.args,
-                                                 openapi)
+        headers, status_code, content = api_.openapi(
+            request.headers, request.args, openapi)
 
-    response = make_response(content, status_code)
+        response = make_response(content, status_code)
 
-    if headers:
-        response.headers = headers
+        if headers:
+            response.headers = headers
 
-    return response
+        return response
 
 
 @BLUEPRINT.route('/conformance')

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -38,7 +38,7 @@ from pygeoapi import __version__
 from pygeoapi.plugin import load_plugin
 from pygeoapi.provider.base import ProviderTypeError
 from pygeoapi.util import (filter_dict_by_key_value, get_provider_by_type,
-                           filter_providers_by_type, yaml_load)
+                           filter_providers_by_type, to_json, yaml_load)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -938,11 +938,17 @@ def get_oas(cfg, version='3.0'):
 @click.command('generate-openapi-document')
 @click.pass_context
 @click.option('--config', '-c', 'config_file', help='configuration file')
-def generate_openapi_document(ctx, config_file):
+@click.option('--format', '-f', 'format_', type=click.Choice(['json', 'yaml']),
+              default='yaml', help='output format (json|yaml)')
+def generate_openapi_document(ctx, config_file, format_='yaml'):
     """Generate OpenAPI Document"""
 
     if config_file is None:
         raise click.ClickException('--config/-c required')
     with open(config_file) as ff:
         s = yaml_load(ff)
-        click.echo(yaml.safe_dump(get_oas(s), default_flow_style=False))
+        pretty_print = s['server'].get('pretty_print', False)
+        if format_ == 'yaml':
+            click.echo(yaml.safe_dump(get_oas(s), default_flow_style=False))
+        else:
+            click.echo(to_json(get_oas(s), pretty=pretty_print))

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -103,16 +103,20 @@ async def openapi(request: Request):
     """
 
     with open(os.environ.get('PYGEOAPI_OPENAPI'), encoding='utf8') as ff:
-        openapi = yaml_load(ff)
+        if os.environ.get('PYGEOAPI_OPENAPI').endswith(('.yaml', '.yml')):
+            openapi = yaml_load(ff)
+        else:  # JSON file, do not transform
+            openapi = ff
 
-    headers, status_code, content = api_.openapi(
-        request.headers, request.query_params, openapi)
+        headers, status_code, content = api_.openapi(
+            request.headers, request.query_params, openapi)
 
-    response = Response(content=content, status_code=status_code)
-    if headers:
-        response.headers.update(headers)
+        response = Response(content=content, status_code=status_code)
 
-    return response
+        if headers:
+            response.headers.update(headers)
+
+        return response
 
 
 @app.route('/conformance')


### PR DESCRIPTION
cc @jvanulden

This PR provides functionality for generating the OpenAPI document as JSON (in addition to the default YAML output).  

Here's why:

In pygeoapi, we use a modified YAML parser which includes support for environment variables in the YAML itself.  See https://github.com/geopython/pygeoapi/blob/master/pygeoapi/util.py#L105

This works great in most current cases, but with huge YAMLs this suffers performance at runtime.  This is because the modified YAML parser we use in `/openapi?f=json` mode returns JSON, not YAML, hence a transformation on the fly.

As a result, this PR updates `pygeoapi generate-openapi-description` to accept an `-f json` parameter (default is still YAML), where a JSON would be written to disk.

Then, pygeoapi will check at runtime if `PYGEOAPI_OPENAPI` is a YAML or JSON file via checking for the file extension.  If the former, then current functionality.  If the latter, then just dump the JSON file as is with no transformation (faster).