### PR TITLE
Added missing parameters on the openapi definition of the get an observations tile request

### DIFF
--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -42,7 +42,7 @@ server:
       # path: /path/to/Jinja2/templates
       # static: /path/to/static/folder # css/js/img
     map:
-        url: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
+        url: https://tile.openstreetmap.org/{z}/{x}/{y}.png
         attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
 #    manager:
 #        name: TinyDB

--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -42,7 +42,7 @@ server:
       # path: /path/to/Jinja2/templates
       # static: /path/to/static/folder # css/js/img
     map:
-        url: https://tile.openstreetmap.org/{z}/{x}/{y}.png
+        url: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
         attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
 #    manager:
 #        name: TinyDB

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -50,6 +50,7 @@ OPENAPI_YAML = {
     'oapimt': 'https://raw.githubusercontent.com/opengeospatial/ogcapi-tiles/master/openapi/swaggerhub/map-tiles.yaml',  # noqa
     'oapir': 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi',  # noqa
     'oaedr': 'https://raw.githubusercontent.com/opengeospatial/ogcapi-environmental-data-retrieval/master/candidate-standard/openapi', # noqa
+    'oat': 'https://raw.githubusercontent.com/opengeospatial/ogcapi-tiles/master/openapi/swaggerHubUnresolved/ogc-api-tiles.yaml', # noqa
 }
 
 
@@ -695,7 +696,12 @@ def get_oas_30(cfg):
                     'description': v['description'],
                     'tags': [k],
                     'operationId': 'get{}Tiles'.format(k.capitalize()),
-                    'parameters': [{
+                    'parameters': [ 
+                        {'$ref': '{}#/components/parameters/tileMatrixSetId'.format(OPENAPI_YAML['oat'])},  # noqa
+                        {'$ref': '{}#/components/parameters/tileMatrix'.format(OPENAPI_YAML['oat'])},  # noqa
+                        {'$ref': '{}#/components/parameters/tileRow'.format(OPENAPI_YAML['oat'])},  # noqa
+                        {'$ref': '{}#/components/parameters/tileCol'.format(OPENAPI_YAML['oat'])},  # noqa
+                        {
                         'name': 'f',
                         'in': 'query',
                         'description': 'The optional f parameter indicates the output format which the server shall provide as part of the response document.',  # noqa


### PR DESCRIPTION
The parameters were:
- tileMatrixSetId
- tileMatrixSet
- tileCol
- tileCol

I also had to add an OpenApi parameter definition file:
https://raw.githubusercontent.com/opengeospatial/ogcapi-tiles/master/openapi/swaggerHubUnresolved/ogc-api-tiles.yaml
