### PR TITLE
optimise geojson provider if file does not exist

### DIFF
--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -76,14 +76,16 @@ class GeoJSONProvider(BaseProvider):
         :returns: dict of fields
         """
 
+        fields = {}
         LOGGER.debug('Treating all columns as string types')
         if os.path.exists(self.data):
             with open(self.data) as src:
                 data = json.loads(src.read())
-            fields = {}
             for f in data['features'][0]['properties'].keys():
                 fields[f] = {'type': 'string'}
-            return fields
+        else:
+            LOGGER.warning('File {} does not exist.'.format(self.data))
+        return fields
 
     def _load(self, skip_geometry=None, properties=[], select_properties=[]):
         """Load and validate the source GeoJSON file
@@ -97,6 +99,7 @@ class GeoJSONProvider(BaseProvider):
             with open(self.data) as src:
                 data = json.loads(src.read())
         else:
+            LOGGER.warning('File {} does not exist.'.format(self.data))
             data = {
                 'type': 'FeatureCollection',
                 'features': []}


### PR DESCRIPTION
this checks if fields exist before calling keys() or items() on it, i wanted to use get('fields',{}), but the get function is already defined on provider.

this error occurs for example when the geojson file does not exist, although for this case it would be better to make the error more explicit! Should I add it in this PR?

resolves #908