### PR TITLE
add support for API transactions

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -176,6 +176,8 @@ default.
               - type: feature # underlying data geospatial type: (allowed values are: feature, coverage, record, tile, edr)
                 default: true  # optional: if not specified, the first provider definition is considered the default
                 name: CSV
+                # transactions: DO NOT ACTIVATE unless you have setup access contol beyond pygeoapi
+                editable: true  # optional: if backend is writable, default is false
                 data: tests/data/obs.csv  # required: the data filesystem path or URL, depending on plugin setup
                 id_field: id  # required for vector data, the field corresponding to the ID
                 uri_field: uri # optional field corresponding to the Uniform Resource Identifier (see Linked Data section)

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -15,19 +15,19 @@ pygeoapi core feature providers are listed below, along with a matrix of support
 parameters.
 
 .. csv-table::
-   :header: Provider, property filters/display, resulttype, bbox, datetime, sortby, skipGeometry, CQL
+   :header: Provider, property filters/display, resulttype, bbox, datetime, sortby, skipGeometry, CQL, transactions
    :align: left
 
-   CSV,✅/✅,results/hits,❌,❌,❌,✅,❌
-   Elasticsearch,✅/✅,results/hits,✅,✅,✅,✅,✅
-   ESRIFeatureService,✅/✅,results/hits,✅,✅,✅,✅,❌
-   GeoJSON,✅/✅,results/hits,❌,❌,❌,✅,❌
-   MongoDB,✅/❌,results,✅,✅,✅,✅,❌
-   OGR,✅/❌,results/hits,✅,❌,❌,✅,❌
-   PostgreSQL,✅/✅,results/hits,✅,❌,✅,✅,❌
-   SQLiteGPKG,✅/❌,results/hits,✅,❌,❌,✅,❌
-   SensorThingsAPI,✅/✅,results/hits,✅,✅,✅,✅,❌
-   Socrata,✅/✅,results/hits,✅,✅,✅,✅,❌
+   CSV,✅/✅,results/hits,❌,❌,❌,✅,❌,❌
+   Elasticsearch,✅/✅,results/hits,✅,✅,✅,✅,✅,✅
+   ESRIFeatureService,✅/✅,results/hits,✅,✅,✅,✅,❌,❌
+   GeoJSON,✅/✅,results/hits,❌,❌,❌,✅,❌,❌
+   MongoDB,✅/❌,results,✅,✅,✅,✅,❌,❌
+   OGR,✅/❌,results/hits,✅,❌,❌,✅,❌,❌
+   PostgreSQL,✅/✅,results/hits,✅,❌,✅,✅,❌,❌
+   SQLiteGPKG,✅/❌,results/hits,✅,❌,❌,✅,❌,❌
+   SensorThingsAPI,✅/✅,results/hits,✅,✅,✅,✅,❌,❌
+   Socrata,✅/✅,results/hits,✅,✅,✅,✅,❌,❌
 
 
 Below are specific connection examples based on supported providers.
@@ -86,6 +86,7 @@ To publish an Elasticsearch index, the following are required in your index:
    providers:
        - type: feature
          name: Elasticsearch
+         editable: true|false  # optional, default is false
          data: http://localhost:9200/ne_110m_populated_places_simple
          id_field: geonameid
          time_field: datetimefield

--- a/docs/source/data-publishing/ogcapi-records.rst
+++ b/docs/source/data-publishing/ogcapi-records.rst
@@ -15,11 +15,11 @@ pygeoapi core record providers are listed below, along with a matrix of supporte
 parameters.
 
 .. csv-table::
-   :header: Provider, properties (filters), resulttype, q, bbox, datetime, sortby, properties (display)
+   :header: Provider, properties (filters), resulttype, q, bbox, datetime, sortby, properties (display), transactions
    :align: left
 
-   ElasticsearchCatalogue,✅,results/hits,✅,✅,✅,✅
-   TinyDBCatalogue,✅,results/hits,✅,✅,✅,✅
+   ElasticsearchCatalogue,✅,results/hits,✅,✅,✅,✅,❌
+   TinyDBCatalogue,✅,results/hits,✅,✅,✅,✅,✅
 
 
 Below are specific connection examples based on supported providers.
@@ -63,6 +63,7 @@ To publish a TinyDB index, the following are required in your index:
 
    providers:
        - type: record
+         editable: true|false  # optional, default is false
          name: TinyDBCatalogue
          data: /path/to/file.db
          id_field: identifier

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,7 @@ reference documentation on all aspects of the project.
    tour
    openapi
    data-publishing/index
+   transactions
    plugins
    html-templating
    cql

--- a/docs/source/tour.rst
+++ b/docs/source/tour.rst
@@ -88,6 +88,32 @@ map.
 .. seealso::
    :ref:`ogcapi-features` for more OGC API - Features request examples.
 
+.. _transactions_examples:
+
+Transactions
+^^^^^^^^^^^^
+
+Add an item to a collection (using `curl`_):
+
+.. code-block:: bash
+
+   curl -XPOST -H "Content-Type: application/geo+json" http://localhost:5000/collections/canada-metadata/items -d @new-item.json
+
+
+Update an item in a collection (using `curl`_):
+
+.. code-block:: bash
+
+   curl -XPUT -H "Content-Type: application/geo+json" http://localhost:5000/collections/canada-metadata/items/item1 -d @updated-feature.json
+
+
+Delete an item from a collection:
+
+.. code-block:: bash
+
+   curl -XDELETE http://localhost:5000/collections/canada-metadata/items/item1
+
+
 Raster data
 -----------
 
@@ -147,6 +173,11 @@ This page provides metadata catalogue search capabilities
 
 .. seealso::
    :ref:`ogcapi-records` for more OGC API - Records request examples.
+
+Transactions
+^^^^^^^^^^^^
+
+See the :ref:`transactions_examples` section for examples.
 
 
 Processes
@@ -218,3 +249,4 @@ discover what is supported by the server.
 
 .. _`Toronto, Ontario, Canada`: https://en.wikipedia.org/wiki/Toronto
 .. _`Swagger`: https://en.wikipedia.org/wiki/Swagger_(software)
+.. _`curl`: https://curl.se

--- a/docs/source/transactions.rst
+++ b/docs/source/transactions.rst
@@ -1,0 +1,19 @@
+.. _transactions:
+
+Transactions
+============
+
+pygeoapi supports the `OGC API - Features - Part 4: Create, Replace, Update and Delete`_ draft specification, allowing
+for transactional capabilities against feature and record data.
+
+To enable transactions in pygeoapi, a given resource provider needs to be editable (via the configuration resource provider
+``editable: true`` property).  Note that the feature or record provider MUST support create/update/delete.  See the
+:ref:`ogcapi-features` and :ref:`ogcapi-records` documentation for transaction support status of pygeoapi backends.
+
+Access control
+^^^^^^^^^^^^^^
+
+It should be made clear that authentication and authorization is beyond the responsibility of pygeoapi.  This means that
+if a pygeoapi user enables transactions, they must provide access control explicity via another service.
+
+.. _`OGC API - Features - Part 4: Create, Replace, Update and Delete`: http://docs.ogc.org/DRAFTS/20-002.html

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -918,6 +918,18 @@ class API:
             LOGGER.debug('Adding JSON and HTML link relations')
             collection['links'].append({
                 'type': FORMAT_TYPES[F_JSON],
+                'rel': 'root',
+                'title': 'The landing page of this server as JSON',
+                'href': '{}?f={}'.format(self.config['server']['url'], F_JSON)
+            })
+            collection['links'].append({
+                'type': FORMAT_TYPES[F_HTML],
+                'rel': 'root',
+                'title': 'The landing page of this server as HTML',
+                'href': '{}?f={}'.format(self.config['server']['url'], F_HTML)
+            })
+            collection['links'].append({
+                'type': FORMAT_TYPES[F_JSON],
                 'rel': request.get_linkrel(F_JSON),
                 'title': 'This document as JSON',
                 'href': '{}/{}?f={}'.format(
@@ -2024,6 +2036,16 @@ class API:
             content['links'] = []
 
         content['links'].extend([{
+            'type': FORMAT_TYPES[F_JSON],
+            'rel': 'root',
+            'title': 'The landing page of this server as JSON',
+            'href': '{}?f={}'.format(self.config['server']['url'], F_JSON)
+            }, {
+            'type': FORMAT_TYPES[F_HTML],
+            'rel': 'root',
+            'title': 'The landing page of this server as HTML',
+            'href': '{}?f={}'.format(self.config['server']['url'], F_HTML)
+            }, {
             'rel': request.get_linkrel(F_JSON),
             'type': 'application/geo+json',
             'title': 'This document as GeoJSON',
@@ -3398,7 +3420,7 @@ class API:
             400, headers, request.format, 'InvalidParameterValue', msg)
 
     def get_collections_url(self):
-        return '{}/collections'.format((self.config['server']['url']))
+        return '{}/collections'.format(self.config['server']['url'])
 
 
 def validate_bbox(value=None) -> list:

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1897,8 +1897,8 @@ class API:
                 400, headers, request.format, 'InvalidParameterValue', msg)
 
         if action in ['create', 'update'] and not request.data:
-            LOGGER.error(msg)
             msg = 'No data found'
+            LOGGER.error(msg)
             return self.get_exception(
                 400, headers, request.format, 'InvalidParameterValue', msg)
 

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -61,8 +61,8 @@ from pygeoapi.process.base import ProcessorExecuteError
 from pygeoapi.plugin import load_plugin, PLUGINS
 from pygeoapi.provider.base import (
     ProviderGenericError, ProviderConnectionError, ProviderNotFoundError,
-    ProviderInvalidQueryError, ProviderNoDataError, ProviderQueryError,
-    ProviderItemNotFoundError, ProviderTypeError)
+    ProviderInvalidDataError, ProviderInvalidQueryError, ProviderNoDataError,
+    ProviderQueryError, ProviderItemNotFoundError, ProviderTypeError)
 
 from pygeoapi.provider.tile import (ProviderTileNotFoundError,
                                     ProviderTileQueryError,
@@ -107,7 +107,8 @@ CONFORMANCE = {
         'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
         'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30',
         'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html',
-        'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson'
+        'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson',
+        'http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/create-replace-delete'  # noqa
     ],
     'coverage': [
         'http://www.opengis.net/spec/ogcapi-coverages-1/1.0/conf/core',
@@ -1842,6 +1843,100 @@ class API:
             pass
 
         return headers, 200, to_json(content, self.pretty_print)
+
+    @gzip
+    @pre_process
+    def manage_collection_item(
+            self, request: Union[APIRequest, Any],
+            action, dataset, identifier=None) -> Tuple[dict, int, str]:
+        """
+        Adds an item to a collection
+
+        :param request: A request object
+        :param dataset: dataset name
+
+        :returns: tuple of headers, status code, content
+        """
+
+        if not request.is_valid(PLUGINS['formatter'].keys()):
+            return self.get_format_exception(request)
+
+        # Set Content-Language to system locale until provider locale
+        # has been determined
+        headers = request.get_response_headers(SYSTEM_LOCALE)
+
+        collections = filter_dict_by_key_value(self.config['resources'],
+                                               'type', 'collection')
+
+        if dataset not in collections.keys():
+            msg = 'Collection not found'
+            LOGGER.error(msg)
+            return self.get_exception(
+                404, headers, request.format, 'NotFound', msg)
+
+        LOGGER.debug('Loading provider')
+        try:
+            provider_def = get_provider_by_type(
+                collections[dataset]['providers'], 'feature')
+            p = load_plugin('provider', provider_def)
+        except ProviderTypeError:
+            try:
+                provider_def = get_provider_by_type(
+                    collections[dataset]['providers'], 'record')
+                p = load_plugin('provider', provider_def)
+            except ProviderTypeError:
+                msg = 'Invalid provider type'
+                LOGGER.error(msg)
+                return self.get_exception(
+                    400, headers, request.format, 'InvalidParameterValue', msg)
+
+        if not p.editable:
+            msg = 'Collection is not editable'
+            LOGGER.error(msg)
+            return self.get_exception(
+                400, headers, request.format, 'InvalidParameterValue', msg)
+
+        if action in ['create', 'update'] and not request.data:
+            LOGGER.error(msg)
+            msg = 'No data found'
+            return self.get_exception(
+                400, headers, request.format, 'InvalidParameterValue', msg)
+
+        if action == 'create':
+            LOGGER.debug('Creating item')
+            try:
+                identifier = p.create(request.data)
+            except ProviderInvalidDataError as err:
+                msg = str(err)
+                return self.get_exception(
+                    400, headers, request.format, 'InvalidParameterValue', msg)
+
+            headers['Location'] = '{}/{}/items/{}'.format(
+                self.get_collections_url(), dataset, identifier)
+
+            return headers, 201, ''
+
+        if action == 'update':
+            LOGGER.debug('Updating item')
+            try:
+                _ = p.update(identifier, request.data)
+            except ProviderGenericError as err:
+                msg = str(err)
+                return self.get_exception(
+                    400, headers, request.format, 'InvalidParameterValue', msg)
+
+            return headers, 204, ''
+
+        if action == 'delete':
+            LOGGER.debug('Deleting item')
+            try:
+                _ = p.delete(identifier)
+            except ProviderGenericError as err:
+                msg = str(err)
+                return self.get_exception(
+                    400, headers, request.format, 'InvalidParameterValue', msg)
+
+            return headers, 200, ''
 
     @gzip
     @pre_process

--- a/pygeoapi/django_/views.py
+++ b/pygeoapi/django_/views.py
@@ -87,10 +87,8 @@ def conformance(request: HttpRequest) -> HttpResponse:
     return response
 
 
-def collections(
-    request: HttpRequest,
-    collection_id: Optional[str] = None,
-) -> HttpResponse:
+def collections(request: HttpRequest,
+                collection_id: Optional[str] = None) -> HttpResponse:
     """
     OGC API collections endpoint
 
@@ -106,10 +104,8 @@ def collections(
     return response
 
 
-def collection_queryables(
-    request: HttpRequest,
-    collection_id: Optional[str] = None,
-) -> HttpResponse:
+def collection_queryables(request: HttpRequest,
+                          collection_id: Optional[str] = None) -> HttpResponse:
     """
     OGC API collections queryables endpoint
 
@@ -127,10 +123,7 @@ def collection_queryables(
     return response
 
 
-def collection_items(
-    request: HttpRequest,
-    collection_id: str,
-) -> HttpResponse:
+def collection_items(request: HttpRequest, collection_id: str) -> HttpResponse:
     """
     OGC API collections items endpoint
 
@@ -140,21 +133,24 @@ def collection_items(
     :returns: Django HTTP response
     """
 
-    response_ = _feed_response(
-        request,
-        'get_collection_items',
-        collection_id,
-    )
+    if request.method == 'GET':
+        response_ = _feed_response(
+            request,
+            'get_collection_items',
+            collection_id,
+        )
+    elif request.method == 'POST':
+        response_ = _feed_response(
+            request, 'manage_collection_item', request, 'create', collection_id
+        )
+
     response = _to_django_response(*response_)
 
     return response
 
 
-def collection_item(
-    request: HttpRequest,
-    collection_id: str,
-    item_id: str,
-) -> HttpResponse:
+def collection_item(request: HttpRequest,
+                    collection_id: str, item_id: str) -> HttpResponse:
     """
     OGC API collections items endpoint
 
@@ -165,18 +161,28 @@ def collection_item(
     :returns: Django HTTP response
     """
 
-    response_ = _feed_response(
-        request, 'get_collection_item', collection_id, item_id
-    )
+    if request.method == 'GET':
+        response_ = _feed_response(
+            request, 'get_collection_item', collection_id, item_id
+        )
+    elif request.method == 'PUT':
+        response_ = _feed_response(
+            request, 'manage_collection_item', request, 'update',
+            collection_id, item_id
+        )
+    elif request.method == 'DELETE':
+        response_ = _feed_response(
+            request, 'manage_collection_item', request, 'delete',
+            collection_id, item_id
+        )
+
     response = _to_django_response(*response_)
 
     return response
 
 
-def collection_coverage(
-    request: HttpRequest,
-    collection_id: str,
-) -> HttpResponse:
+def collection_coverage(request: HttpRequest,
+                        collection_id: str) -> HttpResponse:
     """
     OGC API - Coverages coverage endpoint
 
@@ -194,10 +200,8 @@ def collection_coverage(
     return response
 
 
-def collection_coverage_domainset(
-    request: HttpRequest,
-    collection_id: str,
-) -> HttpResponse:
+def collection_coverage_domainset(request: HttpRequest,
+                                  collection_id: str) -> HttpResponse:
     """
     OGC API - Coverages coverage domainset endpoint
 
@@ -215,10 +219,8 @@ def collection_coverage_domainset(
     return response
 
 
-def collection_coverage_rangetype(
-    request: HttpRequest,
-    collection_id: str,
-) -> HttpResponse:
+def collection_coverage_rangetype(request: HttpRequest,
+                                  collection_id: str) -> HttpResponse:
     """
     OGC API - Coverages coverage rangetype endpoint
 
@@ -236,10 +238,7 @@ def collection_coverage_rangetype(
     return response
 
 
-def collection_tiles(
-    request: HttpRequest,
-    collection_id: str,
-) -> HttpResponse:
+def collection_tiles(request: HttpRequest, collection_id: str) -> HttpResponse:
     """
     OGC API - Tiles collection tiles endpoint
 
@@ -255,11 +254,8 @@ def collection_tiles(
     return response
 
 
-def collection_tiles_metadata(
-    request: HttpRequest,
-    collection_id: str,
-    tileMatrixSetId: str,
-) -> HttpResponse:
+def collection_tiles_metadata(request: HttpRequest, collection_id: str,
+                              tileMatrixSetId: str) -> HttpResponse:
     """
     OGC API - Tiles collection tiles metadata endpoint
 
@@ -281,14 +277,9 @@ def collection_tiles_metadata(
     return response
 
 
-def collection_item_tiles(
-    request: HttpRequest,
-    collection_id: str,
-    tileMatrixSetId: str,
-    tileMatrix: str,
-    tileRow: str,
-    tileCol: str,
-) -> HttpResponse:
+def collection_item_tiles(request: HttpRequest, collection_id: str,
+                          tileMatrixSetId: str, tileMatrix: str,
+                          tileRow: str, tileCol: str,) -> HttpResponse:
     """
     OGC API - Tiles collection tiles data endpoint
 
@@ -316,10 +307,8 @@ def collection_item_tiles(
     return response
 
 
-def processes(
-    request: HttpRequest,
-    process_id: Optional[str] = None,
-) -> HttpResponse:
+def processes(request: HttpRequest,
+              process_id: Optional[str] = None) -> HttpResponse:
     """
     OGC API - Processes description endpoint
 
@@ -335,10 +324,7 @@ def processes(
     return response
 
 
-def jobs(
-    request: HttpRequest,
-    job_id: Optional[str] = None,
-) -> HttpResponse:
+def jobs(request: HttpRequest, job_id: Optional[str] = None) -> HttpResponse:
     """
     OGC API - Jobs endpoint
 
@@ -348,16 +334,15 @@ def jobs(
 
     :returns: Django HTTP response
     """
+
     response_ = _feed_response(request, 'get_jobs', job_id)
     response = _to_django_response(*response_)
 
     return response
 
 
-def job_results(
-    request: HttpRequest,
-    job_id: Optional[str] = None,
-) -> HttpResponse:
+def job_results(request: HttpRequest,
+                job_id: Optional[str] = None) -> HttpResponse:
     """
     OGC API - Job result endpoint
 
@@ -366,18 +351,15 @@ def job_results(
 
     :returns: Django HTTP response
     """
+
     response_ = _feed_response(request, 'get_job_result', job_id)
     response = _to_django_response(*response_)
 
     return response
 
 
-def job_results_resource(
-    request: HttpRequest,
-    process_id: str,
-    job_id: str,
-    resource: str,
-) -> HttpResponse:
+def job_results_resource(request: HttpRequest, process_id: str, job_id: str,
+                         resource: str) -> HttpResponse:
     """
     OGC API - Job result resource endpoint
 
@@ -387,6 +369,7 @@ def job_results_resource(
 
     :returns: Django HTTP response
     """
+
     response_ = _feed_response(
         request,
         'get_job_result_resource',
@@ -398,11 +381,8 @@ def job_results_resource(
     return response
 
 
-def get_collection_edr_query(
-    request: HttpRequest,
-    collection_id: str,
-    instance_id: str,
-) -> HttpResponse:
+def get_collection_edr_query(request: HttpRequest, collection_id: str,
+                             instance_id: str) -> HttpResponse:
     """
     OGC API - EDR endpoint
 
@@ -412,6 +392,7 @@ def get_collection_edr_query(
 
     :returns: Django HTTP response
     """
+
     query_type = request.path.split('/')[-1]
     response_ = _feed_response(
         request,
@@ -440,10 +421,7 @@ def stac_catalog_root(request: HttpRequest) -> HttpResponse:
     return response
 
 
-def stac_catalog_path(
-    request: HttpRequest,
-    path: str,
-) -> HttpResponse:
+def stac_catalog_path(request: HttpRequest, path: str) -> HttpResponse:
     """
     STAC path endpoint
 
@@ -463,22 +441,21 @@ def stac_catalog_search(request: HttpRequest) -> HttpResponse:
     pass
 
 
-def _feed_response(
-    request: HttpRequest, api_definition: str, *args, **kwargs
-) -> Tuple[Dict, int, str]:
+def _feed_response(request: HttpRequest, api_definition: str,
+                   *args, **kwargs) -> Tuple[Dict, int, str]:
     """Use pygeoapi api to process the input request"""
+
     api_ = API(settings.PYGEOAPI_CONFIG)
     api = getattr(api_, api_definition)
     return api(request, *args, **kwargs)
 
 
-def _to_django_response(
-    headers: Mapping,
-    status_code: int,
-    content: str,
-) -> HttpResponse:
+def _to_django_response(headers: Mapping, status_code: int,
+                        content: str) -> HttpResponse:
     """Convert API payload to a django response"""
+
     response = HttpResponse(content, status=status_code)
+
     for key, value in headers.items():
         response[key] = value
     return response

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -175,8 +175,10 @@ def collection_queryables(collection_id=None):
     return get_response(api_.get_collection_queryables(request, collection_id))
 
 
-@BLUEPRINT.route('/collections/<path:collection_id>/items', methods=['GET', 'POST'])  # noqa
-@BLUEPRINT.route('/collections/<path:collection_id>/items/<item_id>')
+@BLUEPRINT.route('/collections/<path:collection_id>/items',
+                 methods=['GET', 'POST'])
+@BLUEPRINT.route('/collections/<path:collection_id>/items/<item_id>',
+                 methods=['GET', 'PUT', 'DELETE'])
 def collection_items(collection_id, item_id=None):
     """
     OGC API collections items endpoint
@@ -186,14 +188,28 @@ def collection_items(collection_id, item_id=None):
 
     :returns: HTTP response
     """
+
     if item_id is None:
         if request.method == 'GET':  # list items
             return get_response(
                 api_.get_collection_items(request, collection_id))
-        elif request.method == 'POST':  # filter items
-            return get_response(
-                api_.post_collection_items(request, collection_id))
+        elif request.method == 'POST':  # filter or manage items
+            if request.content_type is not None:
+                return get_response(
+                    api_.manage_collection_item(request, 'create',
+                                                collection_id))
+            else:
+                return get_response(
+                    api_.post_collection_items(request, collection_id))
 
+    elif request.method == 'DELETE':
+        return get_response(
+            api_.manage_collection_item(request, 'delete',
+                                        collection_id, item_id))
+    elif request.method == 'PUT':
+        return get_response(
+            api_.manage_collection_item(request, 'update',
+                                        collection_id, item_id))
     else:
         return get_response(
             api_.get_collection_item(request, collection_id, item_id))

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -509,6 +509,28 @@ def get_oas_30(cfg):
                 }
             }
 
+            if p.editable:
+                LOGGER.debug('Provider is editable; adding post')
+                paths[items_path]['post'] = {
+                    'summary': 'Add {} items'.format(title),  # noqa
+                    'description': desc,
+                    'tags': [name],
+                    'operationId': 'add{}Features'.format(name.capitalize()),
+                    'consumes': ['application/json'],
+                    'produces': ['application/json'],
+                    'parameters': [{
+                        'in': 'body',
+                        'name': 'body',
+                        'description': 'Adds item to collection',
+                        'required': True,
+                    }],
+                    'responses': {
+                        '201': {'description': 'Successful creation'},
+                        '400': {'$ref': '{}#/components/responses/InvalidParameter'.format(OPENAPI_YAML['oapif'])},  # noqa
+                        '500': {'$ref': '{}#/components/responses/ServerError'.format(OPENAPI_YAML['oapif'])}  # noqa
+                    }
+                }
+
             if ptype == 'record':
                 paths[items_path]['get']['parameters'].append(
                     {'$ref': '{}/parameters/q.yaml'.format(OPENAPI_YAML['oapir'])})  # noqa
@@ -596,6 +618,53 @@ def get_oas_30(cfg):
                     }
                 }
             }
+
+            if p.editable:
+                LOGGER.debug('Provider is editable; adding put/delete')
+                paths['{}/items/{{featureId}}'.format(collection_name_path)]['put'] = {  # noqa
+                    'summary': 'Update {} items'.format(title),
+                    'description': desc,
+                    'tags': [name],
+                    'operationId': 'update{}Features'.format(name.capitalize()),  # noqa
+                    'consumes': ['application/json'],
+                    'produces': ['application/json'],
+                    'parameters': [
+                        {'$ref': '{}#/components/parameters/featureId'.format(OPENAPI_YAML['oapif'])},  # noqa
+                        {
+                            'in': 'body',
+                            'name': 'body',
+                            'description': 'Updates item in collection',
+                            'required': True,
+                        }
+                    ],
+                    'responses': {
+                        '204': {'description': 'Successful update'},
+                        '400': {'$ref': '{}#/components/responses/InvalidParameter'.format(OPENAPI_YAML['oapif'])},  # noqa
+                        '500': {'$ref': '{}#/components/responses/ServerError'.format(OPENAPI_YAML['oapif'])}  # noqa
+                    }
+                }
+                paths['{}/items/{{featureId}}'.format(collection_name_path)]['delete'] = {  # noqa
+                    'summary': 'Delete {} items'.format(title),
+                    'description': desc,
+                    'tags': [name],
+                    'operationId': 'delete{}Features'.format(name.capitalize()),  # noqa
+                    'produces': ['application/json'],
+                    'parameters': [
+                        {'$ref': '{}#/components/parameters/featureId'.format(OPENAPI_YAML['oapif'])},  # noqa
+                        {
+                            'in': 'body',
+                            'name': 'body',
+                            'description': 'Updates item in collection',
+                            'required': True,
+                        }
+                    ],
+                    'responses': {
+                        '200': {'description': 'Successful delete'},
+                        '400': {'$ref': '{}#/components/responses/InvalidParameter'.format(OPENAPI_YAML['oapif'])},  # noqa
+                        '500': {'$ref': '{}#/components/responses/ServerError'.format(OPENAPI_YAML['oapif'])}  # noqa
+                    }
+                }
+
         except ProviderTypeError:
             LOGGER.debug('collection is not feature based')
 

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -223,6 +223,11 @@ class BaseProvider:
             LOGGER.error(msg)
             raise ProviderInvalidDataError(msg)
 
+        if 'geometry' not in json_data or 'properties' not in json_data:
+            msg = 'Missing core GeoJSON geometry or properties'
+            LOGGER.error(msg)
+            raise ProviderInvalidDataError(msg)
+
         if raise_if_exists:
             LOGGER.debug('Querying database whether item exists')
             try:
@@ -233,11 +238,6 @@ class BaseProvider:
                 raise ProviderInvalidDataError(msg)
             except ProviderItemNotFoundError:
                 LOGGER.debug('record does not exist')
-
-        json_data['properties']['_metadata-anytext'] = ''.join([
-            json_data['properties']['title'],
-            json_data['properties']['description']
-        ])
 
         return identifier2, json_data
 

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2021 Tom Kralidis
+# Copyright (c) 2022 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -27,6 +27,7 @@
 #
 # =================================================================
 
+import json
 import logging
 
 LOGGER = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ class BaseProvider:
         except KeyError:
             raise RuntimeError('name/type/data are required')
 
+        self.editable = provider_def.get('editable', False)
         self.options = provider_def.get('options', None)
         self.id_field = provider_def.get('id_field', None)
         self.uri_field = provider_def.get('uri_field', None)
@@ -114,22 +116,42 @@ class BaseProvider:
         query the provider by id
 
         :param identifier: feature id
+
         :returns: dict of single GeoJSON feature
         """
 
         raise NotImplementedError()
 
-    def create(self, new_feature):
-        """Create a new feature
+    def create(self, item):
+        """
+        Create a new item
+
+        :param item: `dict` of new item
+
+        :returns: identifier of created item
         """
 
         raise NotImplementedError()
 
-    def update(self, identifier, new_feature):
-        """Updates an existing feature id with new_feature
+    def update(self, identifier, item):
+        """
+        Updates an existing item
 
         :param identifier: feature id
-        :param new_feature: new GeoJSON feature dictionary
+        :param item: `dict` of partial or full item
+
+        :returns: `bool` of update result
+        """
+
+        raise NotImplementedError()
+
+    def delete(self, identifier):
+        """
+        Deletes an existing item
+
+        :param identifier: item id
+
+        :returns: `bool` of deletion result
         """
 
         raise NotImplementedError()
@@ -152,13 +174,72 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def delete(self, identifier):
-        """Deletes an existing feature
+    def _load_and_prepare_item(self, item, identifier=None,
+                               raise_if_exists=True):
+        """
+        Helper function to load a record, detect its idenfier and prepare
+        a record item
 
-        :param identifier: feature id
+        :param item: `str` of incoming item data
+        :param identifier: `str` of item identifier (optional)
+        :param raise_if_exists: `bool` of whether to check if record
+                                 already exists
+
+        :returns: `tuple` of item identifier and item data/payload
         """
 
-        raise NotImplementedError()
+        identifier2 = None
+        msg = None
+
+        LOGGER.debug('Loading data')
+        LOGGER.debug('Data: {}'.format(item))
+        try:
+            json_data = json.loads(item)
+        except TypeError as err:
+            LOGGER.error(err)
+            msg = 'Invalid data'
+        except json.decoder.JSONDecodeError as err:
+            LOGGER.error(err)
+            msg = 'Invalid JSON data'
+
+        if msg is not None:
+            raise ProviderInvalidDataError(msg)
+
+        LOGGER.debug('Detecting identifier')
+        if identifier is not None:
+            identifier2 = identifier
+        else:
+            try:
+                identifier2 = json_data['id']
+            except KeyError:
+                LOGGER.debug('Cannot find id; trying properties.identifier')
+                try:
+                    identifier2 = json_data['properties']['identifier']
+                except KeyError:
+                    LOGGER.debug('Cannot find properties.identifier')
+
+        if identifier2 is None:
+            msg = 'Missing identifier (id or properties.identifier)'
+            LOGGER.error(msg)
+            raise ProviderInvalidDataError(msg)
+
+        if raise_if_exists:
+            LOGGER.debug('Querying database whether item exists')
+            try:
+                _ = self.get(identifier2)
+
+                msg = 'record already exists'
+                LOGGER.error(msg)
+                raise ProviderInvalidDataError(msg)
+            except ProviderItemNotFoundError:
+                LOGGER.debug('record does not exist')
+
+        json_data['properties']['_metadata-anytext'] = ''.join([
+            json_data['properties']['title'],
+            json_data['properties']['description']
+        ])
+
+        return identifier2, json_data
 
     def __repr__(self):
         return '<BaseProvider> {}'.format(self.type)
@@ -206,4 +287,9 @@ class ProviderNotFoundError(ProviderGenericError):
 
 class ProviderVersionError(ProviderGenericError):
     """provider incorrect version error"""
+    pass
+
+
+class ProviderInvalidDataError(ProviderGenericError):
+    """provider invalid data error"""
     pass

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -413,6 +413,55 @@ class ElasticsearchProvider(BaseProvider):
 
         return feature_
 
+    def create(self, item):
+        """
+        Create a new item
+
+        :param item: `dict` of new item
+
+        :returns: identifier of created item
+        """
+
+        identifier, json_data = self._load_and_prepare_item(item)
+
+        LOGGER.debug('Inserting data with identifier {}'.format(identifier))
+        _ = self.es.index(index=self.index_name, id=identifier, body=json_data)
+        LOGGER.debug('Item added')
+
+        return identifier
+
+    def update(self, identifier, item):
+        """
+        Updates an existing item
+
+        :param identifier: feature id
+        :param item: `dict` of partial or full item
+
+        :returns: `bool` of update result
+        """
+
+        LOGGER.debug('Updating item {}'.format(identifier))
+        identifier, json_data = self._load_and_prepare_item(
+            item, identifier, raise_if_exists=False)
+
+        _ = self.es.index(index=self.index_name, id=identifier, body=json_data)
+
+        return True
+
+    def delete(self, identifier):
+        """
+        Deletes an existing item
+
+        :param identifier: item id
+
+        :returns: `bool` of deletion result
+        """
+
+        LOGGER.debug('Deleting item {}'.format(identifier))
+        _ = self.es.delete(index=self.index_name, id=identifier)
+
+        return True
+
     def esdoc2geojson(self, doc):
         """
         generate GeoJSON `dict` from ES document

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -234,7 +234,6 @@ class TinyDBCatalogueProvider(BaseProvider):
             except KeyError:
                 LOGGER.debug('Missing excluded property {}'.format(e))
 
-
         return record
 
     def create(self, item):

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2021 Tom Kralidis
+# Copyright (c) 2022 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -28,10 +28,10 @@
 # =================================================================
 
 import logging
-import os
 import re  # noqa
+import os
 
-from tinydb import TinyDB, Query
+from tinydb import TinyDB, Query, where
 
 from pygeoapi.provider.base import (BaseProvider, ProviderConnectionError,
                                     ProviderQueryError,
@@ -65,7 +65,11 @@ class TinyDBCatalogueProvider(BaseProvider):
             LOGGER.error(msg)
             raise ProviderConnectionError(msg)
 
-        self.db = TinyDB(self.data, access_mode="r")
+        LOGGER.debug('Checking TinyDB DB permissions')
+        if not os.access(self.data, os.W_OK):
+            self.db = TinyDB(self.data, access_mode='r')
+        else:
+            self.db = TinyDB(self.data)
 
         self.fields = self.get_fields()
 
@@ -225,6 +229,55 @@ class TinyDBCatalogueProvider(BaseProvider):
             del record['properties'][e]
 
         return record
+
+    def create(self, item):
+        """
+        Adds an item to the TinyDB repository
+
+        :param item: item data
+
+        :returns: identifier of newly created item
+        """
+
+        identifier, json_data = self._load_and_prepare_item(item)
+
+        LOGGER.debug('Inserting data with identifier {}'.format(identifier))
+        result = self.db.insert(json_data)
+
+        LOGGER.debug('Item added with internal id {}'.format(result))
+
+        return identifier
+
+    def update(self, identifier, item):
+        """
+        Updates an existing item
+
+        :param identifier: feature id
+        :param item: `dict` of partial or full item
+
+        :returns: `bool` of update result
+        """
+
+        LOGGER.debug('Updating item {}'.format(identifier))
+        identifier, json_data = self._load_and_prepare_item(
+            item, identifier, raise_if_exists=False)
+        self.db.update(json_data, where('id') == identifier)
+
+        return True
+
+    def delete(self, identifier):
+        """
+        Deletes an existing item
+
+        :param identifier: item id
+
+        :returns: `bool` of deletion result
+        """
+
+        LOGGER.debug('Deleting item {}'.format(identifier))
+        self.db.remove(where('id') == identifier)
+
+        return True
 
     def _bbox(input_bbox, record_bbox):
         """

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -182,7 +182,10 @@ class TinyDBCatalogueProvider(BaseProvider):
 
         for r in results:
             for e in self.excludes:
-                del r['properties'][e]
+                try:
+                    del r['properties'][e]
+                except KeyError:
+                    LOGGER.debug('Missing excluded property {}'.format(e))
 
         len_results = len(results)
 
@@ -226,7 +229,11 @@ class TinyDBCatalogueProvider(BaseProvider):
             raise ProviderItemNotFoundError('record does not exist')
 
         for e in self.excludes:
-            del record['properties'][e]
+            try:
+                del record['properties'][e]
+            except KeyError:
+                LOGGER.debug('Missing excluded property {}'.format(e))
+
 
         return record
 
@@ -240,6 +247,15 @@ class TinyDBCatalogueProvider(BaseProvider):
         """
 
         identifier, json_data = self._load_and_prepare_item(item)
+
+        try:
+            json_data['properties']['_metadata-anytext'] = ''.join([
+                json_data['properties']['title'],
+                json_data['properties']['description']
+            ])
+        except KeyError:
+            LOGGER.debug('Missing title and description')
+            json_data['properties']['_metadata_anytext'] = ''
 
         LOGGER.debug('Inserting data with identifier {}'.format(identifier))
         result = self.db.insert(json_data)

--- a/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
+++ b/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
@@ -366,6 +366,9 @@ properties:
                                               - type: string
                                               - type: object
                                           description: the data filesystem path or URL, depending on plugin setup
+                                      editable:
+                                          type: boolean
+                                          description: whether the resource is editable
                                       table:
                                           type: string
                                           description: table name for RDBMS-based providers

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -233,7 +233,7 @@ async def collection_items(request: Request, collection_id=None, item_id=None):
                 api_.get_collection_items(
                     request, collection_id))
         elif request.method == 'POST':  # filter or manage items
-            if request.get('content-type') is not None:
+            if request.headers.get('content-type') is not None:
                 return get_response(
                     api_.manage_collection_item(request, 'create',
                                                 collection_id))

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -206,8 +206,10 @@ async def get_collection_items_tiles(request: Request, name=None,
 
 @app.route('/collections/{collection_id:path}/items', methods=['GET', 'POST'])
 @app.route('/collections/{collection_id:path}/items/', methods=['GET', 'POST'])
-@app.route('/collections/{collection_id:path}/items/{item_id}')
-@app.route('/collections/{collection_id:path}/items/{item_id}/')
+@app.route('/collections/{collection_id:path}/items/{item_id}',
+           methods=['GET', 'PUT', 'DELETE'])
+@app.route('/collections/{collection_id:path}/items/{item_id}/',
+           methods=['GET', 'PUT', 'DELETE'])
 async def collection_items(request: Request, collection_id=None, item_id=None):
     """
     OGC API collections items endpoint
@@ -218,6 +220,9 @@ async def collection_items(request: Request, collection_id=None, item_id=None):
 
     :returns: Starlette HTTP Response
     """
+
+    print(request.headers)
+#    print(request.headers['content-type'])
     if 'collection_id' in request.path_params:
         collection_id = request.path_params['collection_id']
     if 'item_id' in request.path_params:
@@ -227,10 +232,23 @@ async def collection_items(request: Request, collection_id=None, item_id=None):
             return get_response(
                 api_.get_collection_items(
                     request, collection_id))
-        elif request.method == 'POST':  # filter items
-            return get_response(
-                api_.post_collection_items(
-                    request, collection_id))
+        elif request.method == 'POST':  # filter or manage items
+            if request.get('content-type') is not None:
+                return get_response(
+                    api_.manage_collection_item(request, 'create',
+                                                collection_id))
+            else:
+                return get_response(
+                    api_.post_collection_items(request, collection_id))
+
+    elif request.method == 'DELETE':
+        return get_response(
+            api_.manage_collection_item(request, 'delete',
+                                        collection_id, item_id))
+    elif request.method == 'PUT':
+        return get_response(
+            api_.manage_collection_item(request, 'update',
+                                        collection_id, item_id))
     else:
         return get_response(api_.get_collection_item(
             request, collection_id, item_id))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -427,7 +427,7 @@ def test_conformance(config, api_):
 
     assert isinstance(root, dict)
     assert 'conformsTo' in root
-    assert len(root['conformsTo']) == 20
+    assert len(root['conformsTo']) == 21
 
     req = mock_request({'f': 'foo'})
     rsp_headers, code, response = api_.conformance(req)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -503,7 +503,7 @@ def test_describe_collections(config, api_):
     collection = json.loads(response)
 
     assert collection['id'] == 'gdps-temperature'
-    assert len(collection['links']) == 12
+    assert len(collection['links']) == 14
 
     # hiearchical collections
     rsp_headers, code, response = api_.describe_collections(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -569,7 +569,7 @@ def test_describe_collections_json_ld(config, api_):
     assert len(expanded['http://schema.org/dataset']) == 1
     dataset = expanded['http://schema.org/dataset'][0]
     assert dataset['@type'][0] == 'http://schema.org/Dataset'
-    assert len(dataset['http://schema.org/distribution']) == 14
+    assert len(dataset['http://schema.org/distribution']) == 12
     assert all(dist['@type'][0] == 'http://schema.org/DataDownload'
                for dist in dataset['http://schema.org/distribution'])
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -468,7 +468,7 @@ def test_describe_collections(config, api_):
     assert collection['id'] == 'obs'
     assert collection['title'] == 'Observations'
     assert collection['description'] == 'My cool observations'
-    assert len(collection['links']) == 10
+    assert len(collection['links']) == 12
     assert collection['extent'] == {
         'spatial': {
             'bbox': [[-180, -90, 180, 90]],
@@ -569,7 +569,7 @@ def test_describe_collections_json_ld(config, api_):
     assert len(expanded['http://schema.org/dataset']) == 1
     dataset = expanded['http://schema.org/dataset'][0]
     assert dataset['@type'][0] == 'http://schema.org/Dataset'
-    assert len(dataset['http://schema.org/distribution']) == 10
+    assert len(dataset['http://schema.org/distribution']) == 12
     assert all(dist['@type'][0] == 'http://schema.org/DataDownload'
                for dist in dataset['http://schema.org/distribution'])
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -569,7 +569,7 @@ def test_describe_collections_json_ld(config, api_):
     assert len(expanded['http://schema.org/dataset']) == 1
     dataset = expanded['http://schema.org/dataset'][0]
     assert dataset['@type'][0] == 'http://schema.org/Dataset'
-    assert len(dataset['http://schema.org/distribution']) == 12
+    assert len(dataset['http://schema.org/distribution']) == 14
     assert all(dist['@type'][0] == 'http://schema.org/DataDownload'
                for dist in dataset['http://schema.org/distribution'])
 

--- a/tests/test_tinydb_catalogue_provider.py
+++ b/tests/test_tinydb_catalogue_provider.py
@@ -27,6 +27,8 @@
 #
 # =================================================================
 
+import json
+
 import pytest
 
 from pygeoapi.provider.base import ProviderItemNotFoundError
@@ -35,6 +37,25 @@ from pygeoapi.provider.tinydb_ import TinyDBCatalogueProvider
 from .util import get_test_file_path
 
 path = get_test_file_path('tests/data/open.canada.ca/sample-records.tinydb')
+
+
+@pytest.fixture()
+def data():
+    return json.dumps({
+        'type': 'Feature',
+        'geometry': {
+            'type': 'Polygon',
+            'coordinates': [[
+                [100.0, 0.0], [101.0, 0.0], [101.0, 1.0],
+                [100.0, 1.0], [100.0, 0.0]
+                ]]
+        },
+        'properties': {
+            'identifier': 123,
+            'title': 'test item',
+            'description': 'test item'
+        }
+    })
 
 
 @pytest.fixture()
@@ -123,3 +144,16 @@ def test_get_not_existing_item_raise_exception(config):
     p = TinyDBCatalogueProvider(config)
     with pytest.raises(ProviderItemNotFoundError):
         p.get('404')
+
+
+def test_transactions_create(config, data):
+    """Testing transactional capabilities"""
+
+    p = TinyDBCatalogueProvider(config)
+
+    new_id = p.create(data)
+    assert new_id == 123
+
+    assert p.update(123, data)
+
+    assert p.delete(123)


### PR DESCRIPTION
# Overview
This PR implements support for the [OGC API - Features - Part 4: Create, Replace, Update and Delete](http://docs.ogc.org/DRAFTS/20-002.html#_example_2) draft specification, using the TinyDB provider as an OGC API - Records example and Elasticsearch provider for OGC API - Records / OGC API - Features.

# Related Issue / Discussion
#107 
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
