### PR TITLE
Add Support for a generic url template, for publishing vector tiles as OGC API Tiles

### DIFF
--- a/docker/examples/elastic/pygeoapi/docker.config.yml
+++ b/docker/examples/elastic/pygeoapi/docker.config.yml
@@ -150,6 +150,21 @@ resources:
               #Note elastic_search is the docker container of ES the name is defined in the docker-compose.yml
               data: http://elastic_search:9200/ne_110m_populated_places_simple
               id_field: geonameid
+            - type: tile
+              name: MVT
+              data: http://elastic_search:9200/ne_110m_populated_places_simple/_mvt/geometry/{z}/{x}/{y}?grid_precision=0
+              # index must have a geo_point
+              options:
+                metadata_format: none # default | tilejson
+                zoom:
+                    min: 0
+                    max: 16
+                schemes:
+                    - WorldCRS84Quad
+              format:
+                    name: pbf
+                    mimetype: application/vnd.mapbox-vector-tile
+
 
     lakes:
         type: collection

--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -7,12 +7,18 @@ Publishing map tiles to OGC API - Tiles
 (map, vector, etc.).
 
 pygeoapi can publish tiles from local or remote data sources (including cloud
-object storage).  To integrate tiles from a local data source, it is assumed
+object storage or a tile service). To integrate tiles from a local data source, it is assumed
 that a directory tree of static tiles has been created on disk.  Examples of
 tile generation software include (but are not limited to):
 
 * `MapProxy`_
 * `tippecanoe`_
+
+The remote data sources can be an external service like Elasticsearch, read from a generic url template.
+
+.. note::
+   Currently, the url template only supports the formats: `/{z}/{x}/{y}` or `/{z}/{y}/{x}`. 
+   If you have a different use case, feel free to file an `issue <https://github.com/geopython/pygeoapi/issues>`_.  
 
 Providers
 ---------
@@ -36,13 +42,15 @@ MVT
 
 The MVT provider plugin provides access to `Mapbox Vector Tiles`_.
 
+This code block shows how to configure pygeoapi to read Mapbox vector tiles, from disk or from an url.
+
 .. code-block:: yaml
 
    providers:
        - type: tile
          name: MVT 
          data: tests/data/tiles/ne_110m_lakes  # local directory tree
-         # data: https://example.org/ne_110m_lakes/{z}/{x}/{y}.pbf
+         # data: http://localhost:9000/ne_110m_lakes/{z}/{x}/{y}.pbf # tiles stored on a Minio bucket
          options:
              metadata_format: raw # default | tilejson
              zoom:
@@ -54,6 +62,26 @@ The MVT provider plugin provides access to `Mapbox Vector Tiles`_.
              name: pbf 
              mimetype: application/vnd.mapbox-vector-tile
 
+This code block shows how to configure pygeoapi to read Mapbox vector tiles, from an Elasticsearch endpoint.
+
+.. code-block:: yaml
+
+   providers:
+       - type: tile
+         name: MVT 
+         data: http://localhost:9200/ne_110m_populated_places_simple2/_mvt/geometry/{z}/{x}/{y}?grid_precision=0
+         # if you don't use precision 0, you will be requesting for aggregations which are not supported in the 
+         # free version of elastic
+         options:
+             metadata_format: raw # default | tilejson
+             zoom:
+                 min: 0
+                 max: 5
+             schemes:
+                 - WorldCRS84Quad
+         format:
+             name: pbf 
+             mimetype: application/vnd.mapbox-vector-tile
 
 Data access examples
 --------------------

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -60,14 +60,14 @@ class MVTProvider(BaseTileProvider):
             baseurl = '{}://{}'.format(url.scheme, url.netloc)
             param_type = '?f=mvt'
 
-            # try x,y,z - this works for mapbox, ES         
+            # try x,y,z - this works for mapbox, ES
             layer = url.path.split('/{z}/{x}/{y}')[0]
             # try z,y,x - this works for OS Data Hub
             layer = layer.split('/{z}/{y}/{x}')[0]
             # Do we need to try different combinations?
 
             if ('.' in layer):
-                layer=layer.split('.')[0]
+                layer = layer.split('.')[0]
 
             tilepath = '{}/tiles'.format(layer)
             servicepath = \
@@ -80,15 +80,11 @@ class MVTProvider(BaseTileProvider):
                     param_type
                     )
 
-            self._service_url = url_join(baseurl, servicepath
-            )
+            self._service_url = url_join(baseurl, servicepath)
 
             self._service_metadata_url = urljoin(
                 self.service_url.split('{tileMatrix}/{tileRow}/{tileCol}')[0],
                 'metadata')
-
-
-
         else:
             data_path = Path(self.data)
             if not data_path.exists():
@@ -119,7 +115,8 @@ class MVTProvider(BaseTileProvider):
 
         if is_url(self.data):
             url = urlparse(self.data)
-            # We need to try, at least these different variations that I have seen across products (maybe there more??)
+            # We need to try, at least these different variations that
+            # I have seen across products (maybe there more??)
             layer = url.path.split("/{z}/{x}/{y}")[0]
             layer = layer.split("/{z}/{y}/{x}")[0]
             return layer[1:]
@@ -217,24 +214,25 @@ class MVTProvider(BaseTileProvider):
         """
         if format_ == "mvt":
             format_ = self.format_type
-        if is_url(self.data):            
+        if is_url(self.data):
             url = urlparse(self.data)
             base_url = '{}://{}'.format(url.scheme, url.netloc)
             with requests.Session() as session:
                 session.get(base_url)
                 # There is a "." in the url path
                 if '.' in url.path:
-                    resp = session.get('{base_url}/{lyr}/{z}/{y}/{x}.{f}{q}'.format(
-                        base_url=base_url, lyr=layer,
-                        z=z, y=y, x=x, f=format_, q= "?" + url.query
-                    if url.query else ''))
+                    resp = session.get(
+                        '{base_url}/{lyr}/{z}/{y}/{x}.{f}{q}'.format(
+                            base_url=base_url, lyr=layer,
+                            z=z, y=y, x=x, f=format_, q="?" + url.query
+                            if url.query else ''))
                 # There is no "." in the url )e.g. elasticsearch)
                 else:
-                    LOGGER.error("no dot")
-                    resp = session.get('{base_url}/{lyr}/{z}/{y}/{x}{q}'.format(
-                        base_url=base_url, lyr=layer,
-                        z=z, y=y, x=x, q= "?" + url.query
-                    if url.query else ''))
+                    resp = session.get(
+                        '{base_url}/{lyr}/{z}/{y}/{x}{q}'.format(
+                            base_url=base_url, lyr=layer,
+                            z=z, y=y, x=x, q="?" + url.query
+                            if url.query else ''))
                 resp.raise_for_status()
                 return resp.content
         else:

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -204,9 +204,20 @@ class MVTProvider(BaseTileProvider):
             base_url = '{}://{}'.format(url.scheme, url.netloc)
             with requests.Session() as session:
                 session.get(base_url)
-                resp = session.get('{base_url}/{lyr}/{z}/{y}/{x}.{f}'.format(
-                    base_url=base_url, lyr=layer,
-                    z=z, y=y, x=x, f=format_))
+                # There is a "." in the url path
+                if '.' in url.path:
+                    resp = session.get('{base_url}/{lyr}/{z}/{y}/{x}.{f}{q}'.format(
+                        base_url=base_url, lyr=layer,
+                        z=z, y=y, x=x, f=format_, q= "?" + url.query
+                    if url.query else ''))
+
+                # There is no "." in the url )e.g. elasticsearch)
+                else:
+                    LOGGER.error("no dot")
+                    resp = session.get('{base_url}/{lyr}/{z}/{y}/{x}{q}'.format(
+                        base_url=base_url, lyr=layer,
+                        z=z, y=y, x=x, q= "?" + url.query
+                    if url.query else ''))
                 resp.raise_for_status()
                 return resp.content
         else:

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -59,7 +59,7 @@ class MVTProvider(BaseTileProvider):
             url = urlparse(self.data)
             baseurl = '{}://{}'.format(url.scheme, url.netloc)
             param_type = '?f=mvt'
-            layer= '/' + self.get_layer()
+            layer = '/' + self.get_layer()
 
             LOGGER.debug('Extracting layer name from url')
             LOGGER.debug('Layer: {}'.format(layer))
@@ -113,16 +113,17 @@ class MVTProvider(BaseTileProvider):
             # We need to try, at least these different variations that
             # I have seen across products (maybe there more??)
 
-            if "/{z}/{x}/{y}" not in url.path and "/{z}/{y}/{x}" not in url.path:
+            if ("/{z}/{x}/{y}" not in url.path and
+                    "/{z}/{y}/{x}" not in url.path):
                 msg = 'This url template is not supported yet: {}'.format(
-                url.path)
+                    url.path)
                 LOGGER.error(msg)
                 raise ProviderConnectionError(msg)
 
             layer = url.path.split("/{z}/{x}/{y}")[0]
             layer = layer.split("/{z}/{y}/{x}")[0]
 
-            # Removing the extension, if it is there            
+            # Removing the extension, if it is there
             if ('.' in layer):
                 layer = layer.split('.')[0]
 

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -59,15 +59,10 @@ class MVTProvider(BaseTileProvider):
             url = urlparse(self.data)
             baseurl = '{}://{}'.format(url.scheme, url.netloc)
             param_type = '?f=mvt'
+            layer= '/' + self.get_layer()
 
-            # try x,y,z - this works for mapbox, ES
-            layer = url.path.split('/{z}/{x}/{y}')[0]
-            # try z,y,x - this works for OS Data Hub
-            layer = layer.split('/{z}/{y}/{x}')[0]
-            # Do we need to try different combinations?
-
-            if ('.' in layer):
-                layer = layer.split('.')[0]
+            LOGGER.debug('Extracting layer name from url')
+            LOGGER.debug('Layer: {}'.format(layer))
 
             tilepath = '{}/tiles'.format(layer)
             servicepath = \
@@ -117,9 +112,25 @@ class MVTProvider(BaseTileProvider):
             url = urlparse(self.data)
             # We need to try, at least these different variations that
             # I have seen across products (maybe there more??)
+
+            if "/{z}/{x}/{y}" not in url.path and "/{z}/{y}/{x}" not in url.path:
+                msg = 'This url template is not supported yet: {}'.format(
+                url.path)
+                LOGGER.error(msg)
+                raise ProviderConnectionError(msg)
+
             layer = url.path.split("/{z}/{x}/{y}")[0]
             layer = layer.split("/{z}/{y}/{x}")[0]
-            return layer[1:]
+
+            # Removing the extension, if it is there            
+            if ('.' in layer):
+                layer = layer.split('.')[0]
+
+            LOGGER.debug(layer)
+            # Removing the first "/"
+            layer = layer[1:]
+            LOGGER.debug(layer)
+            return layer
         else:
             return Path(self.data).name
 

--- a/pygeoapi/templates/collections/tiles/index.html
+++ b/pygeoapi/templates/collections/tiles/index.html
@@ -39,9 +39,10 @@
       </div>
       <br/>
       <div class="row">
-        <div class="col-md-2 col-sm-12">{% trans %}Metadata{% endtrans %}</div>
-        <div class="col-md-8"><a id="tilejson" href="" target="_blank">Tiles metadata in {{ data['format'] }} format</a></div>
-      </div>
+        {% if data['format']=='tilejson' %}
+          <div class="col-md-2 col-sm-12">{% trans %}Metadata{% endtrans %}</div>
+          <div class="col-md-8"><a id="tilejson" href="" target="_blank">Tiles metadata in {{ data['format'] }} format</a></div>
+        {% endif %}      </div>
       <script>
         var select = document.getElementById('tilingScheme');
         var tileset = select.value;
@@ -54,8 +55,10 @@
           var scheme = ev.target.value;
           document.location.search = `scheme=${scheme}`;
         });
-        document.getElementById("tilejson").href = "{{ config['server']['url'] }}/collections/{{ data['id'] }}/tiles/" + tileset + "/metadata";
-      </script>
+        if (document.getElementById("tilejson")){
+          document.getElementById("tilejson").href = "{{ config['server']['url'] }}/collections/{{ data['id'] }}/tiles/" + tileset + "/metadata";
+        }
+        </script>
       <br/>
       <div class="row">
         <div class="col-md-2 col-sm-12">Map</div>


### PR DESCRIPTION
# Overview

It would be nice to support vector tile services, other than mapbox, as OGC API Tiles backend.

For instance we could use elasticsearch:

`http://localhost:9200/ne_110m_populated_places_simple2/_mvt/geometry/{z}/{x}/{y}?grid_precision=0`

Or OS Data Hub:

`https://api.os.uk/maps/vector/v1/vts/boundaries/tile/{z}/{y}/{x}.pbf?srs=3857&key=USE-YOUR-KEY`

# Related Issue / Discussion

https://github.com/geopython/pygeoapi/issues/1049

# Additional Information

![pygeoapi-collections](https://user-images.githubusercontent.com/1038897/204846892-efd21628-09c4-4fff-a081-20e2bc83d30c.png)

![pygeoapi-es-tiles](https://user-images.githubusercontent.com/1038897/204846947-a0c182f8-5dca-436f-a62b-d5a86c59342e.png)

![os-data-hub-vtiles](https://user-images.githubusercontent.com/1038897/204847019-3f682601-67a2-4e42-b122-ea80f6eb49f6.png)

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
