### PR TITLE
- Added support for elasticsearch tiles in the mvt provider

### DIFF
--- a/docker/examples/elastic/pygeoapi/docker.config.yml
+++ b/docker/examples/elastic/pygeoapi/docker.config.yml
@@ -150,6 +150,20 @@ resources:
               #Note elastic_search is the docker container of ES the name is defined in the docker-compose.yml
               data: http://elastic_search:9200/ne_110m_populated_places_simple
               id_field: geonameid
+            - type: tile
+              name: MVT
+              data: http://elastic_search:9200/ne_110m_populated_places_simple/_mvt/geometry/{z}/{x}/{y}
+              options:
+                metadata_format: None # default | tilejson
+                bounds: [[-180.0, -90.0],[180.0, 90.0]]
+                zoom:
+                    min: 0
+                    max: 15
+                schemes:
+                    - WebMercatorQuad
+              format:
+                    name: elastic
+                    mimetype: application/vnd.mapbox-vector-tile
 
     lakes:
         type: collection

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -111,10 +111,12 @@ class MVTProvider(BaseTileProvider):
 
         tile_matrix_set_links_list = [{
                 'tileMatrixSet': 'WorldCRS84Quad',
-                'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json'  # noqa
+                'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json',  # noqa
+                'crs': 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
             }, {
                 'tileMatrixSet': 'WebMercatorQuad',
-                'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WebMercatorQuad.json'  # noqa
+                'tileMatrixSetURI': 'http://schemas.opengis.net/tms/1.0/json/examples/WebMercatorQuad.json',  # noqa
+                'crs': 'http://www.opengis.net/def/crs/EPSG/0/3857'
             }]
         tile_matrix_set_links = [
             item for item in tile_matrix_set_links_list if item[
@@ -158,19 +160,25 @@ class MVTProvider(BaseTileProvider):
             'metadata')
 
         links = {
-            'links': [{
-                'type': self.mimetype,
-                'rel': 'item',
-                'title': 'This collection as Mapbox vector tiles',
-                'href': self.service_url,
-                'templated': True
-            }, {
-                'type': 'application/json',
-                'rel': 'describedby',
-                'title': 'Metadata for this collection in the TileJSON format',
-                'href': '{}?f=json'.format(self.service_metadata_url),
-                'templated': True
-            }]
+            'links': [
+                {
+                    'type': 'application/json',
+                    'rel': 'self',
+                    'title': 'This collection as multi vector tilesets',
+                    'href': self.service_url,
+                },
+                {
+                    'type': self.mimetype,
+                    'rel': 'item',
+                    'title': 'This collection as multi vector tiles',
+                    'href': self.service_url,
+                }, {
+                    'type': 'application/json',
+                    'rel': 'describedby',
+                    'title': 'Collection metadata in TileJSON format',
+                    'href': '{}?f=json'.format(self.service_metadata_url),
+                }
+            ]
         }
 
         return links

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -207,7 +207,8 @@ class MVTProvider(BaseTileProvider):
                 session.get(base_url)
                 resp = session.get('{base_url}/{lyr}/{z}/{y}/{x}{f}'.format(
                     base_url=base_url, lyr=layer,
-                    z=z, y=y, x=x, f= '?grid_precision=0' if format_ == "elastic" else '.' + format_))
+                    z=z, y=y, x=x, f='?grid_precision=0'
+                    if format_ == "elastic" else '.' + format_))
                 resp.raise_for_status()
                 return resp.content
         else:
@@ -242,7 +243,7 @@ class MVTProvider(BaseTileProvider):
         """
 
         if tilejson is False:
-             return
+            return
 
         if is_url(self.data):
             url = urlparse(self.data)

--- a/pygeoapi/templates/collections/tiles/index.html
+++ b/pygeoapi/templates/collections/tiles/index.html
@@ -39,8 +39,10 @@
       </div>
       <br/>
       <div class="row">
-        <div class="col-md-2 col-sm-12">{% trans %}Metadata{% endtrans %}</div>
-        <div class="col-md-8"><a id="tilejson" href="" target="_blank">Tiles metadata in {{ data['format'] }} format</a></div>
+        {% if data['format']=='tilejson' %}
+          <div class="col-md-2 col-sm-12">{% trans %}Metadata{% endtrans %}</div>
+          <div class="col-md-8"><a id="tilejson" href="" target="_blank">Tiles metadata in {{ data['format'] }} format</a></div>
+        {% endif %}
       </div>
       <script>
         var select = document.getElementById('tilingScheme');
@@ -54,8 +56,10 @@
           var scheme = ev.target.value;
           document.location.search = `scheme=${scheme}`;
         });
-        document.getElementById("tilejson").href = "{{ config['server']['url'] }}/collections/{{ data['id'] }}/tiles/" + tileset + "/metadata";
-      </script>
+        if (document.getElementById("tilejson")){
+          document.getElementById("tilejson").href = "{{ config['server']['url'] }}/collections/{{ data['id'] }}/tiles/" + tileset + "/metadata";
+        }
+        </script>
       <br/>
       <div class="row">
         <div class="col-md-2 col-sm-12">Map</div>


### PR DESCRIPTION
# Overview
Version 8 of ES gives support to [publishing data as vector tiles](https://www.elastic.co/blog/introducing-elasticsearch-vector-tile-search-api-for-geospatial). This PR leverages that, to enable another vector tiles backend on the mvt provider.
Because ES does not provide a tilejson, I introduce the option of using a provider with no tile metadata.

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/970

# Additional Information
In order to use this feature, we need ES8, so I introduced another PR for using that in the examples: https://github.com/geopython/pygeoapi/pull/985
As I explain on that PR, ES needs to run on compatibility mode, or it won't work with the python client.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
