### PR TITLE
fix for issue #993 - fix ESRI Provider tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
         pytest tests/test_csv__formatter.py
         pytest tests/test_csv__provider.py
         pytest tests/test_elasticsearch__provider.py
-        #pytest tests/test_esri_provider.py
+        pytest tests/test_esri_provider.py
         pytest tests/test_filesystem_provider.py
         pytest tests/test_geojson_provider.py
         pytest tests/test_mongo_provider.py

--- a/tests/test_esri_provider.py
+++ b/tests/test_esri_provider.py
@@ -172,6 +172,7 @@ def test_query_sortby_datetime(config):
                       sortby=[{'property': TIME_FIELD, 'order': '+'}])
     assert results['features'][0]['properties'][TIME_FIELD] == 967838400000
 
+
 def test_get(config):
     p = ESRIServiceProvider(config)
 

--- a/tests/test_esri_provider.py
+++ b/tests/test_esri_provider.py
@@ -159,19 +159,18 @@ def test_query_sortby_datetime(config):
         return timestamp.strftime(DATETIME_FORMAT)
 
     results = p.query(sortby=[{'property': TIME_FIELD, 'order': '+'}])
-    assert feature_time(results) == '2000-08-04T02:00:00.000000Z'
+    assert results['features'][0]['properties'][TIME_FIELD] == 965354400000
 
     results = p.query(sortby=[{'property': TIME_FIELD, 'order': '-'}])
-    assert feature_time(results) == '2000-10-22T20:00:00.000000Z'
+    assert results['features'][0]['properties'][TIME_FIELD] == 972244800000
 
     results = p.query(datetime_='../2000-09-01',
                       sortby=[{'property': TIME_FIELD, 'order': '-'}])
-    assert feature_time(results) == '2000-08-25T14:00:00.000000Z'
+    assert results['features'][0]['properties'][TIME_FIELD] == 967212000000
 
     results = p.query(datetime_='2000-09-01/..',
                       sortby=[{'property': TIME_FIELD, 'order': '+'}])
-    assert feature_time(results) == '2000-09-01T20:00:00.000000Z'
-
+    assert results['features'][0]['properties'][TIME_FIELD] == 967838400000
 
 def test_get(config):
     p = ESRIServiceProvider(config)

--- a/tests/test_esri_provider.py
+++ b/tests/test_esri_provider.py
@@ -159,18 +159,18 @@ def test_query_sortby_datetime(config):
         return timestamp.strftime(DATETIME_FORMAT)
 
     results = p.query(sortby=[{'property': TIME_FIELD, 'order': '+'}])
-    assert feature_time(results) == '2000-08-04T04:00:00.000000Z'
+    assert feature_time(results) == '2000-08-04T02:00:00.000000Z'
 
     results = p.query(sortby=[{'property': TIME_FIELD, 'order': '-'}])
-    assert feature_time(results) == '2000-10-22T22:00:00.000000Z'
+    assert feature_time(results) == '2000-10-22T20:00:00.000000Z'
 
     results = p.query(datetime_='../2000-09-01',
                       sortby=[{'property': TIME_FIELD, 'order': '-'}])
-    assert feature_time(results) == '2000-08-25T16:00:00.000000Z'
+    assert feature_time(results) == '2000-08-25T14:00:00.000000Z'
 
     results = p.query(datetime_='2000-09-01/..',
                       sortby=[{'property': TIME_FIELD, 'order': '+'}])
-    assert feature_time(results) == '2000-09-01T22:00:00.000000Z'
+    assert feature_time(results) == '2000-09-01T20:00:00.000000Z'
 
 
 def test_get(config):

--- a/tests/test_esri_provider.py
+++ b/tests/test_esri_provider.py
@@ -159,18 +159,18 @@ def test_query_sortby_datetime(config):
         return timestamp.strftime(DATETIME_FORMAT)
 
     results = p.query(sortby=[{'property': TIME_FIELD, 'order': '+'}])
-    assert feature_time(results) == '2000-08-04T02:00:00.000000Z'
+    assert feature_time(results) == '2000-08-04T04:00:00.000000Z'
 
     results = p.query(sortby=[{'property': TIME_FIELD, 'order': '-'}])
-    assert feature_time(results) == '2000-10-22T20:00:00.000000Z'
+    assert feature_time(results) == '2000-10-22T22:00:00.000000Z'
 
     results = p.query(datetime_='../2000-09-01',
                       sortby=[{'property': TIME_FIELD, 'order': '-'}])
-    assert feature_time(results) == '2000-08-25T14:00:00.000000Z'
+    assert feature_time(results) == '2000-08-25T16:00:00.000000Z'
 
     results = p.query(datetime_='2000-09-01/..',
                       sortby=[{'property': TIME_FIELD, 'order': '+'}])
-    assert feature_time(results) == '2000-09-01T20:00:00.000000Z'
+    assert feature_time(results) == '2000-09-01T22:00:00.000000Z'
 
 
 def test_get(config):


### PR DESCRIPTION
# Overview
Fixes ESRI Provider tests.

# Related Issue / Discussion
#993  - concerns several tests.

Strangely the only changes were shifting 2 hours in date-time assertions. Hopefully this is not a local (timezone-)context dependent assertion. Like in The Netherlands we are 2 hours from Zulu (Z) time...

# Additional Information
Still should look into the OGC ESRI tests (still commented out but OGR may not be working in main.yml).

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
