### PR TITLE
add debian requirements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Depends: ${python3:Depends},
          python3-unicodecsv,
          python3-yaml,
          ${misc:Depends}
-Suggests: python3-babel, python3-elasticsearch, python3-elasticsearch-dsl, python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
+Suggests: python3-babel, python3-elasticsearch, python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
 Description: pygeoapi provides an API to geospatial data.
  .
  This package the pygeoapi module for Python 3.

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Depends: ${python3:Depends},
          python3-unicodecsv,
          python3-yaml,
          ${misc:Depends}
-Suggests: python3-babel, python3-elasticsearch, python3-fiona, python3-geojson, python3-pygeometa, python3-pyproj, python3-rasterio
+Suggests: python3-babel, python3-elasticsearch, python3-elasticsearch-dsl, python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
 Description: pygeoapi provides an API to geospatial data.
  .
  This package the pygeoapi module for Python 3.


### PR DESCRIPTION
Testing 0.11.0 against via UbuntuGIS experimental yields import errors:

```
[Fri Oct 29 20:47:10.317465 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584] mod_wsgi (pid=13248): Target WSGI script '/opt/woudc-api/app/woudc-api.wsgi' cannot be loaded as Python module.
[Fri Oct 29 20:47:10.317631 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584] mod_wsgi (pid=13248): Exception occurred processing WSGI script '/opt/woudc-api/app/woudc-api.wsgi'.
[Fri Oct 29 20:47:10.317969 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584] Traceback (most recent call last):
[Fri Oct 29 20:47:10.318051 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]   File "/opt/woudc-api/app/woudc-api.wsgi", line 67, in <module>
[Fri Oct 29 20:47:10.318100 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]     from woudc_api.app import app as application
[Fri Oct 29 20:47:10.318543 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]   File "/usr/lib/python3.6/dist-packages/woudc_api/app.py", line 51, in <module>
[Fri Oct 29 20:47:10.318627 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]     from pygeoapi.flask_app import BLUEPRINT as pygeoapi_blueprint
[Fri Oct 29 20:47:10.319009 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]   File "/usr/lib/python3/dist-packages/pygeoapi/flask_app.py", line 39, in <module>
[Fri Oct 29 20:47:10.319136 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]     from pygeoapi.api import API
[Fri Oct 29 20:47:10.319336 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]   File "/usr/lib/python3/dist-packages/pygeoapi/api.py", line 69, in <module>
[Fri Oct 29 20:47:10.319542 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]     from pygeoapi.models.cql import CQLModel
[Fri Oct 29 20:47:10.319691 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]   File "/usr/lib/python3/dist-packages/pygeoapi/models/cql.py", line 39, in <module>
[Fri Oct 29 20:47:10.319883 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584]     from pydantic import BaseModel, Field
[Fri Oct 29 20:47:10.320103 2021] [wsgi:error] [pid 13248:tid 140203063650048] [remote 10.10.11.42:45584] ModuleNotFoundError: No module named 'pydantic'
```

Note that we will likely need Python elasticsearch_dsl packaging to cover the enhancements made in #723 (cc @francbartoli)