### PR TITLE
Fix SQL injection vulnerability. Fix bug with schema prefixed tables.

### DIFF
--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -122,7 +122,7 @@ class DatabaseConnection:
             INNER JOIN pg_catalog.pg_type as tp
                 ON tp.oid = attr.atttypid
             WHERE
-                attr.attrelid = '%s'::regclass::oid
+                attr.attrelid = %s::regclass::oid
                 AND tp.typname != 'geometry'
                 AND attnum > 0
             """

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -91,7 +91,9 @@ def test_query_materialised_view(config, config_materialised_view):
     features = p.query(limit=14776).get("features", None)
     properties = features[0].get("properties", None)
     # Only width and depth properties should be available
-    assert sorted(list(properties.keys())) == sorted(["osm_id", "width", "depth"])
+    assert sorted(list(properties.keys())) == sorted(
+        ["osm_id", "width", "depth"]
+    )
     p_full = PostgreSQLProvider(config)
     full_features = p_full.query(limit=14776).get("features", None)
     drain_features = [

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -91,7 +91,7 @@ def test_query_materialised_view(config, config_materialised_view):
     features = p.query(limit=14776).get("features", None)
     properties = features[0].get("properties", None)
     # Only width and depth properties should be available
-    assert list(properties.keys()) == ["osm_id", "width", "depth"]
+    assert sorted(list(properties.keys())) == sorted(["osm_id", "width", "depth"])
     p_full = PostgreSQLProvider(config)
     full_features = p_full.query(limit=14776).get("features", None)
     drain_features = [


### PR DESCRIPTION
Make sure that we use sql injection resistant formatting from psycopg2 rather than python string formatting for query to get column information from Postgresql provider.

Make sure that we only get columns from a single table. As the column query is now, if there is a public.tablename table and a myschema.tablename table, the columns list will be all columns that are in either of those tables.