### PR TITLE
Hardcoded version of ES client python library

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Depends: ${python3:Depends},
          python3-unicodecsv,
          python3-yaml,
          ${misc:Depends}
-Suggests: python3-babel, python3-elasticsearch, python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
+Suggests: python3-babel, python3-elasticsearch<8.0.0, python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
 Description: pygeoapi provides an API to geospatial data.
  .
  This package the pygeoapi module for Python 3.

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Depends: ${python3:Depends},
          python3-unicodecsv,
          python3-yaml,
          ${misc:Depends}
-Suggests: python3-babel, python3-elasticsearch<8, python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
+Suggests: python3-babel, python3-elasticsearch (<8.0.0), python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
 Description: pygeoapi provides an API to geospatial data.
  .
  This package the pygeoapi module for Python 3.

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Depends: ${python3:Depends},
          python3-unicodecsv,
          python3-yaml,
          ${misc:Depends}
-Suggests: python3-babel, python3-elasticsearch<8.0.0, python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
+Suggests: python3-babel, python3-elasticsearch<8, python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
 Description: pygeoapi provides an API to geospatial data.
  .
  This package the pygeoapi module for Python 3.

--- a/debian/control
+++ b/debian/control
@@ -23,7 +23,7 @@ Depends: ${python3:Depends},
          python3-unicodecsv,
          python3-yaml,
          ${misc:Depends}
-Suggests: python3-babel, python3-elasticsearch (<8.0.0), python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
+Suggests: python3-babel, python3-elasticsearch (<8), python3-fiona, python3-geojson, python3-pydantic, python3-pygeometa, python3-pyproj, python3-rasterio
 Description: pygeoapi provides an API to geospatial data.
  .
  This package the pygeoapi module for Python 3.

--- a/docker/examples/elastic/ES/Dockerfile
+++ b/docker/examples/elastic/ES/Dockerfile
@@ -54,7 +54,7 @@ RUN echo "discovery.type: single-node" >> config/elasticsearch.yml
 
 RUN yum --enablerepo=extras -y install epel-release \
         && yum install -y python3 python3-pip python3-setuptools python-typing \
-        && pip3 install --upgrade pip elasticsearch elasticsearch-dsl \
+        && pip3 install --upgrade pip elasticsearch==7.17.1 elasticsearch-dsl \
 	&& yum clean packages
 
 USER elasticsearch

--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -1,4 +1,4 @@
-elasticsearch==7.1.0
+elasticsearch<8.0.0
 fiona
 #GDAL>=3.0.0
 netCDF4
@@ -10,4 +10,5 @@ pymongo==3.10.1
 scipy
 xarray
 zarr
-elasticsearch-dsl
+elasticsearch-dsl<8.0.0
+

--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -1,4 +1,4 @@
-elasticsearch<8.0.0
+elasticsearch<8
 fiona
 #GDAL>=3.0.0
 netCDF4
@@ -10,5 +10,5 @@ pymongo==3.10.1
 scipy
 xarray
 zarr
-elasticsearch-dsl<8.0.0
+elasticsearch-dsl<8
 


### PR DESCRIPTION
Specified version of the python client of ES, to avoid breaking changes from version [v8.0.0](https://github.com/elastic/elasticsearch-py/releases/tag/v8.0.0).
