### PR TITLE
[fix] Rasterio provider: Check if self.options is None

### DIFF
--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -202,7 +202,7 @@ class RasterioProvider(BaseProvider):
 
             crs_src = CRS.from_epsg(bbox_crs)
 
-            if 'crs' in self.options:
+            if self.options and 'crs' in self.options:
                 crs_dest = CRS.from_string(self.options['crs'])
             else:
                 crs_dest = self._data.crs


### PR DESCRIPTION
# Overview
Fixes a `TypeError: argument of type 'NoneType' is not iterable` when ` self.options` is `None`

# Related Issue / Discussion
None

# Additional Information
` self.options` can be `None` and therefore Python crashes with a `TypeError` if no condition to check for `None` is made

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
