### PR TITLE
move numpy based tests to xarray/zarr provider

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -29,7 +29,6 @@
 
 from datetime import datetime, date, time
 from decimal import Decimal
-from numpy import float64, int64
 
 import pytest
 
@@ -87,12 +86,6 @@ def test_json_serial():
 
     d = Decimal(1.0)
     assert util.json_serial(d) == 1.0
-
-    d = int64(500_000_000_000)
-    assert util.json_serial(d) == 500_000_000_000
-
-    d = float64(500.00000005)
-    assert util.json_serial(d) == 500.00000005
 
     with pytest.raises(TypeError):
         util.json_serial('foo')

--- a/tests/test_xarray_zarr_provider.py
+++ b/tests/test_xarray_zarr_provider.py
@@ -27,9 +27,12 @@
 #
 # =================================================================
 
+from numpy import float64, int64
+
 import pytest
 
 from pygeoapi.provider.xarray_ import XarrayProvider
+from pygeoapi.util import json_serial
 
 from .util import get_test_file_path
 
@@ -86,3 +89,11 @@ def test_query(config):
 
     data = p.query(format_='zarr')
     assert isinstance(data, bytes)
+
+
+def test_numpy_json_serial():
+    d = int64(500_000_000_000)
+    assert json_serial(d) == 500_000_000_000
+
+    d = float64(500.00000005)
+    assert json_serial(d) == 500.00000005


### PR DESCRIPTION
# Overview
Follow on of #913, moves numpy specific tests to xarray/zarr provider.
# Related Issue / Discussion
#913 
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
