### PR TITLE
Upgrade the docker example to ES=8

### DIFF
--- a/docker/examples/elastic/ES/Dockerfile
+++ b/docker/examples/elastic/ES/Dockerfile
@@ -31,7 +31,7 @@
 #
 # =================================================================
 
-FROM docker.elastic.co/elasticsearch/elasticsearch:7.5.1
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.4.0
 
 LABEL maintainer="jorge.dejesus@geocat.net justb4@gmail.com"
 ARG DATA_FOLDER=/usr/share/elasticsearch/data
@@ -41,7 +41,7 @@ USER root
 COPY docker-entrypoint.sh  /docker-entrypoint.sh
 COPY add_data.sh /add_data.sh
 
-RUN yum install -y wget
+RUN apt update && apt install -y wget
 
 RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh -O bin/wait-for-it.sh
 RUN chmod +x bin/wait-for-it.sh
@@ -52,10 +52,9 @@ RUN echo "xpack.security.enabled: false" >> config/elasticsearch.yml
 RUN echo "http.host: 0.0.0.0" >> config/elasticsearch.yml
 RUN echo "discovery.type: single-node" >> config/elasticsearch.yml
 
-RUN yum --enablerepo=extras -y install epel-release \
-        && yum install -y python3 python3-pip python3-setuptools python-typing \
+RUN     apt install -y python3 python3-pip python3-setuptools python-typing \
         && pip3 install --upgrade pip elasticsearch==7.17.1 elasticsearch-dsl \
-	&& yum clean packages
+	&& apt clean packages
 
 USER elasticsearch
 

--- a/docker/examples/elastic/docker-compose.yml
+++ b/docker/examples/elastic/docker-compose.yml
@@ -62,6 +62,10 @@ services:
     ports:
       - 9300:9300
       - 9200:9200
+    environment:
+      ELASTIC_CLIENT_APIVERSIONING: 1
+      # Enabling compatibility mode in ES
+      # https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/migration.html#migration-compat-mode
     volumes:
       - elastic_search_data:/usr/share/elasticsearch/data
 


### PR DESCRIPTION
# Overview
ES8 introduces new capabilities (like the ability to publish data as vector tiles), but we are tied to the elastic-search client, which did not produce a version compatible with 8, yet. See: https://github.com/elastic/elasticsearch-dsl-py/issues/1569
The approach here is to run ES8 in compatibility mode, so that it does not break the client.

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/970

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute the feature to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
