### PR TITLE
Coerce ES type `long` to `number`

### DIFF
--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -148,7 +148,7 @@ class ElasticsearchProvider(BaseProvider):
                     fields_[k] = {'type': 'string'}
                 elif v['type'] == 'date':
                     fields_[k] = {'type': 'string', 'format': 'date'}
-                elif v['type'] == 'float':
+                elif v['type'] in ('float', 'long'):
                     fields_[k] = {'type': 'number', 'format': v['type']}
                 else:
                     fields_[k] = {'type': v['type']}


### PR DESCRIPTION
# Overview
Set Elasticsearch provider to cast field with type `long` to type `number` & format `long`.

# Related Issue / Discussion
N/A

# Additional Information
OpenAPI document leverages the provider method `get_fields`.  A valid document must have fields of type `['array', 'boolean', 'integer', 'number', 'object', 'string']`. This PR applies the same typing for field of type `float` and `long`, casting the type to `number` and format to the ES field type.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
