### PR TITLE
Fixes to display queryables on mongo data provider

### DIFF
--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -83,8 +83,8 @@ class MongoProvider(BaseProvider):
             map, reduce, "myresults")
 
         # prepare a dictionary with fields
-        # set the field type to 'string'. By operating without a schema,
-        # it can store, retrieve, and query any data type.        
+        # set the field type to 'string'.
+        # by operating without a schema, mongo can query any data type.        
         fields={}
         for i in result.distinct('_id'):
             fields[i] = {'type': 'string'}

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -84,8 +84,8 @@ class MongoProvider(BaseProvider):
 
         # prepare a dictionary with fields
         # set the field type to 'string'.
-        # by operating without a schema, mongo can query any data type.        
-        fields={}
+        # by operating without a schema, mongo can query any data type.
+        fields = {}
         for i in result.distinct('_id'):
             fields[i] = {'type': 'string'}
 

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -84,8 +84,7 @@ class MongoProvider(BaseProvider):
 
         # prepare a dictionary with fields
         # set the field type to 'string'. By operating without a schema,
-        # it can store, retrieve, and query any data type.
-        
+        # it can store, retrieve, and query any data type.        
         fields={}
         for i in result.distinct('_id'):
             fields[i] = {'type': 'string'}

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -83,13 +83,13 @@ class MongoProvider(BaseProvider):
             map, reduce, "myresults")
 
         # prepare a dictionary with fields
-        # set the field type to 'string'. By operating without a schema, it can store, retrieve, and query any data type.
+        # set the field type to 'string'. By operating without a schema, 
+        # it can store, retrieve, and query any data type.
         fields={}
         for i in result.distinct('_id'):
             fields[i] = {'type': 'string'}
 
         return(fields)
-
 
     def _get_feature_list(self, filterObj, sortList=[], skip=0, maxitems=1,
                           skip_geometry=False):

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -66,6 +66,7 @@ class MongoProvider(BaseProvider):
         self.featuredb = dbclient.get_default_database()
         self.collection = provider_def['collection']
         self.featuredb[self.collection].create_index([("geometry", GEOSPHERE)])
+        self.fields = self.get_fields()
 
     def get_fields(self):
         """
@@ -73,13 +74,22 @@ class MongoProvider(BaseProvider):
 
         :returns: dict of fields
         """
+
         map = Code(
             "function() { for (var key in this.properties) "
             "{ emit(key, null); } }")
         reduce = Code("function(key, stuff) { return null; }")
         result = self.featuredb[self.collection].map_reduce(
             map, reduce, "myresults")
-        return result.distinct('_id')
+
+        # prepare a dictionary with fields
+        # set the field type to 'string'. By operating without a schema, it can store, retrieve, and query any data type.
+        fields={}
+        for i in result.distinct('_id'):
+            fields[i] = {'type': 'string'}
+
+        return(fields)
+
 
     def _get_feature_list(self, filterObj, sortList=[], skip=0, maxitems=1,
                           skip_geometry=False):

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -83,8 +83,9 @@ class MongoProvider(BaseProvider):
             map, reduce, "myresults")
 
         # prepare a dictionary with fields
-        # set the field type to 'string'. By operating without a schema, 
+        # set the field type to 'string'. By operating without a schema,
         # it can store, retrieve, and query any data type.
+        
         fields={}
         for i in result.distinct('_id'):
             fields[i] = {'type': 'string'}


### PR DESCRIPTION
# Overview
- The get_fields method was not called on the constructor, and thus the list of fields was empty.
- The get_fields method was not providing a dictionary (name, type), but a list of fields.

As a consequence, the queryables were not rendered for the mongo data provider.

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/938

# Additional Information
As mongo is schemaless, the queryables type was set to 'string' in every field.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
