### PR TITLE
when title-field has a multilingual configuration, use it

### DIFF
--- a/docs/source/language.rst
+++ b/docs/source/language.rst
@@ -148,6 +148,20 @@ If you wish to make these text values available in English and French, you could
 In other words: each plain text value should be replaced by a dictionary, where the language code is the key and the translated text represents the matching value.
 For lists, this can be applied as well (see ``keywords`` example above), as long as you nest the entire list under a language key instead of each list item.
 
+A similar concept can be applied to the ``title-field`` property of the provider in a collection configuration. If a dataset contains multiple columns each representing the title 
+element in a specific language, you can configure the title-field accordingly.
+
+.. code-block:: yaml
+
+  providers:
+    - type: feature
+      name: GeoJSON
+      data: tests/data/ne_110m_lakes.geojson
+      title_field: 
+        en: name-en 
+        fr: name-fr
+        de: name-de
+
 Note that the example above uses generic language tags, but you can also supply more localized tags (with a country code) if required.
 pygeoapi should always be able find the best match to the requested language, i.e. if the user wants Swiss-French (`fr-CH`) but pygeoapi can only find `fr` tags,
 those values will be returned. However, if a `fr-CH` tag can also be found, that value will be returned and not the `fr` value.

--- a/docs/source/language.rst
+++ b/docs/source/language.rst
@@ -158,9 +158,9 @@ element in a specific language, you can configure the title-field accordingly.
       name: GeoJSON
       data: tests/data/ne_110m_lakes.geojson
       title_field: 
-        en: name-en 
-        fr: name-fr
-        de: name-de
+        en: name_eng 
+        fr: nom_fre
+        de: name_deu
 
 Note that the example above uses generic language tags, but you can also supply more localized tags (with a country code) if required.
 pygeoapi should always be able find the best match to the requested language, i.e. if the user wants Swiss-French (`fr-CH`) but pygeoapi can only find `fr` tags,

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1542,6 +1542,8 @@ class API:
             if p.title_field is not None:
                 content['title_field'] = l10n.translate(p.title_field,
                                                         request.locale)
+                # If title exists, use it as id in html templates
+                content['id_field'] = content['title_field']
             content = render_j2_template(self.config,
                                          'collections/items/index.html',
                                          content, request.locale)

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1960,7 +1960,8 @@ class API:
             if p.uri_field is not None:
                 content['uri_field'] = p.uri_field
             if p.title_field is not None:
-                content['title_field'] = p.title_field
+                content['title_field'] = l10n.translate(p.title_field,
+                                                        request.locale)
             content['collections_path'] = self.get_collections_url()
 
             content = render_j2_template(self.config,

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1540,9 +1540,8 @@ class API:
             if p.uri_field is not None:
                 content['uri_field'] = p.uri_field
             if p.title_field is not None:
-                content['title_field'] = p.title_field
-                content['id_field'] = p.title_field
-
+                content['title_field'] = l10n.translate(p.title_field,
+                                                        request.locale)
             content = render_j2_template(self.config,
                                          'collections/items/index.html',
                                          content, request.locale)


### PR DESCRIPTION
resolves #921

an example added to docs:

```
  providers:
    - type: feature
      name: GeoJSON
      data: tests/data/ne_110m_lakes.geojson
      title_field: 
        en: name-en 
        fr: name-fr
        de: name-de
```

?lang=en
<img width="374" alt="image" src="https://user-images.githubusercontent.com/299829/173148035-42796daf-d592-4a24-a42d-a76380106d4e.png">
?lang=it
<img width="351" alt="image" src="https://user-images.githubusercontent.com/299829/173148116-c382995d-893e-4465-96b8-84a9b9b3c023.png">
