### PR TITLE
Add missing ports to first docker-compose example

### DIFF
--- a/docs/source/running-with-docker.rst
+++ b/docs/source/running-with-docker.rst
@@ -57,6 +57,8 @@ For a cleaner approach, You can use ``docker-compose`` as per below:
        image: geopython/pygeoapi:latest
        volumes:
          - ./my.config.yml:/pygeoapi/local.config.yml
+       ports:
+         - "5000:80"
 
 Or you can create a ``Dockerfile`` extending the base image and **copy** in your configuration:
 


### PR DESCRIPTION
This was present in the second example but should also be needed for the first one.