### PR TITLE
[WIP] preserve predefined links for item responses

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1912,7 +1912,7 @@ class API:
             '{}/{}/items/{}'.format(
                 self.get_collections_url(), dataset, identifier)
 
-        content['links'] = [{
+        content['links'].extend([{
             'rel': request.get_linkrel(F_JSON),
             'type': 'application/geo+json',
             'title': 'This document as GeoJSON',
@@ -1934,7 +1934,7 @@ class API:
                                     request.locale),
             'href': '{}/{}'.format(
                 self.get_collections_url(), dataset)
-        }]
+        }])
 
         if 'prev' in content:
             content['links'].append({

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1912,6 +1912,9 @@ class API:
             '{}/{}/items/{}'.format(
                 self.get_collections_url(), dataset, identifier)
 
+        if 'links' not in content:
+            content['links'] = []
+
         content['links'].extend([{
             'rel': request.get_linkrel(F_JSON),
             'type': 'application/geo+json',


### PR DESCRIPTION
# Overview
This PR extends single item link relations to support the case where a provider item response already contains a `links` object.

# Related Issue / Discussion
None

# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
