### PR TITLE
Embed jsonld snippet directly, without requesting with ajax

### DIFF
--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -140,7 +140,7 @@ def jsonldify_collection(cls, collection, locale_):
         ),
         "name": l10n.translate(collection['title'], locale_),
         "description": l10n.translate(collection['description'], locale_),
-        "license": cls.fcmld['license'],
+        "license": cls.config['metadata'].get('license', {}).get('url', None),
         "keywords": l10n.translate(collection.get('keywords', None), locale_),
         "spatial": None if (not hascrs84 or not bbox) else [{
             "@type": "Place",

--- a/pygeoapi/templates/_base.html
+++ b/pygeoapi/templates/_base.html
@@ -22,6 +22,11 @@
     {% endfor %}
     {% block extrahead %}
     {% endblock %}
+    {% if data['ld'] %}
+    <script type="application/ld+json">
+      {{ data['ld'] | to_json | safe }}
+    </script>
+    {% endif %}
   </head>
   <body>
   <div class="bg-light sticky-top border-bottom">
@@ -91,22 +96,5 @@
         style="height:24px;vertical-align: middle;" /></a> {{ version }}</footer>
     {% block extrafoot %}
     {% endblock %}
-    <script>
-      // Requests and embeds JSON-LD representation of current page
-      var xhr = new XMLHttpRequest();
-      var path = window.location.protocol + "//" + window.location.host + window.location.pathname + "?f=jsonld";
-      xhr.open('GET', path);
-      xhr.onload = function() {
-        if (xhr.status === 200) {
-          var head = document.getElementsByTagName('head')[0];
-          var jsonld_datablock = document.createElement('script');
-          jsonld_datablock.type = "application/ld+json";
-          //remove full context path, because search engines don't expect it here, pyld requires it.
-          jsonld_datablock.textContent = xhr.responseText.replace('docs/jsonldcontext.jsonld','');
-          head.appendChild(jsonld_datablock);
-        }
-      };
-      xhr.send();
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Goal is to:
- ggl rich snippets test does not parse the ajax response (not clear if rich snippets test is fully representative for google structured data crawler)
- better performance

This is a work in progress, now implemented for /collections/foo and collections/foo/items/faa