### PR TITLE
update TinyDB q= support for multiple terms

### DIFF
--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -155,7 +155,8 @@ class TinyDBCatalogueProvider(BaseProvider):
                 QUERY.append("(Q.properties['{}']=='{}')".format(*prop))
 
         if q is not None:
-            QUERY.append("(Q.properties['_metadata-anytext'].search('{}'))".format(q))  # noqa
+            for t in q.split():
+                QUERY.append("(Q.properties['_metadata-anytext'].search('{}'))".format(t))  # noqa
 
         QUERY_STRING = '&'.join(QUERY)
         LOGGER.debug('QUERY_STRING: {}'.format(QUERY_STRING))

--- a/tests/test_tinydb_catalogue_provider.py
+++ b/tests/test_tinydb_catalogue_provider.py
@@ -69,6 +69,11 @@ def test_query(config):
     assert results['numberMatched'] == 6
     assert results['numberReturned'] == 6
 
+    results = p.query(q='crops barley')
+    assert len(results['features']) == 2
+    assert results['numberMatched'] == 2
+    assert results['numberReturned'] == 2
+
     results = p.query(limit=1)
     assert len(results['features']) == 1
     assert results['features'][0]['id'] == 'e5a71860-827c-453f-990e-0e0ba0ee67bb'  # noqa


### PR DESCRIPTION
This PR updates the TinyDB provider to handle multiple term `q=` queries (i.e. `q=crops barley`) as exclusive (i.e. `crops AND barley`) in the provider machinery, instead of fixed terms.