### PR TITLE
Changed default background map to OSM

### DIFF
--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -42,7 +42,7 @@ server:
       # path: /path/to/Jinja2/templates
       # static: /path/to/static/folder # css/js/img
     map:
-        url: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
+        url: https://tile.openstreetmap.org/{z}/{x}/{y}.png
         attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
 #    manager:
 #        name: TinyDB


### PR DESCRIPTION
Default map provider (maps.wikimedia.org) tile requests are returning HTTP 403 response codes.

Reference to this issue:
https://github.com/geopython/pygeoapi/issues/567