### PR TITLE
fix refs for default templates

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -602,7 +602,7 @@ class API:
         self.default_locale = self.locales[0]
 
         if 'templates' not in self.config['server']:
-            self.config['server']['templates'] = TEMPLATES
+            self.config['server']['templates'] = {'path': TEMPLATES}
 
         if 'pretty_print' not in self.config['server']:
             self.config['server']['pretty_print'] = False


### PR DESCRIPTION
# Overview
This PR sets default template objects in alignment to the schema.

# Related Issue / Discussion
None

# Additional Information
Thanks to @webb-ben for the fix.
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
