### PR TITLE
fix CI by pinning to pandas 1.2.5

### DIFF
--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -2,7 +2,8 @@ elasticsearch==7.1.0
 fiona
 #GDAL>=3.0.0
 netCDF4
-pandas==1.2.5
+pandas; python_version < '3.7'
+pandas==1.2.5; python_version >= '3.7'
 psycopg2-binary==2.8.4
 pygeometa
 pymongo==3.10.1

--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -2,6 +2,7 @@ elasticsearch==7.1.0
 fiona
 #GDAL>=3.0.0
 netCDF4
+pandas==1.2.5
 psycopg2-binary==2.8.4
 pygeometa
 pymongo==3.10.1

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -58,7 +58,7 @@ def test_query_datastreams(config):
     results = p.query()
     assert len(results['features']) == 10
     assert results['numberReturned'] == 10
-    assert len(results['features'][0]['properties']['Observations']) == 18
+    assert len(results['features'][0]['properties']['Observations']) == 19
 
     assert results['features'][0]['geometry']['coordinates'][0] == -105.581
     assert results['features'][0]['geometry']['coordinates'][1] == 36.713

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -58,7 +58,7 @@ def test_query_datastreams(config):
     results = p.query()
     assert len(results['features']) == 10
     assert results['numberReturned'] == 10
-    assert len(results['features'][0]['properties']['Observations']) == 19
+    assert len(results['features'][0]['properties']['Observations']) == 18
 
     assert results['features'][0]['geometry']['coordinates'][0] == -105.581
     assert results['features'][0]['geometry']['coordinates'][1] == 36.713


### PR DESCRIPTION
This PR pins to pandas 1.2.5 as a resut of an issue introduced when using pandas 1.3.1:

```
[2021-07-19T22:45:15Z] {/Users/tkralidi/Dev/pygeoapi/lib/python3.7/site-packages/pygeoapi-0.11.dev0-py3.7.egg/pygeoapi/provider/xarray_.py:262} WARNING - _maybe_cast_slice_bound() missing 1 required positional argument: 'kind'
```