### PR TITLE
fix linked data ref for geometry objects with varying number of members

### DIFF
--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -326,6 +326,11 @@ def geom2schemageo(geom):
             except NotImplementedError:
                 poly_geom.extend(p.exterior.coords[:])
 
-    _ = [f'{x},{y}' for (x, y) in poly_geom]
-    f['schema:polygon'] = ' '.join(_)
+    try:
+        schema_polygon = [f'{x},{y}' for (x, y) in poly_geom]
+    except ValueError:
+        schema_polygon = [f'{x},{y},{z}' for (x, y, z) in poly_geom]
+
+    f['schema:polygon'] = ' '.join(schema_polygon)
+
     return f


### PR DESCRIPTION
# Overview
Fixes varying geometry members for linked data rendering.
# Related Issue / Discussion
#959 
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
