### PR TITLE
Fix `workflow_dispatch` event for Publish Docker image workflow

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -19,7 +19,7 @@ jobs:
   on-success:
     name: Build, Test and Push Docker Image to DockerHub
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
# Overview

Fix `workflow_dispatch` event for "Publish Docker image" workflow. 

## Before change

If you tried to manually trigger the Publish Docker image workflow, it would skip.

<img width="953" alt="image" src="https://user-images.githubusercontent.com/6187649/209029563-a63e2021-d689-4ef8-bda4-2e228df2442e.png">

## After change

It works!

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/6187649/209029723-144c3ee7-7507-40f3-8b0b-f56f6c3d7546.png">


# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
