### PR TITLE
remove canonical link from ogc-api features config

### DIFF
--- a/pygeoapi/templates/_base.html
+++ b/pygeoapi/templates/_base.html
@@ -14,9 +14,10 @@
       <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
     <![endif]-->
     {% for link in data['links'] %}
-      <link rel="{{ link['rel'] }}" type="{{ link['type'] }}" title="{{ link['title'] }}" href="{{ link['href'] }}"/>
       {% if (link['rel']=="self" and link['type']=="text/html") %}
-      <link rel="canonical" href="{{ link['href'].split('?')[0] }}" />
+      <link rel="canonical" href="{{ link['href'].split('?')[0] }}?f=html" />
+      {% elif (link['rel']!="canonical") %}
+      <link rel="{{ link['rel'] }}" type="{{ link['type'] }}" title="{{ link['title'] }}" href="{{ link['href'] }}"/>
       {% endif %}
     {% endfor %}
     {% block extrahead %}


### PR DESCRIPTION
- also sets canonical url to xxx?f=html to prevent issues when json is default encoding

resolves #900