### PR TITLE
update OAProc execute handling

### DIFF
--- a/docs/source/data-publishing/ogcapi-processes.rst
+++ b/docs/source/data-publishing/ogcapi-processes.rst
@@ -66,8 +66,10 @@ Processing examples
   - http://localhost:5000/processes/hello-world/jobs
 - execute a job for the ``hello-world`` process
   - ``curl -X POST "http://localhost:5000/processes/hello-world/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"name\": \"hi there2\"}}"``
-- execute a job for the ``hello-world`` process with a raw response
-  - ``curl -X POST "http://localhost:5000/processes/hello-world/execution?response=raw" -H "Content-Type: application/json" -d "{\"inputs\":{\"name\": \"hi there2\"}}"``
+- execute a job for the ``hello-world`` process with a raw response (default)
+  - ``curl -X POST "http://localhost:5000/processes/hello-world/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"name\": \"hi there2\"}}"``
+- execute a job for the ``hello-world`` process with a response document
+  - ``curl -X POST "http://localhost:5000/processes/hello-world/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"name\": \"hi there2\"},\"response\":\"document\"}"``
 - execute a job for the ``hello-world`` process in asynchronous mode
   - ``curl -X POST "http://localhost:5000/processes/hello-world/execution" -H "Content-Type: application/json" -d "{\"mode\": \"async\", \"inputs\":{\"name\": \"hi there2\"}}"``
 

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2672,7 +2672,7 @@ class API:
         if status == JobStatus.failed:
             response = outputs
 
-        if data.get('response', 'document') == 'raw':
+        if data.get('response', 'raw') == 'raw':
             headers['Content-Type'] = mime_type
             if F_JSON in mime_type:
                 response = to_json(outputs)

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2674,13 +2674,10 @@ class API:
 
         if data.get('response', 'raw') == 'raw':
             headers['Content-Type'] = mime_type
-            if F_JSON in mime_type:
-                response = to_json(outputs)
-            else:
-                response = outputs
+            response = outputs
 
         elif status != JobStatus.failed and not is_async:
-            response['outputs'] = outputs
+            response['outputs'] = [outputs]
 
         if is_async:
             http_status = 201

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -929,17 +929,6 @@ def get_oas_30(cfg):
                     'description': md_desc,
                     'tags': [name],
                     'operationId': 'execute{}Job'.format(name.capitalize()),
-                    'parameters': [{
-                        'name': 'response',
-                        'in': 'query',
-                        'description': 'Response type',
-                        'required': False,
-                        'schema': {
-                            'type': 'string',
-                            'enum': ['raw', 'document'],
-                            'default': 'document'
-                        }
-                    }],
                     'responses': {
                         '200': {'$ref': '#/components/responses/200'},
                         '201': {'$ref': '{}/responses/ExecuteAsync.yaml'.format(OPENAPI_YAML['oapip'])},  # noqa

--- a/pygeoapi/process/hello_world.py
+++ b/pygeoapi/process/hello_world.py
@@ -127,10 +127,10 @@ class HelloWorldProcessor(BaseProcessor):
 
         value = 'Hello {}! {}'.format(name, data.get('message', '')).strip()
 
-        outputs = [{
+        outputs = {
             'id': 'echo',
             'value': value
-        }]
+        }
 
         return mimetype, outputs
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1246,7 +1246,7 @@ def test_delete_process_job(api_):
     data = json.loads(response)
     assert code == 200
     assert 'Location' in rsp_headers
-    assert data['outputs'][0]['value'] == 'Hello Sync Test Deletion!'
+    assert data['value'] == 'Hello Sync Test Deletion!'
 
     job_id = rsp_headers['Location'].split('/')[-1]
     rsp_headers, code, response = api_.delete_process_job(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1104,14 +1104,11 @@ def test_execute_process(config, api_):
 
     rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
-    print("1", response)
-    print("2", json.loads(response))
-    print("3", type(json.loads(response)))
     data = json.loads(response)
     assert code == 200
     assert 'Location' in rsp_headers
 
-    assert len(data.keys()) == 1
+    assert len(data.keys()) == 2
     assert data['id'] == 'echo'
     assert data['value'] == 'Hello Test!'
 
@@ -1124,7 +1121,8 @@ def test_execute_process(config, api_):
     data = json.loads(response)
     assert code == 200
     assert 'Location' in rsp_headers
-    assert len(data['outputs']) == 1
+
+    assert len(data.keys()) == 1
     assert data['outputs'][0]['id'] == 'echo'
     assert data['outputs'][0]['value'] == 'Hello Test!'
 
@@ -1137,7 +1135,7 @@ def test_execute_process(config, api_):
     data = json.loads(response)
     assert code == 200
     assert 'Location' in rsp_headers
-    assert data['outputs'][0]['value'] == 'Hello Tést!'
+    assert data['value'] == 'Hello Tést!'
 
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
@@ -1148,7 +1146,7 @@ def test_execute_process(config, api_):
     data = json.loads(response)
     assert code == 200
     assert 'Location' in rsp_headers
-    assert data['outputs'][0]['value'] == 'Hello Tést! This is a test.'
+    assert data['value'] == 'Hello Tést! This is a test.'
 
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
@@ -1186,7 +1184,7 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    req = mock_request(data=req_body)
+    req = mock_request(data=req_body_0)
     rsp_headers, code, response = api_.execute_process(req, 'goodbye-world')
 
     response = json.loads(response)
@@ -1202,8 +1200,8 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    req_body['mode'] = 'async'
-    req = mock_request(data=req_body)
+    req_body_1['mode'] = 'async'
+    req = mock_request(data=req_body_1)
     rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     assert 'Location' in rsp_headers

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1046,10 +1046,16 @@ def test_describe_processes(config, api_):
 
 
 def test_execute_process(config, api_):
-    req_body = {
+    req_body_0 = {
         'inputs': {
             'name': 'Test'
         }
+    }
+    req_body_1 = {
+        'inputs': {
+            'name': 'Test'
+        },
+        'response': 'document'
     }
     req_body_2 = {
         'inputs': {
@@ -1088,7 +1094,7 @@ def test_execute_process(config, api_):
     assert 'Location' not in rsp_headers
     assert data['code'] == 'MissingParameterValue'
 
-    req = mock_request(data=req_body)
+    req = mock_request(data=req_body_0)
     rsp_headers, code, response = api_.execute_process(req, 'foo')
 
     data = json.loads(response)
@@ -1096,6 +1102,23 @@ def test_execute_process(config, api_):
     assert 'Location' not in rsp_headers
     assert data['code'] == 'NoSuchProcess'
 
+    rsp_headers, code, response = api_.execute_process(req, 'hello-world')
+
+    print("1", response)
+    print("2", json.loads(response))
+    print("3", type(json.loads(response)))
+    data = json.loads(response)
+    assert code == 200
+    assert 'Location' in rsp_headers
+
+    assert len(data.keys()) == 1
+    assert data['id'] == 'echo'
+    assert data['value'] == 'Hello Test!'
+
+    cleanup_jobs.add(tuple(['hello-world',
+                            rsp_headers['Location'].split('/')[-1]]))
+
+    req = mock_request(data=req_body_1)
     rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     data = json.loads(response)


### PR DESCRIPTION
cc @alpha-beta-soup @totycro 

- updates default Execute response (`response=raw`) to be raw payload
- `response=document` returns an OAProc result (list of responses)
- OAProc responses are now set as lists from `pygeoapi.api`