### PR TITLE
Add normal function to generate openapi document

### DIFF
--- a/pygeoapi/models/openapi.py
+++ b/pygeoapi/models/openapi.py
@@ -30,6 +30,7 @@
 # =================================================================
 
 from enum import Enum
+
 from pydantic import BaseModel
 
 

--- a/pygeoapi/models/openapi.py
+++ b/pygeoapi/models/openapi.py
@@ -1,0 +1,42 @@
+# ****************************** -*-
+# flake8: noqa
+# =================================================================
+#
+# Authors: Francesco Bartoli <xbartolone@gmail.com>
+#
+# Copyright (c) 2022 Francesco Bartoli
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from enum import Enum
+from pydantic import BaseModel
+
+
+class SupportedFormats(Enum):
+    JSON = "json"
+    YAML = "yaml"
+
+
+class OAPIFormat(BaseModel):
+    __root__: SupportedFormats = SupportedFormats.YAML

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -29,13 +29,13 @@
 #
 # =================================================================
 
-from typing import Union
 from copy import deepcopy
-from pathlib import Path
+import io
 import json
 import logging
-import io
 import os
+from pathlib import Path
+from typing import Union
 
 import click
 from jsonschema import validate as jsonschema_validate


### PR DESCRIPTION
# Overview

This pull request aims to add a normal public function to generate the OpenAPI document content which can be used programmatically by the external implementations that wraps pygeoapi as a library. It keeps backward compatibility with the `click` function.

Example:

```python
    try:
        # override pygeoapi os variables
        os.environ["PYGEOAPI_CONFIG"] = cfg.PYGEOAPI_CONFIG
        os.environ["PYGEOAPI_OPENAPI"] = cfg.PYGEOAPI_OPENAPI

        from pygeoapi.starlette_app import app as pygeoapi_app
        from pygeoapi.provider.base import ProviderConnectionError
        from pygeoapi.openapi import get_oas, generate_openapi_document

        pygeoapi_conf = Path.cwd() / os.environ["PYGEOAPI_CONFIG"]
        pygeoapi_oapi = Path.cwd() / os.environ["PYGEOAPI_OPENAPI"]
        with pygeoapi_oapi.open(mode="w") as oapi_file:
                s = generate_openapi_document(pygeoapi_conf)
                oapi = get_oas(s)
                oapi_file.write(oapi)

    except ProviderConnectionError as e:
        loguru.logger.error(e)
        raise e
    except FileNotFoundError:
        loguru.logger.error(
            "Please configure pygeoapi settings in .env properly"
        )
        raise
```

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
