### PR TITLE
Add postgres properties filter example to documentation & k8s installation notice

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -240,7 +240,7 @@ This provider has support for the CQL queries as indicated in the Provider table
 .. seealso::
   :ref:`cql` for more details on how to use Common Query Language (CQL) to filter the collection with specific queries.
 
-It is possible to control the order and which properties are exposed/unexposed from a PostGreSQL table using ``properties``, see the example below. 
+It is possible to control the order and which properties are exposed/unexposed for any supported feature provider using ``properties``, see the example below. 
 
 .. code-block:: yaml
 

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -240,6 +240,28 @@ This provider has support for the CQL queries as indicated in the Provider table
 .. seealso::
   :ref:`cql` for more details on how to use Common Query Language (CQL) to filter the collection with specific queries.
 
+It is possible to control the order and which properties are exposed/unexposed from a PostGreSQL table using ``properties``, see the example below. 
+
+.. code-block:: yaml
+
+   providers:
+      - type: feature
+        name: PostgreSQL
+        data:
+            host: 127.0.0.1
+            port: 3010 # Default 5432 if not provided 
+            dbname: test
+            user: postgres
+            password: postgres
+            search_path: [osm, public]
+        id_field: osm_id
+        table: hotosm_bdi_waterways
+        geom_field: foo_geom
+        properties:
+            - waterway
+            - depth
+            - name
+
 SQLiteGPKG
 ^^^^^^^^^^
 

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -355,6 +355,19 @@ relies on `sodapy <https://github.com/xmunoz/sodapy>`.
         time_field: datetime # Optional time_field for datetime queries
         token: my_token # Optional app token
 
+Controlling the order of properties
+-----------------------------------
+
+It is possible to control the order and which properties are exposed/unexposed for any supported feature provider using ``properties`` key within a provider definition, see the example below:
+
+.. code-block:: yaml
+
+   properties:
+       - waterway
+       - depth
+       - name
+
+
 Data access examples
 --------------------
 

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -240,28 +240,6 @@ This provider has support for the CQL queries as indicated in the Provider table
 .. seealso::
   :ref:`cql` for more details on how to use Common Query Language (CQL) to filter the collection with specific queries.
 
-It is possible to control the order and which properties are exposed/unexposed for any supported feature provider using ``properties``, see the example below. 
-
-.. code-block:: yaml
-
-   providers:
-      - type: feature
-        name: PostgreSQL
-        data:
-            host: 127.0.0.1
-            port: 3010 # Default 5432 if not provided 
-            dbname: test
-            user: postgres
-            password: postgres
-            search_path: [osm, public]
-        id_field: osm_id
-        table: hotosm_bdi_waterways
-        geom_field: foo_geom
-        properties:
-            - waterway
-            - depth
-            - name
-
 SQLiteGPKG
 ^^^^^^^^^^
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -67,6 +67,44 @@ Using GitHub Container Registry
 
    docker pull ghcr.io/geopython/pygeoapi:latest   
 
+Kubenetes
+---------
+
+.. note:: 
+   If using the postgres provider we recommend setting nginx ingress affinity-mode to persistent, see below ingress example. 
+
+.. code-block:: bash
+   
+   ---
+   apiVersion: networking.k8s.io/v1
+   kind: Ingress
+   metadata:
+   name: ${KUBE_NAMESPACE}
+   labels:
+      app: ${KUBE_NAMESPACE}
+   annotations:
+      nginx.ingress.kubernetes.io/affinity: "cookie"
+      nginx.ingress.kubernetes.io/session-cookie-name: ${KUBE_NAMESPACE}
+      nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
+      nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
+      nginx.ingress.kubernetes.io/ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/affinity-mode: persistent
+      nginx.ingress.kubernetes.io/session-cookie-hash: sha1
+   spec:
+   ingressClassName: nginx
+   rules:
+   - host: ${APP_HOSTNAME}
+      http:
+         paths:
+         - path: /
+         pathType: Prefix
+         backend:
+            service:
+               name: ${KUBE_NAMESPACE}
+               port:
+               number: ${CONTAINER_PORT}
+
+
 Conda
 -----
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -67,11 +67,11 @@ Using GitHub Container Registry
 
    docker pull ghcr.io/geopython/pygeoapi:latest   
 
-Kubenetes
----------
+Kubernetes
+----------
 
 .. note:: 
-   If using the postgres provider we recommend setting nginx ingress affinity-mode to persistent, see below ingress example. 
+   If using the PostgreSQL feature provider it is recommended to set NGINX ingress affinity-mode to persistent; see the below ingress example. 
 
 .. code-block:: bash
    


### PR DESCRIPTION
# Overview
Function discussed on Gitter missing from the documentation to set with a list of properties the attributes of a postgres to expose/unexpose and to order in HTML output. 

# Related Issue / Discussion
https://gitter.im/geopython/pygeoapi?at=635beb9abad3c73752f906fe

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
