### PR TITLE
Update requirement.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel
-click<8
+click>8
 Flask
 jsonschema
 pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel
-7 < click <= 8
+click>7,<=8
 Flask
 jsonschema
 pyproj

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel
-click>8
+7 < click <= 8
 Flask
 jsonschema
 pyproj


### PR DESCRIPTION
I have updated the `click` requirement which was originally set to `<7` to `>8`. It is advised to update the requirement as there's a security issue for versions < 8.

This change is needed for the effective functioning of the FastGeoAPI application as the dependency causes the build test to fail.

Signed-off-by: Abdulazeez Abdulazeez Adeshina <youngestdev@gmail.com>