### PR TITLE
Stay with Shapely 1.x for a while

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ python-dateutil
 pytz
 PyYAML
 rasterio
-shapely
+shapely<2.0
 tinydb
 unicodecsv
 future-annotations


### PR DESCRIPTION
# Overview

Shapely 2.0 pulls NumPy as a dependency along with many changes:
https://shapely.readthedocs.io/en/latest/release/2.x.html#version-2-0-0
I believe we should wait/test a bit before moving to this new version

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
