### PR TITLE
Fixes #750, retrieval of path attribute in starlette

### DIFF
--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -445,7 +445,7 @@ async def get_collection_edr_query(request: Request, collection_id=None, instanc
     if 'instance_id' in request.path_params:
         instance_id = request.path_params['instance_id']
 
-    query_type = request.path.split('/')[-1]  # noqa
+    query_type = request["path"].split('/')[-1]  # noqa
     return get_response(api_.get_collection_edr_query(request, collection_id,
                                                       instance_id, query_type))
 


### PR DESCRIPTION
Fixes the problem described in #750. If this worked previously, starlette must have had a different access to the `path` attribute. Otherwise this might have been copied from Flask? 

The change brings the code in accordance to the [(current) starlette API](https://www.starlette.io/requests/):
> For instance: request['path'] will return the ASGI path.