### PR TITLE
Add case-insensitive partial matching for text columns to Postgres provider

### DIFF
--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -273,3 +273,38 @@ resources:
         type: process
         processor:
             name: HelloWorld
+
+            # Uncomment this section to add the test data for PostgreSQL
+            # provider
+            #    hot_osm_waterways:
+            #        type: collection
+            #        title: OSM waterways
+            #        description: Waterways demo data
+            #        keywords:
+            #            - OSM
+            #            - waterways
+            #        links:
+            #            - type: text/html
+            #              rel: canonical
+            #              title: Source instructions for loading data
+            #              href: https://github.com/geopython/pygeoapi/blob/master/pygeoapi/provider/postgresql.py
+            #              hreflang: en-UK
+            #        extents:
+            #            spatial:
+            #                bbox: [-180, -90, 180, 90]
+            #                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            #            temporal:
+            #                begin: null
+            #                end: null  # or empty (either means open ended)
+            #        providers:
+            #          - type: feature
+            #            name: PostgreSQL
+            #            data:
+            #                host: localhost
+            #                dbname: test
+            #                user: postgres
+            #                password: postgres
+            #                search_path: [osm, public]
+            #            id_field: osm_id
+            #            table: hotosm_bdi_waterways
+            #            geom_field: foo_geom

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -196,23 +196,27 @@ class PostgreSQLProvider(BaseProvider):
 
     def __get_where_clauses(self, properties=[], bbox=[]):
         """
-        Generarates WHERE conditions to be implemented in query.
+        Generates WHERE conditions to be implemented in query.
         Private method mainly associated with query method
         :param properties: list of tuples (name, value)
         :param bbox: bounding box [minx,miny,maxx,maxy]
 
         :returns: psycopg2.sql.Composed or psycopg2.sql.SQL
         """
-        # List of types we can match with LIKE
-        string_types = ['varchar', 'text', 'character varying', 'char', 'character']
         where_conditions = []
+
         if properties:
+            string_types = ['varchar', 'text', 'character varying', 'char',
+                            'character']
             property_clauses = []
             for field_name, field_value in properties:
                 if self.fields[field_name]['type'] in string_types:
+                    # String columns can be made lower case and matched with
+                    # LIKE to allow case-insensitive partial matches
                     property_clause = SQL('lower({}) LIKE lower({})').format(
                         Identifier(field_name), Literal(f"%{field_value}%"))
                 else:
+                    # Use simple equality for other column types
                     property_clause = SQL('{} = {}').format(
                         Identifier(field_name), Literal(field_value))
                 property_clauses.append(property_clause)

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -216,7 +216,6 @@ class PostgreSQLProvider(BaseProvider):
                 else:   
                     property_clause = SQL('{} = {}').format(
                         Identifier(k), Literal(v))
-                    where_conditions += property_clauses
                     property_clauses.append(property_clause)
             where_conditions += property_clauses
         if bbox:

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -206,8 +206,8 @@ class PostgreSQLProvider(BaseProvider):
 
         where_conditions = []
         if properties:
-            property_clauses = [SQL('{} = {}').format(
-                Identifier(k), Literal(v)) for k, v in properties]
+            property_clauses = [SQL('{} LIKE {}').format(
+                Identifier(k), Literal(f"%{v}%")) for k, v in properties]
             where_conditions += property_clauses
         if bbox:
             bbox_clause = SQL('{} && ST_MakeEnvelope({})').format(

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -204,27 +204,21 @@ class PostgreSQLProvider(BaseProvider):
         :returns: psycopg2.sql.Composed or psycopg2.sql.SQL
         """
         # List of types we can match with LIKE
-        fuzzy_matchable = ['varchar', 'text', 'character varying']
+        string_types = ['varchar', 'text', 'character varying', 'char', 'character']
         where_conditions = []
         if properties:
             property_clauses = []
-            if len(properties) == 1:
-                for k, v in properties:
-                    if self.fields[properties[0][0]]['type'] in fuzzy_matchable:
-                        property_clause = SQL('lower({}) LIKE lower({})').format(
-                            Identifier(k), Literal(f"%{v}%"))
-                        property_clauses.append(property_clause)
-                    else:
-                        property_clause = SQL('{} = {}').format(
-                            Identifier(k), Literal(v))
-                        property_clauses.append(property_clause)
-            else:
-                for k, v in properties:
+            for field_name, field_value in properties:
+                if self.fields[field_name]['type'] in string_types:
+                    property_clause = SQL('lower({}) LIKE lower({})').format(
+                        Identifier(field_name), Literal(f"%{field_value}%"))
+                else:
                     property_clause = SQL('{} = {}').format(
-                        Identifier(k), Literal(v))
-                    property_clauses.append(property_clause)
+                        Identifier(field_name), Literal(field_value))
+                property_clauses.append(property_clause)
 
             where_conditions += property_clauses
+
         if bbox:
             bbox_clause = SQL('{} && ST_MakeEnvelope({})').format(
                 Identifier(self.geom), SQL(', ').join(

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -214,7 +214,7 @@ class PostgreSQLProvider(BaseProvider):
             property_clauses = []
             for k, v in properties:
                 if self.fields[properties[0][0]]['type'] in fuzzy_matchable:
-                    property_clause = SQL('{} LIKE {}').format(
+                    property_clause = SQL('lower({}) LIKE lower({})').format(
                         Identifier(k), Literal(f"%{v}%"))  # this is where it goes wrong
                     property_clauses.append(property_clause)
                     #  need some extra logic within the list comprehension if we hit a numeric type

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -203,25 +203,16 @@ class PostgreSQLProvider(BaseProvider):
 
         :returns: psycopg2.sql.Composed or psycopg2.sql.SQL
         """
-
-        # New req: only do this for if the target db column is text
-        fuzzy_matchable = ['varchar', 'text']   # List of types we can match with LIKE
-
-        #breakpoint()
-
+        # List of types we can match with LIKE
+        fuzzy_matchable = ['varchar', 'text', 'character varying']   
         where_conditions = []
         if properties:
             property_clauses = []
             for k, v in properties:
                 if self.fields[properties[0][0]]['type'] in fuzzy_matchable:
                     property_clause = SQL('lower({}) LIKE lower({})').format(
-                        Identifier(k), Literal(f"%{v}%"))  # this is where it goes wrong
-                    property_clauses.append(property_clause)
-                    #  need some extra logic within the list comprehension if we hit a numeric type
-                    # don't think you can cleanly do this in a list comp without becoming ugly
-                    # maybe try a for loop with conditions - test for fuzz matching
-                    #breakpoint()
-            
+                        Identifier(k), Literal(f"%{v}%"))
+                    property_clauses.append(property_clause)           
                 else:   
                     property_clause = SQL('{} = {}').format(
                         Identifier(k), Literal(v))

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -173,14 +173,14 @@ def test_query_hits(config):
     """Test query resulttype=hits with properties"""
     psp = PostgreSQLProvider(config)
     results = psp.query(resulttype="hits")
-    assert results["numberMatched"] == 44328  #  13930 - was previously this value, have more been added? 
+    assert results["numberMatched"] == 59104  #  13930 - was previously this value, have more been added? 
 
     results = psp.query(
         bbox=[29.3373, -3.4099, 29.3761, -3.3924], resulttype="hits")
-    assert results["numberMatched"] == 15  # This was 5? Hmmm...
+    assert results["numberMatched"] == 20  # This was 5? Hmmm...
 
     results = psp.query(properties=[("waterway", "stream")], resulttype="hits")
-    assert results["numberMatched"] == 41790  # 13930 - was previously this value, have more been added? 
+    assert results["numberMatched"] == 55720  # 13930 - was previously this value, have more been added? 
 
 
 def test_query_bbox(config):

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -173,14 +173,14 @@ def test_query_hits(config):
     """Test query resulttype=hits with properties"""
     psp = PostgreSQLProvider(config)
     results = psp.query(resulttype="hits")
-    assert results["numberMatched"] == 14776
+    assert results["numberMatched"] == 44328  #  13930 - was previously this value, have more been added? 
 
     results = psp.query(
         bbox=[29.3373, -3.4099, 29.3761, -3.3924], resulttype="hits")
-    assert results["numberMatched"] == 5
+    assert results["numberMatched"] == 15  # This was 5? Hmmm...
 
     results = psp.query(properties=[("waterway", "stream")], resulttype="hits")
-    assert results["numberMatched"] == 13930
+    assert results["numberMatched"] == 41790  # 13930 - was previously this value, have more been added? 
 
 
 def test_query_bbox(config):

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -130,14 +130,20 @@ def test_query_with_property_filter(config):
     ([("waterway", "tream")], 10),  # Partial match
     ([("waterway", "st%m")], 10),  # Partial match with wildcard in middle
     ([("waterway", "STREAM")], 10),  # Case insensitive match
+    ([("waterway", "STREA")], 10),  # Case insensitive partial match
+    ([("waterway", "ST%EA")], 10),  # Case insensitive partial wildcard match
     ([("width", "30")], 10),  # Number in text field
     ([("width", "30 cm")], 6),  # Number and text in text field
-    ([("osm_id", "620120062")], 1),  # Integer field as text
-    ([("osm_id", 620120062)], 1),  # Integer field as integer
+    ([("osm_id", "620120062")], 1),  # Integer fields are provided as text
+    ([("osm_id", "62012006")], 0),  # Integer fields, partial-match not allowed
     ([("waterway", "drain"),
       ("width", "30 cm")], 6),  # Multiple columns
+    ([("waterway", "dRaIn"),
+      ("width", "30 cm")], 6),  # Multiple columns, case insensitive
     ([("waterway", "stream"),
-      ("osm_id", 620120062)], 1),  # Multi-columns, mixed type
+      ("osm_id", "620120062")], 1),  # Multi-columns, mixed type
+    ([("waterway", "strea"),
+      ("osm_id", "620120062")], 1),  # Multi-columns, mixed type, partial match
 ])
 def test_query_partial_match(config, properties, expected_count):
     """Test query with a partial matching string"""

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -161,6 +161,14 @@ def test_query_with_config_properties(config_with_properties):
         assert property_name in config_with_properties["properties"]
 
 
+def test_query_match_integer(config):
+    """Test query with a matching integer"""
+    p = PostgreSQLProvider(config)
+    feature_collection = p.query(properties=[("osm_id", 30152037)])
+    features = feature_collection.get('features', None)
+    assert len(features) == 1
+
+
 def test_query_hits(config):
     """Test query resulttype=hits with properties"""
     psp = PostgreSQLProvider(config)

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -73,6 +73,7 @@ def config_materialised_view(config):
 
 def test_query(config):
     """Testing query for a valid JSON object with geometry"""
+
     p = PostgreSQLProvider(config)
     feature_collection = p.query()
     assert feature_collection.get('type', None) == 'FeatureCollection'
@@ -121,6 +122,17 @@ def test_query_with_property_filter(config):
                features))
     assert (len(features) != len(stream_features))
     assert (len(other_features) != 0)
+
+
+def test_query_partial_match(config):
+    """Test query with a partial matching string"""
+    p = PostgreSQLProvider(config)
+    feature_collection = p.query(properties=[("waterway", "strea")])
+    features = feature_collection.get('features', None)
+    stream_features = list(
+        filter(lambda feature: feature['properties']['waterway'] == 'stream',
+               features))
+    assert (len(features) == len(stream_features))
 
 
 def test_query_with_config_properties(config_with_properties):

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -173,14 +173,14 @@ def test_query_hits(config):
     """Test query resulttype=hits with properties"""
     psp = PostgreSQLProvider(config)
     results = psp.query(resulttype="hits")
-    assert results["numberMatched"] == 59104  #  13930 - was previously this value, have more been added? 
+    assert results["numberMatched"] == 14776
 
     results = psp.query(
         bbox=[29.3373, -3.4099, 29.3761, -3.3924], resulttype="hits")
-    assert results["numberMatched"] == 20  # This was 5? Hmmm...
+    assert results["numberMatched"] == 5
 
     results = psp.query(properties=[("waterway", "stream")], resulttype="hits")
-    assert results["numberMatched"] == 55720  # 13930 - was previously this value, have more been added? 
+    assert results["numberMatched"] == 13930
 
 
 def test_query_bbox(config):


### PR DESCRIPTION
### Summary

This pull request adds case-insensitive, partial matches for text columns to the Postgres provider.  This makes it easier for users to search the API where the case and exact text are not known.

### Description

We found situations where building a webpage on top of pygeoapi that it was convenient to be able to have case-insensitive searches to make it easier for users to find items, for example if entries in the database are all upper case.  Including a wildcard in the search also make it easier to run queries where the exact values were not known.

This pull request adds these to the PostgreSQL provider.

### Discussion

We are posting this pull request for consideration.  It has made things more convenient for us, however it there are some other implications in terms of adding to the main Postgres provider.

+ At the moment, if a user doesn't know the exact search term, they can make a request to the single column to get all the items and find their item in there.  This two-step process is extra work but not the end of the world
+ Hopefully the PostgreSQL provider will get CQL support in future, which will supersede this
+ There may be situations where the wildcard search will return items that were not desired


### To test

The merge request includes changes to the included [pygeoapi-config](pygeoapi-config.yml) to add settings for the test Postgres instance.  Uncommenting those lines will add it to the server.

It is then possible to test the following queries, all of which should return the same results:

+ [ ] http://localhost:5000/collections/hot_osm_waterways/items?f=json&lang=en-US&limit=10&skipGeometry=true&waterway=stream
+ [ ] http://localhost:5000/collections/hot_osm_waterways/items?f=json&lang=en-US&limit=10&skipGeometry=true&waterway=STREAM
+ [ ] http://localhost:5000/collections/hot_osm_waterways/items?f=json&lang=en-US&limit=10&skipGeometry=true&waterway=stre
