### PR TITLE
Support accents in yaml config file

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -1142,7 +1142,7 @@ def openapi():
 
 @click.command()
 @click.pass_context
-@click.argument('config_file', type=click.File())
+@click.argument('config_file', type=click.File(encoding='utf-8'))
 @click.option('--format', '-f', 'format_', type=click.Choice(['json', 'yaml']),
               default='yaml', help='output format (json|yaml)')
 @click.option('--output-file', '-of', type=click.File('w', encoding='utf-8'),


### PR DESCRIPTION
# Overview
Support for accentuated characters in the pygeoapi-config.yml file.

# Related Issue / Discussion
Fixes #1008

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
