### PR TITLE
Update ES pytests

### DIFF
--- a/tests/test_elasticsearch__provider.py
+++ b/tests/test_elasticsearch__provider.py
@@ -149,7 +149,8 @@ def test_query(config):
 
     fields = p.get_fields()
     assert len(fields) == 37
-    assert fields['scalerank']['type'] == 'long'
+    assert fields['scalerank']['type'] == 'number'
+    assert fields['scalerank']['format'] == 'long'
     assert fields['changed']['type'] == 'number'
     assert fields['changed']['format'] == 'float'
     assert fields['ls_name']['type'] == 'string'


### PR DESCRIPTION
# Overview
Update pytests for Elasticsearch provider to conform with openapi document. [ES types](https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html) `float` and `long` are cast as type `number`. Their numeric type is retained in the `format` field. 

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/pull/935

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
