### PR TITLE
Simplify API tests

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -189,8 +189,8 @@ class APIRequest:
           if not request.is_valid(['xml']):
              return self.get_format_exception(request)
 
-          force_type = 'application/xml' if request.format == 'xml' else None
-          headers = request.get_response_headers(force_type)
+          content_type = 'application/xml' if request.format == 'xml' else None
+          headers = request.get_response_headers(content_type)
 
           # generate response_body here
 


### PR DESCRIPTION
Removes the path (route) argument from the `create_environ` call, as it is currently not used and is redundant/unclear.
Also fixes a little find/replace issue from #664.
cc @tomkralidis 