### PR TITLE
Move flake8 test before provider tests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  push:
+    paths:
+      - '*.py'
+
+jobs:
+  flake8_py3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7.4
+          architecture: x64
+      - name: Checkout PyTorch
+        uses: actions/checkout@master
+      - name: Install flake8
+        run: pip install flake8
+      - name: Run flake8
+        uses: suo/flake8-github-action@releases/v1
+        with:
+          checkName: 'flake8_py3'   # NOTE: this needs to be the same as the job name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,16 @@ on:
   push:
     paths:
       - '*.py'
+      - '!**.md'   
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '*.py'  
+      - '!**.md'  
+  release:
+    types:
+      - released    
 
 jobs:
   flake8_py3:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,22 +1,14 @@
 name: Build
 
 on: 
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - '**.md'  
-  pull_request:
-    branches:
-      - master
-    paths-ignore:
-      - '**.md'  
-  release:
-    types:
-      - released
   workflow_run:
     workflows: ["Lint"]
-    types: [completed]    
+    types: [completed] 
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'  
+  
 
 jobs:
   main:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
       name: Setup Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}
+    - name: run flake8 ⚙️
+      run: find . -type f -name "*.py" | xargs flake8
     - name: Configure sysctl limits
       run: |
         sudo swapoff -a
@@ -105,8 +107,6 @@ jobs:
         pytest tests/test_util.py
         pytest tests/test_xarray_netcdf_provider.py
         pytest tests/test_xarray_zarr_provider.py
-    - name: run flake8 ⚙️
-      run: find . -type f -name "*.py" | xargs flake8
     - name: build docs 🏗️
       run: cd docs && make html
     - name: failed tests 🚩

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ on:
   release:
     types:
       - released
+  workflow_run:
+    workflows: ["Lint"]
+    types: [completed]    
 
 jobs:
   main:
@@ -32,8 +35,6 @@ jobs:
       name: Setup Python ${{ matrix.python-version }}
       with:
         python-version: ${{ matrix.python-version }}
-    - name: run flake8 ⚙️
-      run: find . -type f -name "*.py" | xargs flake8
     - name: Configure sysctl limits
       run: |
         sudo swapoff -a


### PR DESCRIPTION
# Overview

This PR moves flake testing before the provider setup & testing, this will catch any python errors before running through the effort of setting up and testing the providers.  

PR = 
- Standalone flake lint job
  - runs on
    - All push, any branch
    - pull requests to master
    - any release
- main.yml 'build'
  -  runs on
    -  lint completing on master (so this shouls catch push, pr & releases from above logic)
- containers.yml 
  - runs on 
    - build completing

# Related Issue / Discussion

None - only noticed testing order in other work. 

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
