### PR TITLE
add debugpy remote python debugging

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -22,6 +22,51 @@ Tests can be run locally as part of development workflow.  They are also run on 
 To run all tests, simply run ``pytest`` in the repository.  To run a specific test file,
 run ``pytest tests/test_api.py``, for example.
 
+Debugging Using Debugpy (VS Code only)
+--------------------------------------
+
+To enable debug when running flask:
+
+.. code-block:: bash
+
+   # Enable debugpy with port default port 5678
+   export DEBUGPY=True
+   # Or specifiy the port
+   export DEBUGPY=9876
+
+
+Running pygeoapi with debugging in Docker:
+
+.. code-block:: bash
+   
+   docker build -t pygeoapi:devel --build-arg BUILD_DEV_IMAGE=true .
+   docker run  -e DEBUGPY=5678 -e WSGI_WORKERS=1 -e GEVENT_SUPPORT=True -p 5678:5678 -p 5000:80 -it  pygeoapi:devel
+
+
+Use the following VSCode launch.json entry:
+
+.. code-block:: json
+
+   {
+      "version": "0.2.0",
+      "configurations": [
+         {
+            "name": "Python: Docker Pygeoapi",
+            "type": "python",
+            "request": "attach",
+            "port": 5678,
+            "host": "localhost",
+            "pathMappings": [
+               {
+                  "localRoot": "${workspaceFolder}",
+                  "remoteRoot": "/pygeoapi"
+               }
+            ]
+         }
+      ]
+   }
+
+See `debugpy <https://github.com/microsoft/debugpy/>`_ and `VSCode Python Debugging <https://code.visualstudio.com/docs/python/debugging>`_ for more details on debugging.
 
 CQL extension lifecycle
 -----------------------

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -40,6 +40,32 @@ from pygeoapi.api import API
 from pygeoapi.util import get_mimetype, yaml_load
 
 
+def initialize_flask_server_debugger_if_needed():
+    if os.getenv("DEBUGPY"):
+
+        # Must be "true" or a port
+        if os.getenv('DEBUGPY').lower() == 'true':
+            debugport = 5678
+        else:
+            try:
+                debugport = int(os.getenv('DEBUGPY'))
+            except ValueError:
+                print("VS Code debugger disabled")
+                return
+
+        import multiprocessing
+
+        if multiprocessing.current_process().pid > 1:
+            import debugpy
+
+            debugpy.listen(("0.0.0.0", debugport))
+            print("⏳ VS Code debugger can now be attached,"
+                  + " press F5 in VS Code ⏳", flush=True)
+            debugpy.wait_for_client()
+            print("🎉 VS Code debugger attached, enjoy debugging 🎉",
+                  flush=True)
+
+
 CONFIG = None
 
 if 'PYGEOAPI_CONFIG' not in os.environ:
@@ -61,6 +87,8 @@ BLUEPRINT = Blueprint('pygeoapi', __name__, static_folder=STATIC_FOLDER)
 if CONFIG['server'].get('cors', False):
     from flask_cors import CORS
     CORS(APP)
+
+initialize_flask_server_debugger_if_needed()
 
 APP.config['JSONIFY_PRETTYPRINT_REGULAR'] = CONFIG['server'].get(
     'pretty_print', True)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,9 @@ pytest-env
 coverage
 pyld
 
+# Debugging
+debugpy
+
 # PEP8
 flake8
 


### PR DESCRIPTION
# Overview

Provides the ability to remotely debug pygeoapi using debugpy

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
