### PR TITLE
Fixed an issue with navigation in job templates

### DIFF
--- a/pygeoapi/templates/processes/jobs/job.html
+++ b/pygeoapi/templates/processes/jobs/job.html
@@ -3,7 +3,7 @@
 {% block crumbs %}{{ super() }}
 / <a href="../../">{% trans %}Processes{% endtrans %}</a>
 / <a href="../">{{ data['process']['title'] }}</a>
-/ <a href="./">{% trans %}Jobs{% endtrans %}</a>
+/ <a href="../jobs">{% trans %}Jobs{% endtrans %}</a>
 / <a href="./{{ data['jobs']['jobID'] }}">{{ data['jobs']['jobID'] }}</a>
 {% endblock %}
 {% block body %}


### PR DESCRIPTION
On the job detail page (`/processes/PROCESS/jobs/JOB`), the link to "Jobs" used to be `./`. This
creates the url `/processes/PROCESS/jobs/`.

On that page, the link to "Jobs" is `./jobs`, which then leads you to
`/processes/PROCESS/jobs/jobs`. This however is the URL for the job with
the id `jobs`.

This patch fixes this by changing the link to jobs on the job detail page to `../jobs`.

I'm not sure if this is the best fix. Just using `.` as link doesn't seem to lead to the
desired outcome, it also generates the link `/processes/PROCESS/jobs/`.