### PR TITLE
Small fix on url template

### DIFF
--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -123,10 +123,6 @@ class MVTProvider(BaseTileProvider):
             layer = url.path.split('/{z}/{x}/{y}')[0]
             layer = layer.split('/{z}/{y}/{x}')[0]
 
-            # Removing the extension, if it is there
-            if '.' in layer:
-                layer = layer.split('.')[0]
-
             LOGGER.debug(layer)
             LOGGER.debug('Removing leading "/"')
             return layer[1:]


### PR DESCRIPTION
# Overview

Currently there is a bit of code which is suppose to parse out the layer extension, but it is never being run.

# Related Issue / Discussion

Instead, it is creating issues with layers which contain a "." in the name (like in the case of pg_tileserv).

`http://localhost:7800/public.ne_50m_admin_0_countries/{z}/{x}/{y}.pbf`

# Additional Information

This piece of code can be safely removed.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
