### PR TITLE
Update OATiles to the latest specification changes #1

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2320,6 +2320,20 @@ class API:
                 'dataType' : 'vector',
                 'links': []
             }
+            tile_matrix['links'].append({
+                'type': FORMAT_TYPES[F_JSON],
+                'rel': request.get_linkrel(F_JSON),
+                'title': '{} - {} - {}'.format(dataset,matrix['tileMatrixSet'],F_JSON),
+                'href': '{}/{}/tiles/{}?f={}'.format(
+                    self.get_collections_url(), dataset, matrix['tileMatrixSet'],F_JSON)
+            })
+            tile_matrix['links'].append({
+                'type': FORMAT_TYPES[F_HTML],
+                'rel': request.get_linkrel(F_HTML),
+                'title': '{} - {} - {}'.format(dataset,matrix['tileMatrixSet'],F_HTML),
+                'href': '{}/{}/tiles/{}?f={}'.format(
+                    self.get_collections_url(), dataset, matrix['tileMatrixSet'],F_HTML)
+            })
             tiles['tilesets'].append(tile_matrix)
 
         metadata_format = p.options['metadata_format']

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2272,8 +2272,6 @@ class API:
             return self.get_exception(
                 500, headers, request.format, 'NoApplicableCode', msg)
 
-        title = dataset
-
         tiles = {
             'links': [],
             'tilesets': []
@@ -2314,25 +2312,29 @@ class API:
 
         for matrix in tiling_schemes:
             tile_matrix = {
-                'title' : dataset,
-                'tileMatrixSetURI' : matrix['tileMatrixSetURI'],
-                'crs' : matrix['crs'],
-                'dataType' : 'vector',
+                'title': dataset,
+                'tileMatrixSetURI': matrix['tileMatrixSetURI'],
+                'crs': matrix['crs'],
+                'dataType': 'vector',
                 'links': []
             }
             tile_matrix['links'].append({
                 'type': FORMAT_TYPES[F_JSON],
                 'rel': request.get_linkrel(F_JSON),
-                'title': '{} - {} - {}'.format(dataset,matrix['tileMatrixSet'],F_JSON),
+                'title': '{} - {} - {}'.format(
+                    dataset, matrix['tileMatrixSet'], F_JSON),
                 'href': '{}/{}/tiles/{}?f={}'.format(
-                    self.get_collections_url(), dataset, matrix['tileMatrixSet'],F_JSON)
+                    self.get_collections_url(), dataset,
+                    matrix['tileMatrixSet'], F_JSON)
             })
             tile_matrix['links'].append({
                 'type': FORMAT_TYPES[F_HTML],
                 'rel': request.get_linkrel(F_HTML),
-                'title': '{} - {} - {}'.format(dataset,matrix['tileMatrixSet'],F_HTML),
+                'title': '{} - {} - {}'.format(
+                    dataset, matrix['tileMatrixSet'], F_HTML),
                 'href': '{}/{}/tiles/{}?f={}'.format(
-                    self.get_collections_url(), dataset, matrix['tileMatrixSet'],F_HTML)
+                    self.get_collections_url(), dataset,
+                    matrix['tileMatrixSet'], F_HTML)
             })
             tiles['tilesets'].append(tile_matrix)
 

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2272,13 +2272,11 @@ class API:
             return self.get_exception(
                 500, headers, request.format, 'NoApplicableCode', msg)
 
+        title = dataset
+
         tiles = {
-            'title': dataset,
-            'description': l10n.translate(
-                self.config['resources'][dataset]['description'],
-                SYSTEM_LOCALE),
             'links': [],
-            'tileMatrixSetLinks': []
+            'tilesets': []
         }
 
         tiles['links'].append({
@@ -2312,7 +2310,18 @@ class API:
         for service in tile_services['links']:
             tiles['links'].append(service)
 
-        tiles['tileMatrixSetLinks'] = p.get_tiling_schemes()
+        tiling_schemes = p.get_tiling_schemes()
+
+        for matrix in tiling_schemes:
+            tile_matrix = {
+                'title' : dataset,
+                'tileMatrixSetURI' : matrix['tileMatrixSetURI'],
+                'crs' : matrix['crs'],
+                'dataType' : 'vector',
+                'links': []
+            }
+            tiles['tilesets'].append(tile_matrix)
+
         metadata_format = p.options['metadata_format']
 
         if request.format == F_HTML:  # render

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -55,14 +55,15 @@ class MVTProvider(BaseTileProvider):
         """
 
         super().__init__(provider_def)
-
         if is_url(self.data):
             url = urlparse(self.data)
             baseurl = '{}://{}'.format(url.scheme, url.netloc)
             param_type = '?f=mvt'
+            layer = url.path.split('/{z}/{x}/{y}')[0]
+            tilepath = '{}/tiles'.format(layer)
             servicepath = \
-                '{}/tiles/{{{}}}/{{{}}}/{{{}}}/{{{}}}{}'.format(
-                    url.path.split('/{z}/{x}/{y}')[0],
+                '{}/{{{}}}/{{{}}}/{{{}}}/{{{}}}{}'.format(
+                    tilepath,
                     'tileMatrixSetId',
                     'tileMatrix',
                     'tileRow',
@@ -105,7 +106,7 @@ class MVTProvider(BaseTileProvider):
             url = urlparse(self.data)
             return url.path.split("/{z}/{x}/{y}")[0][1:]
         else:
-            return None
+            return Path(self.data).name
 
     def get_tiling_schemes(self):
 
@@ -156,21 +157,26 @@ class MVTProvider(BaseTileProvider):
         self._service_metadata_url = urljoin(
             self.service_url.split('{tileMatrix}/{tileRow}/{tileCol}')[0],
             'metadata')
-
         links = {
-            'links': [{
-                'type': self.mimetype,
-                'rel': 'item',
-                'title': 'This collection as Mapbox vector tiles',
-                'href': self.service_url,
-                'templated': True
-            }, {
-                'type': 'application/json',
-                'rel': 'describedby',
-                'title': 'Metadata for this collection in the TileJSON format',
-                'href': '{}?f=json'.format(self.service_metadata_url),
-                'templated': True
-            }]
+            'links': [
+                {
+                    'type': 'application/json',
+                    'rel': 'self',
+                    'title': 'This collection as multi vector tilesets',
+                    'href': self.service_url,
+                },
+                {
+                    'type': self.mimetype,
+                    'rel': 'item',
+                    'title': 'This collection as multi vector tiles',
+                    'href': self.service_url,
+                }, {
+                    'type': 'application/json',
+                    'rel': 'describedby',
+                    'title': 'Metadata for this collection in the TileJSON format',
+                    'href': '{}?f=json'.format(self.service_metadata_url),
+                }
+            ]
         }
 
         return links

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -112,10 +112,12 @@ class MVTProvider(BaseTileProvider):
 
         tile_matrix_set_links_list = [{
                 'tileMatrixSet': 'WorldCRS84Quad',
-                'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json'  # noqa
+                'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json',  # noqa
+                'crs' : 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
             }, {
                 'tileMatrixSet': 'WebMercatorQuad',
-                'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WebMercatorQuad.json'  # noqa
+                'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WebMercatorQuad.json',  # noqa
+                'crs' : 'http://www.opengis.net/def/crs/EPSG/0/3857'
             }]
         tile_matrix_set_links = [
             item for item in tile_matrix_set_links_list if item[

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -113,11 +113,11 @@ class MVTProvider(BaseTileProvider):
         tile_matrix_set_links_list = [{
                 'tileMatrixSet': 'WorldCRS84Quad',
                 'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json',  # noqa
-                'crs' : 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+                'crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
             }, {
                 'tileMatrixSet': 'WebMercatorQuad',
                 'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WebMercatorQuad.json',  # noqa
-                'crs' : 'http://www.opengis.net/def/crs/EPSG/0/3857'
+                'crs': 'http://www.opengis.net/def/crs/EPSG/0/3857'
             }]
         tile_matrix_set_links = [
             item for item in tile_matrix_set_links_list if item[
@@ -175,7 +175,7 @@ class MVTProvider(BaseTileProvider):
                 }, {
                     'type': 'application/json',
                     'rel': 'describedby',
-                    'title': 'Metadata for this collection in the TileJSON format',
+                    'title': 'Collection metadata in TileJSON format',
                     'href': '{}?f=json'.format(self.service_metadata_url),
                 }
             ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1125,7 +1125,8 @@ def test_get_collection_tiles(config, api_):
         req, 'naturalearth/lakes')
     assert rsp_headers['Content-Language'] == 'en-US'
     content = json.loads(response)
-    assert content['description'] == 'lakes of the world, public domain'
+    assert len(content['links']) > 0
+    assert len(content['tilesets']) > 0
 
 
 def test_describe_processes(config, api_):


### PR DESCRIPTION
# Overview
This PR updates `collections/{collectionId}/tiles` endpoint to the latest OGC API Tiles specification as discussed in https://github.com/geopython/pygeoapi/issues/699.

- [x] tilesets should replace tileMatrixSetLinks
- [x] there should also be a link to a TileSet resource, where the actual item link to tiles will be (/tiles is only the "list of tilesets")

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/699

# Additional Information
More changes are required to close https://github.com/geopython/pygeoapi/issues/699

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute the bugfix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
