### PR TITLE
Language structs (dicts) must consist of valid locale keys only (#769)

### DIFF
--- a/docs/source/language.rst
+++ b/docs/source/language.rst
@@ -152,6 +152,8 @@ Note that the example above uses generic language tags, but you can also supply 
 pygeoapi should always be able find the best match to the requested language, i.e. if the user wants Swiss-French (`fr-CH`) but pygeoapi can only find `fr` tags,
 those values will be returned. However, if a `fr-CH` tag can also be found, that value will be returned and not the `fr` value.
 
+.. warning::    A language struct is only translated if all language tags (keys) in the struct are valid locales.
+
 .. todo::   Add docs on HTML templating.
 
 Translator guide

--- a/pygeoapi/l10n.py
+++ b/pygeoapi/l10n.py
@@ -275,18 +275,13 @@ def translate(value, language: Union[Locale, str]):
 
     # Find valid locale keys in language struct
     # Also maps Locale instances to actual key names
-    loc_items = OrderedDict()
-    for k in value.keys():
-        loc = str2locale(k, True)
-        if loc:
-            loc_items[loc] = k
-
-    if not loc_items:
-        # No valid locale keys found: return as-is
+    loc_items = OrderedDict((str2locale(k, True), k) for k in value.keys())
+    if not loc_items or None in loc_items:
+        # Return as-is if not ALL keys in the struct are locales
         return value
 
     # Find best language match and return value by its key
-    out_locale = best_match(language, loc_items)
+    out_locale = best_match(language, loc_items.keys())
     return value[loc_items[out_locale]]
 
 

--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -100,6 +100,7 @@ def language_struct():
 @pytest.fixture()
 def nonlanguage_struct():
     return {
+        'id_field': 'id',  # Note: Babel parses this as "Indonesian"!
         None: 'empty key',
         42: 'numeric key',
         'fla': 'non-language key'


### PR DESCRIPTION
Fixes issue #769. Also updated tests and added a warning to the language-related docs.