### PR TITLE
fixes issue #1013 - new URL Dutch RDInfo WFS

### DIFF
--- a/aws-lambda/function/pygeoapi-config.yml
+++ b/aws-lambda/function/pygeoapi-config.yml
@@ -295,7 +295,7 @@ resources:
               name: OGR
               data:
                   source_type: WFS
-                  source: WFS:http://geodata.nationaalgeoregister.nl/rdinfo/wfs?
+                  source: WFS:https://service.pdok.nl/kadaster/rdinfo/wfs/v1_0?
                   source_srs: EPSG:28992
                   target_srs: EPSG:4326
                   source_capabilities:

--- a/docker/default.config.yml
+++ b/docker/default.config.yml
@@ -209,7 +209,7 @@ resources:
               name: OGR
               data:
                   source_type: WFS
-                  source: WFS:http://geodata.nationaalgeoregister.nl/rdinfo/wfs?
+                  source: WFS:https://service.pdok.nl/kadaster/rdinfo/wfs/v1_0?
                   source_srs: EPSG:28992
                   target_srs: EPSG:4326
                   source_capabilities:

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -85,7 +85,7 @@ class OGRProvider(BaseProvider):
             name: OGR
             data:
                 source_type: WFS
-                source: WFS:http://geodata.nationaalgeoregister.nl/rdinfo/wfs?
+                source: WFS:https://service.pdok.nl/kadaster/rdinfo/wfs/v1_0?
                 source_srs: EPSG:28992
                 target_srs: EPSG:4326
                 source_capabilities:

--- a/tests/pygeoapi-test-ogr-config.yml
+++ b/tests/pygeoapi-test-ogr-config.yml
@@ -110,7 +110,7 @@ resources:
               name: OGR
               data:
                   source_type: WFS
-                  source: WFS:http://geodata.nationaalgeoregister.nl/rdinfo/wfs?
+                  source: WFS:https://service.pdok.nl/kadaster/rdinfo/wfs/v1_0?
                   source_srs: EPSG:28992
                   target_srs: EPSG:4326
                   source_capabilities:


### PR DESCRIPTION
# Overview
See issue #1013
# Related Issue / Discussion

# Additional Information
old URL: http://geodata.nationaalgeoregister.nl/rdinfo/wfs
new URL: https://service.pdok.nl/kadaster/rdinfo/wfs/v1_0

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
