### PR TITLE
Fix SQLite provider for GPKG with multiple layers

### DIFF
--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -212,11 +212,11 @@ class SQLiteGPKGProvider(BaseProvider):
         if self.application_id:
             cursor.execute("SELECT AutoGPKGStart()")
             result = cursor.fetchall()
-            if result[0][0] == 1:
+            if result[0][0] >= 1:
                 LOGGER.info("Loaded Geopackage support")
             else:
                 LOGGER.info("SELECT AutoGPKGStart() returned 0." +
-                            "Detected GPKG but couldnt load support")
+                            "Detected GPKG but couldn't load support")
                 raise InvalidPluginError
 
         if self.application_id:


### PR DESCRIPTION
Running SELECT AutoGPKGStart(); returns the number of layers in a GPKG
file.
Therefore, only 0 is an invalid value which should raise an error.

An example GPKG can be provided for testing purposes, if needed.

Resolves #519.