### PR TITLE
add OGC RI for EDR

### DIFF
--- a/docs/source/_templates/indexsidebar.html
+++ b/docs/source/_templates/indexsidebar.html
@@ -4,11 +4,14 @@
         <a title="pygeoapi.io" href="https://pygeoapi.io"><img style="background: white;" title="pygeoapi logo" alt="pygeoapi logo" src="_static/pygeoapi-logo.png" height="63" /></a>
     </p>
 
-    <a title="Certified OGC Compliant" href="https://www.opengeospatial.org/resource/products/details/?pid=1606">
+    <a title="Certified OGC Compliant" href="https://www.opengeospatial.org/resource/products/details/?pid=1663">
         <img alt="Certified OGC Compliant" src="https://portal.opengeospatial.org/public_ogc/compliance/Certified_OGC_Compliant_Logo_Web.gif" width="164" height="64"/>
     </a>
-    <a title="OGC Reference Implementation" href="https://www.opengeospatial.org/resource/products/details/?pid=1606">
+    <a title="OGC Reference Implementation" href="https://www.opengeospatial.org/resource/products/details/?pid=1663">
         <img alt="OGC Reference Implementation" src="https://portal.opengeospatial.org/public_ogc/compliance/badge.php?s=ogcapi-features-1%201.0&r=1)" width="164" height="44"/>
+    </a>
+    <a title="OGC Reference Implementation" href="https://www.opengeospatial.org/resource/products/details/?pid=1663">
+        <img alt="OGC Reference Implementation" src="https://portal.opengeospatial.org/public_ogc/compliance/badge.php?s=ogcapi-edr-1%201.0&r=1)" width="164" height="44"/>
     </a>
     <a title="OSGeo Project" href="https://www.osgeo.org/projects/pygeoapi">
         <img style="background: white;" alt="OSGeo Project" src="https://raw.githubusercontent.com/OSGeo/osgeo/master/incubation/project/OSGeo_project.png" width="164" height="64"/>

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -9,12 +9,14 @@ Features
 --------
 
 * out of the box modern OGC API server
-* certified OGC Compliant and Reference Implementation for OGC API - Features
+* certified OGC Compliant and Reference Implementation
+  * OGC API - Features
+  * OGC API - Environmental Data Retrieval
 * additionally implements
   * OGC API - Coverages
   * OGC API - Tiles
   * OGC API - Processes
-  * OGC API - Environmental Data Retrieval
+  * OGC API - Records
   * SpatioTemporal Asset Library
 * out of the box data provider plugins for rasterio, GDAL/OGR, Elasticsearch, PostgreSQL/PostGIS
 * easy to use OpenAPI / Swagger documentation for developers
@@ -46,7 +48,7 @@ Standards are at the core of pygeoapi.  Below is the project's standards support
    `OGC API - Tiles`_,Implementing
    `OGC API - Processes`_,Implementing
    `OGC API - Records`_,Implementing
-   `OGC API - Environmental Data Retrieval`_,Implementing
+   `OGC API - Environmental Data Retrieval`_,Reference Implementation
    `SpatioTemporal Asset Catalog`_,Implementing
 
 


### PR DESCRIPTION
# Overview
pygeoapi's EDR support is now OGC Compliant and an OGC Reference Implementation.

# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
