### PR TITLE
Restore translations after recreating env

### DIFF
--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -359,6 +359,7 @@ def render_j2_template(config, template, data, locale_=None):
             LOGGER.debug('Custom template not found; using default')
             env = Environment(loader=FileSystemLoader(TEMPLATES),
                               extensions=['jinja2.ext.i18n'])
+            env.install_gettext_translations(translations)
             template = env.get_template(template)
         else:
             raise


### PR DESCRIPTION
# Overview

when env is recreated for custom templates, the loaded translations get lost, user gets error 'gettext undefined'

# Related Issue / Discussion

resolves #968

# Contributions and Licensing

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
