### PR TITLE
Fix github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
         pytest tests/test_openapi.py
         pytest tests/test_postgresql_provider.py
         pytest tests/test_rasterio_provider.py
-        pytest tests/test_sensorthings_provider.py 
+        pytest tests/test_sensorthings_provider.py
         pytest tests/test_socrata_provider.py
         #pytest tests/test_sqlite_geopackage_provider.py
         pytest tests/test_tinydb_catalogue_provider.py
@@ -95,4 +95,8 @@ jobs:
       run: find . -type f -name "*.py" | xargs flake8
     - name: build docs 🏗️
       run: cd docs && make html
+    - name: failed tests 🚩
+      if: ${{ failure() }}
+      run: |
+        pip3 list -v
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -519,7 +519,7 @@ class XarrayProvider(BaseProvider):
             dt = np.array([time_diff.values.astype('timedelta64[{}]'.format(x))
                            for x in ['Y', 'M', 'D', 'h', 'm', 's', 'ms']])
 
-            return str(dt[np.array([x.astype(np.int) for x in dt]) > 0][0])
+            return str(dt[np.array([x.astype(int) for x in dt]) > 0][0])
         else:
             return None
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -519,7 +519,7 @@ class XarrayProvider(BaseProvider):
             dt = np.array([time_diff.values.astype('timedelta64[{}]'.format(x))
                            for x in ['Y', 'M', 'D', 'h', 'm', 's', 'ms']])
 
-            return str(dt[np.array([x.astype(int) for x in dt]) > 0][0])
+            return str(dt[np.array([x.astype(np.int32) for x in dt]) > 0][0])
         else:
             return None
 

--- a/tests/pygeoapi-test-config-envvars.yml
+++ b/tests/pygeoapi-test-config-envvars.yml
@@ -45,7 +45,7 @@ server:
         attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
 
 logging:
-    level: ERROR
+    level: DEBUG
     #logfile: /tmp/pygeoapi.log
 
 metadata:

--- a/tests/pygeoapi-test-config-hidden-resources.yml
+++ b/tests/pygeoapi-test-config-hidden-resources.yml
@@ -50,9 +50,9 @@ server:
         name: TinyDB
         connection: /tmp/pygeoapi-test-process-manager.db
         output_dir: /tmp
-        
+
 logging:
-    level: ERROR
+    level: DEBUG
     #logfile: /tmp/pygeoapi.log
 
 metadata:

--- a/tests/pygeoapi-test-config.yml
+++ b/tests/pygeoapi-test-config.yml
@@ -50,9 +50,9 @@ server:
         name: TinyDB
         connection: /tmp/pygeoapi-test-process-manager.db
         output_dir: /tmp
-        
+
 logging:
-    level: ERROR
+    level: DEBUG
     #logfile: /tmp/pygeoapi.log
 
 metadata:
@@ -216,7 +216,7 @@ resources:
                     max: 11
                 schemes:
                     - WorldCRS84Quad
-              format: 
+              format:
                     name: pbf
                     mimetype: application/vnd.mapbox-vector-tile
 

--- a/tests/pygeoapi-test-ogr-config.yml
+++ b/tests/pygeoapi-test-ogr-config.yml
@@ -45,7 +45,7 @@ server:
         attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
 
 logging:
-    level: ERROR
+    level: DEBUG
     #logfile: /tmp/pygeoapi.log
 
 metadata:
@@ -115,18 +115,18 @@ resources:
                   target_srs: EPSG:4326
                   source_capabilities:
                       paging: True
-  
+
                   source_options:
   #                    OGR_WFS_VERSION: 1.1.0
                       OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN: NO
-  
+
                   gdal_ogr_options:
                       EMPTY_AS_NULL: NO
                       GDAL_CACHEMAX: 64
                       # GDAL_HTTP_PROXY: (optional proxy)
                       # GDAL_PROXY_AUTH: (optional auth for remote WFS)
                       CPL_DEBUG: NO
-  
+
               id_field: gml_id
               layer: rdinfo:stations
 
@@ -164,18 +164,18 @@ resources:
                   target_srs: EPSG:4326
                   source_capabilities:
                       paging: True
-  
+
                   source_options:
   #                    OGR_WFS_VERSION: 2.0.0
                       OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN: NO
-  
+
                   gdal_ogr_options:
                       EMPTY_AS_NULL: NO
                       GDAL_CACHEMAX: 64
                       # GDAL_HTTP_PROXY: (optional proxy)
                       # GDAL_PROXY_AUTH: (optional auth for remote WFS)
                       CPL_DEBUG: NO
-  
+
               id_field: gml_id
               layer: inspireadressen:inspireadressen
 
@@ -211,18 +211,18 @@ resources:
                   target_srs: EPSG:4326
                   source_capabilities:
                       paging: True
-  
+
                   source_options:
   #                    OGR_WFS_VERSION: 2.0.0
                       OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN: NO
-  
+
                   gdal_ogr_options:
                       EMPTY_AS_NULL: NO
                       GDAL_CACHEMAX: 64
                       # GDAL_HTTP_PROXY: (optional proxy)
                       # GDAL_PROXY_AUTH: (optional auth for remote WFS)
                       CPL_DEBUG: NO
-  
+
               id_field: NAME
               layer: app:SGID93_LOCATION_UDOTMap_CityLocations
 
@@ -257,18 +257,18 @@ resources:
                   target_srs: EPSG:4326
                   source_capabilities:
                       paging: True
-  
+
                   source_options:
   #                    OGR_WFS_VERSION: 1.1.0
                       OGR_WFS_LOAD_MULTIPLE_LAYER_DEFN: NO
-  
+
                   gdal_ogr_options:
                       EMPTY_AS_NULL: NO
                       GDAL_CACHEMAX: 64
                       # GDAL_HTTP_PROXY: (optional proxy)
                       # GDAL_PROXY_AUTH: (optional auth for remote WFS)
                       CPL_DEBUG: NO
-  
+
               id_field: gml_id
               layer: unesco:Unesco_point
 
@@ -308,14 +308,14 @@ resources:
                   target_srs: EPSG:4326
                   source_capabilities:
                       paging: True
-  
+
                   gdal_ogr_options:
                       EMPTY_AS_NULL: NO
                       GDAL_CACHEMAX: 64
                       # GDAL_HTTP_PROXY: (optional proxy)
                       # GDAL_PROXY_AUTH: (optional auth for remote WFS)
                       CPL_DEBUG: NO
-  
+
               id_field: osm_id
               layer: poi_portugal
 
@@ -350,14 +350,14 @@ resources:
                   target_srs: EPSG:4326
                   source_capabilities:
                       paging: True
-  
+
                   gdal_ogr_options:
                       EMPTY_AS_NULL: NO
                       GDAL_CACHEMAX: 64
                       # GDAL_HTTP_PROXY: (optional proxy)
                       # GDAL_PROXY_AUTH: (optional auth for remote WFS)
                       CPL_DEBUG: NO
-  
+
               id_field: objectid
 
     cases_italy_per_region_from_github:


### PR DESCRIPTION
# Overview
This PR fixes pygeoapi's github actions.

# Related Issue / Discussion
[![build ⚙️](https://github.com/geopython/pygeoapi/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/geopython/pygeoapi/actions/workflows/main.yml)
https://github.com/geopython/pygeoapi/actions/runs/3085911124

# Additional Information
There seem to be two things causing failed tests:
- `np.int` is deprecated in favor of `int`
- EPA Waters database is empty causing the ESRI tests to fail. The Waters database has been replaced with the NOAA/NWS 2000 Hurricane tracker hosted on the same test server used by `tests/test_ogr_esrijson_provider.py`.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
