### PR TITLE
allow vendor specific parameters on .../items queries

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1366,12 +1366,8 @@ class API:
 
         LOGGER.debug('processing property parameters')
         for k, v in request.params.items():
-            if k not in reserved_fieldnames and k not in p.fields.keys():
-                msg = 'unknown query parameter: {}'.format(k)
-                return self.get_exception(
-                    400, headers, request.format, 'InvalidParameterValue', msg)
-            elif k not in reserved_fieldnames and k in list(p.fields.keys()):
-                LOGGER.debug('Add property filter {}={}'.format(k, v))
+            if k not in reserved_fieldnames and k in list(p.fields.keys()):
+                LOGGER.debug('Adding property filter {}={}'.format(k, v))
                 properties.append((k, v))
 
         LOGGER.debug('processing sort parameter')

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -346,6 +346,16 @@ def get_oas_30(cfg):
                 },
                 'style': 'form',
                 'explode': False
+            },
+            'vendorSpecificParameters': {
+                'name': 'vendorSpecificParameters',
+                'in': 'query',
+                'description': 'Additional "free-form" parameters that are not explicitly defined',  # noqa
+                'schema': {
+                    'type': 'object',
+                    'additionalProperties': True
+                },
+                'style': 'form'
             }
         },
         'schemas': {
@@ -482,6 +492,7 @@ def get_oas_30(cfg):
                         {'$ref': '{}#/components/parameters/bbox'.format(OPENAPI_YAML['oapif'])},  # noqa
                         {'$ref': '{}#/components/parameters/limit'.format(OPENAPI_YAML['oapif'])},  # noqa
                         coll_properties,
+                        {'$ref': '#/components/parameters/vendorSpecificParameters'},  # noqa
                         {'$ref': '#/components/parameters/skipGeometry'},
                         {'$ref': '{}/parameters/sortby.yaml'.format(OPENAPI_YAML['oapir'])},  # noqa
                         {'$ref': '#/components/parameters/offset'},


### PR DESCRIPTION
Implements OAFeat `/req/core/query-param-unknown` (http://docs.opengeospatial.org/is/17-069r3/17-069r3.html#query_parameters), so that `.../items` queries can accept foreign property names (e.g. cache killers, tokens, etc.).

cc @webb-ben 