### PR TITLE
Removed branches requirement on build action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,7 @@ name: Build
 on: 
   workflow_run:
     workflows: ["Lint"]
-    types: [completed] 
-    branches:
-      - master
+    types: [completed]
     paths-ignore:
       - '**.md'  
   


### PR DESCRIPTION
# Overview

Build action will now run whenever Lint job is completed: All pushes, PR to Master branch & releases

Build wasn't running when PR's were made until after they were merged which didn't meet dev requirements.  

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
