### PR TITLE
Json serialize numpy types

### DIFF
--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -43,7 +43,6 @@ import re
 from urllib.request import urlopen
 from urllib.parse import urlparse
 
-import numpy
 from shapely.geometry import Polygon
 
 import dateutil.parser
@@ -284,9 +283,9 @@ def json_serial(obj):
             return base64.b64encode(obj)
     elif isinstance(obj, Decimal):
         return float(obj)
-    elif isinstance(obj, numpy.int64):
+    elif type(obj).__name__ == 'int64':
         return int(obj)
-    elif isinstance(obj, numpy.float64):
+    elif type(obj).__name__ == 'float64':
         return float(obj)
     elif isinstance(obj, l10n.Locale):
         return l10n.locale2str(obj)

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -42,6 +42,8 @@ import os
 import re
 from urllib.request import urlopen
 from urllib.parse import urlparse
+
+import numpy
 from shapely.geometry import Polygon
 
 import dateutil.parser
@@ -281,6 +283,10 @@ def json_serial(obj):
             LOGGER.debug('Returning as base64 encoded JSON object')
             return base64.b64encode(obj)
     elif isinstance(obj, Decimal):
+        return float(obj)
+    elif isinstance(obj, numpy.int64):
+        return int(obj)
+    elif isinstance(obj, numpy.float64):
         return float(obj)
     elif isinstance(obj, l10n.Locale):
         return l10n.locale2str(obj)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -29,6 +29,7 @@
 
 from datetime import datetime, date, time
 from decimal import Decimal
+from numpy import float64, int64
 
 import pytest
 
@@ -86,6 +87,12 @@ def test_json_serial():
 
     d = Decimal(1.0)
     assert util.json_serial(d) == 1.0
+
+    d = int64(500_000_000_000)
+    assert util.json_serial(d) == 500_000_000_000
+
+    d = float64(500.00000005)
+    assert util.json_serial(d) == 500.00000005
 
     with pytest.raises(TypeError):
         util.json_serial('foo')


### PR DESCRIPTION
This proves necessary for the xarray provider, as it passes values loaded into an xarray dataset from a NetCDF file directly to a dictonary that is later json serialized.

This commit thereby fixes #895