### PR TITLE
readonly access to tinydb

### DIFF
--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -65,7 +65,7 @@ class TinyDBCatalogueProvider(BaseProvider):
             LOGGER.error(msg)
             raise ProviderConnectionError(msg)
 
-        self.db = TinyDB(self.data)
+        self.db = TinyDB(self.data, access_mode="r")
 
         self.fields = self.get_fields()
 


### PR DESCRIPTION
this PR sets access mode to readonly for tinydb connection, it is required if filesystem is readonly, else tinydb provider will throw an error. if at some point pygeoapi allows transactions, we should make a more advanced check (verify if readonly file first)

https://github.com/msiemens/tinydb/blob/569447981a9f0d383c4be5556cd336c9ed7ef758/tinydb/storages.py#L83 allows to send a access_mode=r parameter to override the default writable behaviour

or is it better to add such a check now, in preparation for transations?

resolves #909