### PR TITLE
set F_HTML as default if no &f={enc} or accept header is provided

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -38,7 +38,7 @@ The ``server`` section provides directives on binding and high level tuning.
         host: 0.0.0.0  # listening address for incoming connections
         port: 5000  # listening port for incoming connections
     url: http://localhost:5000/  # url of server
-    mimetype: application/json; charset=UTF-8  # default MIME type
+    mimetype: application/json; charset=UTF-8  # default MIME type (if no accept header is provided)
     encoding: utf-8  # default server encoding
     language: en-US  # default server language
     gzip: false # default server config to gzip/compress responses to requests with gzip in the Accept-Encoding header

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -82,6 +82,7 @@ HEADERS = {
     'X-Powered-By': 'pygeoapi {}'.format(__version__)
 }
 
+MIMETYPE = ['']
 CHARSET = ['utf-8']
 F_JSON = 'json'
 F_HTML = 'html'
@@ -402,7 +403,16 @@ class APIRequest:
                 format_ = fmts[idx_]
                 break
 
-        return format_ or F_HTML
+        # if no accept header on request, use mimetype from config
+        defmime = MIMETYPE[0].split(';')[0]
+        if defmime == "application/json":
+            defmime = F_JSON
+        elif defmime == "application/ld+json":
+            defmime = F_JSONLD
+        else:
+            defmime = F_HTML
+
+        return format_ or defmime
 
     @property
     def data(self) -> bytes:
@@ -596,6 +606,8 @@ class API:
         if config['server'].get('gzip') is True:
             FORMAT_TYPES[F_GZIP] = 'application/gzip'
             FORMAT_TYPES.move_to_end(F_JSON)
+
+        MIMETYPE[0] = config['server'].get('mimetype', '')
 
         # Process language settings (first locale is default!)
         self.locales = l10n.get_locales(config)

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -402,7 +402,7 @@ class APIRequest:
                 format_ = fmts[idx_]
                 break
 
-        return format_ or None
+        return format_ or F_HTML
 
     @property
     def data(self) -> bytes:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,7 +99,7 @@ def test_apirequest(api_):
     req = mock_request()
     apireq = APIRequest(req, api_.locales)
     assert apireq.is_valid()
-    assert apireq.format is None
+    assert apireq.format is F_JSON
     assert apireq.get_response_headers()['Content-Type'] == \
            FORMAT_TYPES[F_JSON]
     assert apireq.get_linkrel(F_JSON) == 'self'


### PR DESCRIPTION
resolves issue #901
plz consider that there may be regression for clients which do not send accept header and expect json to be returned