### PR TITLE
Handle `null` geometries in PostgreSQL provider

### DIFF
--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -389,8 +389,10 @@ class PostgreSQLProvider(BaseProvider):
             feature = {
                 'type': 'Feature'
             }
-            feature["geometry"] = json.loads(
-                rd.pop('st_asgeojson'))
+
+            geom = rd.pop('st_asgeojson')
+
+            feature['geometry'] = json.loads(geom) if geom is not None else None
 
             feature['properties'] = rd
             feature['id'] = feature['properties'].get(self.id_field)


### PR DESCRIPTION
If the geometry value is `null`, then a JSON serialization error occurs
because `None` by itself is not JSON serializable.