### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# pygeoapi Security Policy
+
+## Supported Versions
+
+Security/vulnerability reports **should not** be submitted through GitHub issues or public discussions, but instead please send your report 
+to **tomkralidis nospam @ gmail.com** (remove the blanks and ‘nospam’).  
+
+Please follow the [contributor guidelines](https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md) when submitting a vulnerability report.
+
+## Supported Versions
+
+The pygeoapi Project Steering Committee (PSC) will release patches for security vulnerabilities for the following versions:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.10.x  | :white_check_mark: |
+| < 0.10  | :x:                |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 Security/vulnerability reports **should not** be submitted through GitHub issues or public discussions, but instead please send your report 
-to **tomkralidis nospam @ gmail.com** (remove the blanks and ‘nospam’).  
+to **tomkralidis nospam @ gmail.com** (remove the blanks and 'nospam').  
 
 Please follow the [contributor guidelines](https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md) when submitting a vulnerability report.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 Security/vulnerability reports **should not** be submitted through GitHub issues or public discussions, but instead please send your report 
-to **tomkralidis nospam @ gmail.com** (remove the blanks and 'nospam').  
+to **geopython-security nospam @ lists.osgeo.org** (remove the blanks and 'nospam').  
 
 Please follow the [contributor guidelines](https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md) when submitting a vulnerability report.
 


### PR DESCRIPTION
FYI, per https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository. Thanks to @jmckenna for the [inspiration](https://lists.osgeo.org/pipermail/mapserver-dev/2021-July/016572.html).

Interested in folks' feedback here about the contact point.  I put myself only because we don't have a dedicated security/private email address.  Should we?  Or is this too much overhead?  I also thought of using [OSGeo's security-priv](https://trac.osgeo.org/osgeo/ticket/1512), but non-members won't be able to send email.  I would also prefer someone else as the contact (or at least two PSC members).