### PR TITLE
Fix ElasticsearchCatalogue provider

### DIFF
--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -489,7 +489,7 @@ class ElasticsearchCatalogueProvider(ElasticsearchProvider):
     def get_fields(self):
         fields = super().get_fields()
         for i in self._excludes():
-            if i in fields.keys():
+            if i in fields:
                 del fields[i]
 
         fields['q'] = {'type': 'string'}

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -483,13 +483,15 @@ class ElasticsearchCatalogueProvider(ElasticsearchProvider):
 
     def _excludes(self):
         return [
-            'properties._metadata-anytext'
+            'properties._metadata-anytext',
+            '_metadata-anytext'
         ]
 
     def get_fields(self):
         fields = super().get_fields()
         for i in self._excludes():
-            del fields[i]
+            if i in fields.keys():
+                del fields[i] 
 
         fields['q'] = {'type': 'string'}
 
@@ -497,7 +499,8 @@ class ElasticsearchCatalogueProvider(ElasticsearchProvider):
 
     def query(self, startindex=0, limit=10, resulttype='results',
               bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None):
+              select_properties=[], skip_geometry=False, q=None,
+              filterq=None, **kwargs):
 
         records = super().query(
             startindex=startindex, limit=limit,

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -483,8 +483,7 @@ class ElasticsearchCatalogueProvider(ElasticsearchProvider):
 
     def _excludes(self):
         return [
-            'properties._metadata-anytext',
-            '_metadata-anytext'
+            'properties._metadata-anytext'
         ]
 
     def get_fields(self):

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -491,7 +491,7 @@ class ElasticsearchCatalogueProvider(ElasticsearchProvider):
         fields = super().get_fields()
         for i in self._excludes():
             if i in fields.keys():
-                del fields[i] 
+                del fields[i]
 
         fields['q'] = {'type': 'string'}
 


### PR DESCRIPTION
This PR fixes two performance issues for the ElasticsearchCatalogue provider.
- The first is making the exclude items exist in the fields before removing them. This was causing an issue when the excluded field was `_metadata-anytext` instead of `properties._metadata-anytext`.
- The second is updating the query method to the base provider. The provider requires this because of the language kwarg.