### PR TITLE
Coverage HTML viewer using Leaflet+arrugator

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1046,6 +1046,13 @@ class API:
                     'href': '{}/{}/coverage?f={}'.format(
                         self.get_collections_url(), k, F_JSON)
                 })
+                collection['links'].append({
+                    'type': 'text/html',
+                    'rel': '{}/coverage'.format(OGC_RELTYPES_BASE),
+                    'title': 'Coverage viewer',
+                    'href': '{}/{}/coverage'.format(
+                        self.get_collections_url(), k)
+                })
                 if collection_data_format is not None:
                     collection['links'].append({
                         'type': collection_data_format['mimetype'],

--- a/pygeoapi/static/css/default.css
+++ b/pygeoapi/static/css/default.css
@@ -22,7 +22,7 @@ main {
 /*    text-transform: capitalize;*/
 }
 
-#items-map, #collection-map {
+#items-map, #collection-map, #coverage-map {
     width: 100%;
     height: 400px;
 }

--- a/pygeoapi/templates/_base.html
+++ b/pygeoapi/templates/_base.html
@@ -103,21 +103,21 @@
     {% block extrafoot %}
     {% endblock %}
     <script>
-      // Requests and embeds JSON-LD representation of current page
-      var xhr = new XMLHttpRequest();
-      var path = window.location.protocol + "//" + window.location.host + window.location.pathname + "?f=jsonld";
-      xhr.open('GET', path);
-      xhr.onload = function() {
-        if (xhr.status === 200) {
-          var head = document.getElementsByTagName('head')[0];
-          var jsonld_datablock = document.createElement('script');
-          jsonld_datablock.type = "application/ld+json";
-          //remove full context path, because search engines don't expect it here, pyld requires it.
-          jsonld_datablock.textContent = xhr.responseText.replace('docs/jsonldcontext.jsonld','');
-          head.appendChild(jsonld_datablock);
-        }
-      };
-      xhr.send();
+      // // Requests and embeds JSON-LD representation of current page
+      // var xhr = new XMLHttpRequest();
+      // var path = window.location.protocol + "//" + window.location.host + window.location.pathname + "?f=jsonld";
+      // xhr.open('GET', path);
+      // xhr.onload = function() {
+      //   if (xhr.status === 200) {
+      //     var head = document.getElementsByTagName('head')[0];
+      //     var jsonld_datablock = document.createElement('script');
+      //     jsonld_datablock.type = "application/ld+json";
+      //     //remove full context path, because search engines don't expect it here, pyld requires it.
+      //     jsonld_datablock.textContent = xhr.responseText.replace('docs/jsonldcontext.jsonld','');
+      //     head.appendChild(jsonld_datablock);
+      //   }
+      // };
+      // xhr.send();
     </script>
   </body>
 </html>

--- a/pygeoapi/templates/collections/coverage/index.html
+++ b/pygeoapi/templates/collections/coverage/index.html
@@ -1,0 +1,85 @@
+{% extends "_base.html" %}
+{% block title %}{{ super() }} {{ data['title'] }} {% endblock %}
+{% block crumbs %}{{ super() }}
+/ <a href="{{ data['collections_path'] }}">{% trans %}Collections{% endtrans %}</a>
+{% for link in data['links'] %}
+  {% if link.rel == 'collection' %} /
+    <a href="{{ data['dataset_path'] }}">{{ link['title'] | string | truncate( 25 ) }}</a>
+    {% set col_title = link['title'] %}
+  {% endif %}
+{% endfor %}
+/ <a href="{{ data['items_path']}}">{% trans %}Items{% endtrans %}</a>
+{% endblock %}
+{% block extrahead %}
+    <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css"/>
+    <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet.imageoverlay.arrugator"></script>
+    <script src="https://unpkg.com/proj4@2.8.0/dist/proj4-src.js"></script>
+{% endblock %}
+
+{% block body %}
+  <section id="map"></section>
+  <section id="collection">
+      <h1>{{ data['title'] }}</h1>
+      <p>{{ data['description'] }}</p>
+  </section>
+<div class="col-md-8">
+	<div id="coverage-map"></div>
+</div>
+{% endblock %}
+
+{% block extrafoot %}
+
+    <script>
+    const map = L.map('coverage-map').setView([0,0], 0);
+    map.addLayer(new L.TileLayer(
+        '{{ config['server']['map']['url'] }}', {
+            maxZoom: 18,
+            attribution: '{{ config['server']['map']['attribution'] | safe }}'
+        }
+    ));
+
+    const bbox = {{ data.bbox | to_json | safe}};
+
+    /// TODO: How to get the proj.4 string for this CRS???!!
+    const crs = {{ data.crs | to_json | safe }};
+
+    let subdivisions = 1;
+    let cropX = [-Infinity, Infinity];
+    let cropY = [-Infinity, Infinity];
+    let proj4str = "";  /// FIXME!!!!
+
+    // Work around known problematic transformations
+    if (crs === "http://www.opengis.net/def/crs/OGC/1.3/CRS84") {
+      subdivisions = 4;
+      cropY = [-89,89];
+      proj4str = "EPSG:4326";
+    } else if (crs === "http://www.opengis.net/def/crs/OGC/1.3//25833"){
+      subdivisions = 1;
+      proj4str = "+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs";
+    }
+
+  let arrugatedCoverage = L.imageOverlay.arrugator(
+      "{{ data.collections_path }}/{{ data.id }}/coverage?f=PNG", {
+      // "{{ data.collections_path }}/{{ data.id }}/coverage", {
+          controlPoints: [
+              [bbox[0], bbox[3]], // top-left
+              [bbox[0], bbox[1]], // bottom-left
+              [bbox[2], bbox[3]], // upper-right
+              [bbox[2], bbox[1]], // lower-right
+          ],
+          projector: proj4(proj4str, "EPSG:3857").forward,
+
+          // Means a max error of 1000 meters per raster px
+          // TODO: calculate from raster metadata!
+          epsilon: 1000000,
+          subdivisions,
+          cropX,
+          cropY,
+      })
+      .addTo(map);
+
+    map.fitBounds(arrugatedCoverage.getBounds());
+
+    </script>
+{% endblock %}

--- a/pygeoapi/templates/collections/coverage/index.html
+++ b/pygeoapi/templates/collections/coverage/index.html
@@ -30,7 +30,6 @@
 	<div>Width: {{data.width}}</div>
 	<div>Height: {{data.height}}</div>
 	<div>CRS: {{data.crs}}</div>
-	ghuhgreihgerugrsreus
 </div>
 {% endblock %}
 
@@ -57,15 +56,10 @@
     if (crs === "http://www.opengis.net/def/crs/OGC/1.3/CRS84") {
       subdivisions = 4;
       cropY = [-89,89];
-    //   proj4str = "EPSG:4326";
-    // } else if (crs === "http://www.opengis.net/def/crs/OGC/1.3//25833"){
-    //   subdivisions = 1;
-    //   proj4str = "+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs";
     }
 
     let arrugatedCoverage = L.imageOverlay.arrugator(
       "{{ data.collections_path }}/{{ data.id }}/coverage?f=png", {
-      // "{{ data.collections_path }}/{{ data.id }}/coverage", {
           controlPoints: [
               [bbox[0], bbox[3]], // top-left
               [bbox[0], bbox[1]], // bottom-left

--- a/pygeoapi/templates/collections/coverage/index.html
+++ b/pygeoapi/templates/collections/coverage/index.html
@@ -25,6 +25,12 @@
   </section>
 <div class="col-md-12">
 	<div id="coverage-map"></div>
+	<div>X range: {{data.bbox[0]}} , {{data.bbox[2]}}</div>
+	<div>Y range: {{data.bbox[1]}} , {{data.bbox[3]}}</div>
+	<div>Width: {{data.width}}</div>
+	<div>Height: {{data.height}}</div>
+	<div>CRS: {{data.crs}}</div>
+	ghuhgreihgerugrsreus
 </div>
 {% endblock %}
 
@@ -41,26 +47,24 @@
 
     const bbox = {{ data.bbox | to_json | safe}};
 
-    /// TODO: How to get the proj.4 string for this CRS???!!
     const crs = {{ data.crs | to_json | safe }};
-
+    proj4.defs( "coveragesource", {{ data.proj4str | to_json | safe }} );
     let subdivisions = 1;
     let cropX = [-Infinity, Infinity];
     let cropY = [-Infinity, Infinity];
-    let proj4str = "";  /// FIXME!!!!
 
     // Work around known problematic transformations
     if (crs === "http://www.opengis.net/def/crs/OGC/1.3/CRS84") {
       subdivisions = 4;
       cropY = [-89,89];
-      proj4str = "EPSG:4326";
-    } else if (crs === "http://www.opengis.net/def/crs/OGC/1.3//25833"){
-      subdivisions = 1;
-      proj4str = "+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs";
+    //   proj4str = "EPSG:4326";
+    // } else if (crs === "http://www.opengis.net/def/crs/OGC/1.3//25833"){
+    //   subdivisions = 1;
+    //   proj4str = "+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs";
     }
 
-  let arrugatedCoverage = L.imageOverlay.arrugator(
-      "{{ data.collections_path }}/{{ data.id }}/coverage?f=PNG", {
+    let arrugatedCoverage = L.imageOverlay.arrugator(
+      "{{ data.collections_path }}/{{ data.id }}/coverage?f=png", {
       // "{{ data.collections_path }}/{{ data.id }}/coverage", {
           controlPoints: [
               [bbox[0], bbox[3]], // top-left
@@ -68,7 +72,7 @@
               [bbox[2], bbox[3]], // upper-right
               [bbox[2], bbox[1]], // lower-right
           ],
-          projector: proj4(proj4str, "EPSG:3857").forward,
+          projector: proj4("coveragesource", "EPSG:3857").forward,
 
           // Means a max error of 1000 meters per raster px
           // TODO: calculate from raster metadata!

--- a/pygeoapi/templates/collections/coverage/index.html
+++ b/pygeoapi/templates/collections/coverage/index.html
@@ -23,7 +23,7 @@
       <h1>{{ data['title'] }}</h1>
       <p>{{ data['description'] }}</p>
   </section>
-<div class="col-md-8">
+<div class="col-md-12">
 	<div id="coverage-map"></div>
 </div>
 {% endblock %}


### PR DESCRIPTION
# Overview

Adds a HTML viewer for coverages, leveraging Leaflet and Leaflet.ImageOverLay.Arrugator.

In order to get a the webpage in as less time as possible, this also adds a fastpath to the rasterio connector, in order to fetch only the metadata and skip reading the coverage's pixels.

# Related Issue / Discussion

In-person discussions with @tomkralidis during the 19th OGC codesprint (https://github.com/opengeospatial/developer-events/wiki/Web-Mapping-Code-Sprint, https://github.com/opengeospatial/developer-events/issues/32)

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
