### PR TITLE
Pass the locale value into jinja templates for improved language handling

### DIFF
--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -364,7 +364,7 @@ def render_j2_template(config, template, data, locale_=None):
             raise
 
     return template.render(config=l10n.translate_struct(config, locale_, True),
-                           data=data, version=__version__)
+                           data=data, locale=locale_, version=__version__)
 
 
 def get_mimetype(filename):


### PR DESCRIPTION
Knowing the current locale of the page directly allows for better language handling in Jinja2 templates. 

Example: implementing a proper language toggle:

```jinja
{% if locale == "en-CA" %}
<li>
  <a class="lang-toggle" href="?lang=fr">Français</a>
</li>
{% endif %}

{% if locale == "fr-CA" %}
<li>
  <a class="lang-toggle" href="?lang=en">English</a>
</li>
{% endif %}
```

Or setting the default `<html>` lang:
```jinja
<html lang="{{ (locale|lower)[:2] }}">
<!-- renders as <html lang="en"> or <html lang="fr"> -->
```