### PR TITLE
Skip CSV row with invalid coordinates

### DIFF
--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -116,7 +116,8 @@ class CSVProvider(BaseProvider):
                         float(row.pop(self.geometry_y)),
                     ]
                 except ValueError:
-                    LOGGER.error(f"Skipping row with invalid coordinates id = {row.get(self.id_field)}")
+                    msg = f'Skipping row with invalid geometry: {row.get(self.id_field)}'  # noqa
+                    LOGGER.error(msg)
                     continue
                 feature = {'type': 'Feature'}
                 feature['id'] = row.pop(self.id_field)

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -110,15 +110,20 @@ class CSVProvider(BaseProvider):
                 return feature_collection
             LOGGER.debug('Slicing CSV rows')
             for row in itertools.islice(data_, offset, offset+limit):
+                try:
+                    coordinates = [
+                        float(row.pop(self.geometry_x)),
+                        float(row.pop(self.geometry_y)),
+                    ]
+                except ValueError:
+                    LOGGER.error(f"Skipping row with invalid coordinates id = {row.get(self.id_field)}")
+                    continue
                 feature = {'type': 'Feature'}
                 feature['id'] = row.pop(self.id_field)
                 if not skip_geometry:
                     feature['geometry'] = {
                         'type': 'Point',
-                        'coordinates': [
-                            float(row.pop(self.geometry_x)),
-                            float(row.pop(self.geometry_y))
-                        ]
+                        'coordinates': coordinates
                     }
                 else:
                     feature['geometry'] = None


### PR DESCRIPTION
# Overview

When a CSV file contains invalid coordinates, skip the row completely and continue with next one. Also, a notification is added to the logs

# Related Issue / Discussion

Closes #958

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
