### PR TITLE
add support for provider plugin schemas

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -94,6 +94,10 @@ The below template provides a minimal example (let's call the file ``mycoolvecto
                }]
            }
 
+       def get_schema():
+           # return a `dict` of a JSON schema (inline or reference)
+           return ('application/geo+json', {'$ref': 'https://geojson.org/schema/Feature.json'})
+
 
 For brevity, the above code will always return the single feature of the dataset.  In reality, the plugin
 developer would connect to a data source with capabilities to run queries and return a relevant result set,

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1920,7 +1920,7 @@ class API:
             LOGGER.debug('Creating item')
             try:
                 identifier = p.create(request.data)
-            except ProviderInvalidDataError as err:
+            except (ProviderInvalidDataError, TypeError) as err:
                 msg = str(err)
                 return self.get_exception(
                     400, headers, request.format, 'InvalidParameterValue', msg)
@@ -1934,7 +1934,7 @@ class API:
             LOGGER.debug('Updating item')
             try:
                 _ = p.update(identifier, request.data)
-            except ProviderGenericError as err:
+            except (ProviderInvalidDataError, TypeError) as err:
                 msg = str(err)
                 return self.get_exception(
                     400, headers, request.format, 'InvalidParameterValue', msg)

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -29,8 +29,16 @@
 
 import json
 import logging
+from enum import Enum
 
 LOGGER = logging.getLogger(__name__)
+
+
+class SchemaType(Enum):
+    item = 'item'
+    create = 'create'
+    update = 'update'
+    replace = 'replace'
 
 
 class BaseProvider:
@@ -75,6 +83,18 @@ class BaseProvider:
         Get provider field information (names, types)
 
         :returns: dict of fields
+        """
+
+        raise NotImplementedError()
+
+    def get_schema(self, schema_type: SchemaType = SchemaType.item):
+        """
+        Get provider schema model
+
+        :param schema_type: `SchemaType` of schema (default is 'item')
+
+        :returns: tuple pair of `str` of media type and `dict` of schema
+                  (i.e. JSON Schema)
         """
 
         raise NotImplementedError()

--- a/pygeoapi/templates/openapi/swagger.html
+++ b/pygeoapi/templates/openapi/swagger.html
@@ -4,9 +4,9 @@
   <head>
     <meta charset="UTF-8">
     <title>Swagger UI - {{ config['metadata']['identification']['title'] }}</title>
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist@3.28.0/swagger-ui.css" >
-    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@3.28.0/favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist@3.28.0/favicon-16x16.png" sizes="16x16" />
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" >
+    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="https://unpkg.com/swagger-ui-dist/favicon-16x16.png" sizes="16x16" />
     <style>
       html
       {
@@ -30,8 +30,8 @@
 
   <body>
     <div id="swagger-ui"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@3.28.0/swagger-ui-bundle.js"> </script>
-    <script src="https://unpkg.com/swagger-ui-dist@3.28.0/swagger-ui-standalone-preset.js"> </script>
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"> </script>
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-standalone-preset.js"> </script>
     <script>
     window.onload = function() {
       // Begin Swagger UI call region


### PR DESCRIPTION
# Overview
This PR adds support for provider plugins to provide schema objects in support of OpenAPI schema definitions.

# Related Issue / Discussion
- https://github.com/opencdms/pyopencdms/issues/59
- https://github.com/wmo-im/wis2box/issues/279

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
