### PR TITLE
do not set ES dates as raw

### DIFF
--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -267,7 +267,7 @@ class ElasticsearchProvider(BaseProvider):
                 sp = sort['property']
 
                 if (self.fields[sp]['type'] == 'string'
-                        and self.fields[sp]['format'] != 'date'):
+                        and self.fields[sp].get('format') != 'date'):
                     LOGGER.debug('setting ES .raw on property')
                     sort_property = '{}.raw'.format(self.mask_prop(sp))
                 else:

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -266,7 +266,8 @@ class ElasticsearchProvider(BaseProvider):
 
                 sp = sort['property']
 
-                if self.fields[sp]['type'] == 'string':
+                if (self.fields[sp]['type'] == 'string'
+                        and self.fields[sp]['format'] != 'date'):
                     LOGGER.debug('setting ES .raw on property')
                     sort_property = '{}.raw'.format(self.mask_prop(sp))
                 else:


### PR DESCRIPTION
# Overview
Do not cast date strings as raw fields for ES queries.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
