### PR TITLE
- added missing curl on pygeoapi container (which was triggering errors)

### DIFF
--- a/docker/examples/elastic/ES/Dockerfile
+++ b/docker/examples/elastic/ES/Dockerfile
@@ -31,7 +31,7 @@
 #
 # =================================================================
 
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.5.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.3.1
 
 LABEL maintainer="jorge.dejesus@geocat.net justb4@gmail.com"
 ARG DATA_FOLDER=/usr/share/elasticsearch/data
@@ -41,7 +41,7 @@ USER root
 COPY docker-entrypoint.sh  /docker-entrypoint.sh
 COPY add_data.sh /add_data.sh
 
-RUN yum install -y wget
+RUN apt-get update && apt-get install -y wget
 
 RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -O bin/wait-for-it.sh
 RUN chmod +x bin/wait-for-it.sh
@@ -52,10 +52,10 @@ RUN echo "xpack.security.enabled: false" >> config/elasticsearch.yml
 RUN echo "http.host: 0.0.0.0" >> config/elasticsearch.yml
 RUN echo "discovery.type: single-node" >> config/elasticsearch.yml
 
-RUN yum --enablerepo=extras -y install epel-release \
-        && yum install -y python3 python3-pip python3-setuptools python-typing \
+RUN apt-get -y install \
+        -y python3 python3-pip python3-setuptools python-typing \
         && pip3 install --upgrade pip elasticsearch==7.17.1 elasticsearch-dsl \
-	&& yum clean packages
+	&& apt-get clean 
 
 USER elasticsearch
 

--- a/docker/examples/elastic/pygeoapi/es-entrypoint.sh
+++ b/docker/examples/elastic/pygeoapi/es-entrypoint.sh
@@ -32,6 +32,11 @@
 
 set +e
 
+echo  "Install Curl"
+
+apt-get update -y &&
+apt-get install curl -y &&
+
 echo  "Waiting for ElasticSearch container..."
 
 # First wait for ES to be up and then execute the original pygeoapi entrypoint.


### PR DESCRIPTION
# Overview
pygeoapi [relies on curl to wait for ES](https://github.com/geopython/pygeoapi/blob/master/docker/examples/elastic/pygeoapi/wait-for-elasticsearch.sh#L40), but cur is not installed in that container. That generates an infinite waiting.

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/931

# Additional Information
There is another problem with the docker composition, which I will address on a separate PR.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
