### PR TITLE
improve MIME type handling for raw payload responses

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2014,7 +2014,7 @@ tiles/{{{}}}/{{{}}}/{{{}}}/{{{}}}?f=mvt'
 
         try:
             LOGGER.debug('Executing process')
-            outputs, status = self.manager.execute_process(
+            mime_type, outputs, status = self.manager.execute_process(
                 process, job_id, data_dict, is_async)
         except ProcessorExecuteError as err:
             LOGGER.error(err)
@@ -2025,11 +2025,9 @@ tiles/{{{}}}/{{{}}}/{{{}}}/{{{}}}?f=mvt'
         if status == JobStatus.failed:
             response = outputs
 
-        ct = process.metadata['outputs'][0]['output']['formats'][0]['mimeType']
-
         if data.get('response', 'document') == 'raw':
-            headers_['Content-Type'] = ct
-            if format_ == 'json':
+            headers_['Content-Type'] = mime_type
+            if 'json' in mime_type:
                 response = to_json(outputs)
             else:
                 response = outputs

--- a/pygeoapi/process/base.py
+++ b/pygeoapi/process/base.py
@@ -51,7 +51,7 @@ class BaseProcessor:
         """
         execute the process
 
-        :returns: dict of process response
+        :returns: tuple of MIME type and process response
         """
 
         raise NotImplementedError()

--- a/pygeoapi/process/hello_world.py
+++ b/pygeoapi/process/hello_world.py
@@ -125,6 +125,7 @@ class HelloWorldProcessor(BaseProcessor):
 
     def execute(self, data):
 
+        mimetype = 'application/json'
         name = data.get('name', None)
 
         if name is None:
@@ -137,7 +138,7 @@ class HelloWorldProcessor(BaseProcessor):
             'value': value
         }]
 
-        return outputs
+        return mimetype, outputs
 
     def __repr__(self):
         return '<HelloWorldProcessor> {}'.format(self.name)

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -148,7 +148,7 @@ class BaseManager:
             args=(p, job_id, data_dict)
         )
         _process.start()
-        return None, JobStatus.accepted
+        return 'application/json', None, JobStatus.accepted
 
     def _execute_handler_sync(self, p, job_id, data_dict):
         """
@@ -162,7 +162,7 @@ class BaseManager:
         :param job_id: job identifier
         :param data_dict: `dict` of data parameters
 
-        :returns: tuple of response payload and status
+        :returns: tuple of MIME type, response payload and status
         """
 
         process_id = p.metadata['id']
@@ -190,10 +190,8 @@ class BaseManager:
             else:
                 job_filename = None
 
-            jfmt = p.metadata['outputs'][0]['output']['formats'][0]['mimeType']
-
             current_status = JobStatus.running
-            outputs = p.execute(data_dict)
+            jfmt, outputs = p.execute(data_dict)
 
             self.update_job(process_id, job_id, {
                 'status': current_status.value,
@@ -245,9 +243,11 @@ class BaseManager:
                 'message': f'{code}: {outputs["description"]}'
             }
 
+            jfmt = 'application/json'
+
             self.update_job(process_id, job_id, job_metadata)
 
-        return outputs, current_status
+        return jfmt, outputs, current_status
 
     def execute_process(self, p, job_id, data_dict, is_async=False):
         """
@@ -258,7 +258,7 @@ class BaseManager:
         :param data_dict: `dict` of data parameters
         :param is_async: `bool` specifying sync or async processing.
 
-        :returns: tuple of response payload and status
+        :returns: tuple of MIME type, response payload and status
         """
 
         if not is_async:

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -74,6 +74,8 @@ class DummyManager(BaseManager):
         :returns: tuple of MIME type, response payload and status
         """
 
+        jfmt = 'application/json'
+
         if is_async:
             LOGGER.debug('Dummy manager does not support asynchronous')
             LOGGER.debug('Forcing synchronous execution')

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -71,7 +71,7 @@ class DummyManager(BaseManager):
         :param data_dict: `dict` of data parameters
         :param is_async: `bool` specifying sync or async processing.
 
-        :returns: tuple of response payload and status
+        :returns: tuple of MIME type, response payload and status
         """
 
         if is_async:
@@ -79,7 +79,7 @@ class DummyManager(BaseManager):
             LOGGER.debug('Forcing synchronous execution')
 
         try:
-            outputs = p.execute(data_dict)
+            jfmt, outputs = p.execute(data_dict)
             current_status = JobStatus.successful
         except Exception as err:
             outputs = {
@@ -89,7 +89,7 @@ class DummyManager(BaseManager):
             current_status = JobStatus.failed
             LOGGER.error(err)
 
-        return outputs, current_status
+        return jfmt, outputs, current_status
 
     def __repr__(self):
         return '<DummyManager> {}'.format(self.name)


### PR DESCRIPTION
This PR fixes MIME type handling for custom processes that return non-JSON responses.  pygeoapi requires this information to correctly set the response MIME type when OAProc clients invoke a job with `"response": "raw"` in the request.

As a result custom processes' `execute` functions must return a tuple of the mime type and the response payload.

cc @alpha-beta-soup @totycro 