### PR TITLE
Add missing f-string for `OGRProvider` query bbox

### DIFF
--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -324,7 +324,7 @@ class OGRProvider(BaseProvider):
                 minx, miny, maxx, maxy = [float(b) for b in bbox]
 
                 wkt = f"POLYGON (({minx} {miny},{minx} {maxy},{maxx} {maxy}," \
-                      "{maxx} {miny},{minx} {miny}))"
+                      f"{maxx} {miny},{minx} {miny}))"
 
                 polygon = self.ogr.CreateGeometryFromWkt(wkt)
                 if self.transform_in:


### PR DESCRIPTION
# Overview

Small bug where a f-string wasn't added to https://github.com/geopython/pygeoapi/commit/f9fb2c600551f2ff11b9e2fb2d3b3aff8c243c98 (https://github.com/geopython/pygeoapi/pull/1064)

Diff for that commit - https://github.com/geopython/pygeoapi/commit/f9fb2c600551f2ff11b9e2fb2d3b3aff8c243c98#diff-e24b19038c51e2a93905b4d787a04cb0d183377cf3fa3698602d4f660d3f6be0L328-L332

This was causing invalid WKT polygons to be passed into `CreateGeometryFromWkt` (from `OGRProvider.query()`)

For example:
- calling `GET /collections/geojson-test/items?bbox=80,-20,140,0` on a collection with an `OGRProvider`
- creates WKT `"POLYGON ((80.0 -20.0,80.0 0.0,140.0 0.0,{maxx} {miny},{minx} {miny}))"`
- which results in the following error

```
[2022-12-13T16:23:02Z] {pygeoapi/provider/ogr.py:817} ERROR - Error Number: 5, Type: Failure, Msg: OGR Error: Corrupt data
[2022-12-13T16:23:02Z] {pygeoapi/provider/ogr.py:372} ERROR - <built-in function CreateGeometryFromWkt> returned a result with an exception set
```

<details><summary><h3>To recreate</h3></summary>

Python version: `Python 3.10.8`

OS: Mac OS 12.2.1 (m1 arch)

PygeoAPI version `0.14.dev0`

GDAL `3.6.0`, released 2022/11/06

Save the following GeoJSON to `test.geojson` in root `pygeoapi` directory

```json
{
  "type": "FeatureCollection",
  "features": [
    {
      "type": "Feature",
      "properties": {
        "fid": 1
      },
      "geometry": {
        "coordinates": [
          [
            [
              115.55383562435048,
              -9.442856058531547
            ],
            [
              107.44867813365192,
              -20.310669515890226
            ],
            [
              124.54895099614407,
              -20.27968136882103
            ],
            [
              125.65932379981899,
              -9.557418135667149
            ],
            [
              115.55383562435048,
              -9.442856058531547
            ]
          ]
        ],
        "type": "Polygon"
      }
    }
  ]
}
```

Add the following to `resources` in `config.yml`

```yml
geojson-test:
    type: collection
    title: GeoJSON OGR test
    description: GeoJSON OGR test
    keywords:
      - test
      - collection
    context:
      - datetime: https://schema.org/DateTime
      - vocab: https://example.com/vocab#
        stn_id: "vocab:stn_id"
        value: "vocab:value"
    links:
      - type: text/html
        rel: canonical
        title: information
        href: some-test-url
        hreflang: en-CA
    extents:
      spatial:
        bbox: [-180, -90, 180, 90]
        crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
    providers:
      - type: feature
        name: OGR
        data:
          source_type: GeoJSON
          source: test.geojson
          source_capabilities:
            paging: True
        layer: test
        id_field: fid
```

Start up `pygeoapi`

Call http://localhost:5000/collections/geojson-test/items?bbox=80,-20,140,0

See error

After PR, you should see

<img width="1389" alt="image" src="https://user-images.githubusercontent.com/6187649/207255277-704dbc42-5972-4dca-a835-aed4f36ecf4c.png">

</details>

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
