### PR TITLE
Relax click requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Babel
-click>7,<=8
+click>7,<=9
 Flask
 jsonschema
 pyproj


### PR DESCRIPTION
# Overview

Relaxes the `click` requirement from `<8` to `<9`. This resolves an issue where the `click` requirement is incompatible with recent versions of `black` (`>=22.0`).

# Related Issue / Discussion

- Closes #880

# Additional Information

The tests pass and I verified that the CLI commands still work (I did not see any CLI-specific tests).

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
