### PR TITLE
flake use python version 3.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7.14
+          python-version: 3.7
           architecture: x64
       - name: Checkout pygeoapi
         uses: actions/checkout@master


### PR DESCRIPTION
3.7.14 no longer works (now 3.7.15) so main.yml is failing, if we set to 3.7 then the incremental changes won't effect us. 

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
