### PR TITLE
Removing Python 3.6 from CI and requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 3.6
           - python-version: 3.7
     env:
       PYGEOAPI_CONFIG: "$(pwd)/pygeoapi-config.yml"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Babel
 click>7,<=8
 Flask
-future-annotations
 jinja2==3.0.3
 jsonschema
 pydantic


### PR DESCRIPTION
# Overview

Python 3.6 is EOL and should be dropped


# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
