### PR TITLE
small SensorThings provider patches

### DIFF
--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -182,6 +182,10 @@ class SensorThingsProvider(BaseProvider):
 
             # Validate intra-links
             for (name, rs) in CONFIG['resources'].items():
+                if not rs.get('providers') or \
+                   rs['providers'][0]['name'] != 'SensorThings':
+                    continue
+
                 _entity = rs['providers'][0].get('entity')
                 uri = rs['providers'][0].get('uri_field', '')
 
@@ -226,16 +230,16 @@ class SensorThingsProvider(BaseProvider):
         params = {
             '$expand': EXPAND[self.entity],
             '$skip': str(startindex),
-            '$top': str(limit)
+            '$top': str(limit),
+            '$count': 'true'
         }
         if properties or bbox or datetime_:
             params['$filter'] = self._make_filter(properties, bbox, datetime_)
         if sortby:
             params['$orderby'] = self._make_orderby(sortby)
-        if resulttype == 'hits':
-            params['$count'] = 'true'
 
         # Form URL for GET request
+        LOGGER.debug('Sending query')
         if identifier:
             r = get(f'{self._url}({identifier})', params=params)
         else:
@@ -245,13 +249,23 @@ class SensorThingsProvider(BaseProvider):
             LOGGER.error('Bad http response code')
             raise ProviderConnectionError('Bad http response code')
 
+        response = r.json()
+        v = [response, ] if identifier else response.get('value')
+
+        hits_ = 1 if identifier else min(limit, response.get('@iot.count'))
         # if hits, return count
         if resulttype == 'hits':
             LOGGER.debug('Returning hits')
-            feature_collection['numberMatched'] = r.json().get('@iot.count')
+            matched = len(v) if len(v) >= limit else hits_
+            feature_collection['numberMatched'] = matched
             return feature_collection
 
-        v = [r.json(), ] if identifier else r.json().get('value')
+        # if # of values less than expected, query for more
+        while len(v) < hits_:
+            LOGGER.debug('Fetching next set of values')
+            r = get(response.get('@iot.nextLink'), params={'$skip': len(v)})
+            response = r.json()
+            v.extend(response.get('value'))
 
         # properties filter & display
         keys = (() if not self.properties and not select_properties else

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -93,6 +93,12 @@ def test_query_observations(config):
     p = SensorThingsProvider(config)
 
     results = p.query(resulttype='hits')
+    assert results['numberMatched'] == 10
+
+    results = p.query(resulttype='hits', limit=1000)
+    assert results['numberMatched'] == 1000
+
+    results = p.query(resulttype='hits', limit=3000)
     assert results['numberMatched'] == 2752
 
     results = p.query(properties=[('result', 7475), ])


### PR DESCRIPTION
This PR adjusts some of the behavior of the SensorThings API provider. 

The first patch addresses when a SensorThings server had a limit below the requested number of features in a collection. [example](https://pygeoapi-test.info.geoconnex.us/collections/Things/items?f=json&limit=2000). Instead of assuming the endpoint will return the appropriate number of features, the provider now iterates through the response until the maximum number of possible features have been returned from the SensorThings endpoint. The sensorthings pytest was also updated to align with this behavior. 

The second patch prevents errors when searching for intralinks with other SensorThings providers. The error occured when there was a process in the resources block (that did not have a providers block).