### PR TITLE
Corrects 'pip install guvicorn' to 'pip install uvicorn'

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -179,7 +179,7 @@ is simple to run from the command, e.g:
    gunicorn pygeoapi.starlette_app:app -w 4 -k uvicorn.workers.UvicornWorker
 
 .. note::
-   Uvicorn is as easy to install as ``pip install guvicorn``
+   Uvicorn is as easy to install as ``pip install uvicorn``
 
 Summary
 -------


### PR DESCRIPTION
# Overview
Fix Typo- uvicorn is installed using `pip install uvicorn`, documentation in running section updated to reflect correct pip install command.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
