### PR TITLE
Fix j2 template calls with i18n implementation for /jobs and /tiles pages

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2612,7 +2612,7 @@ class API:
 
             content = render_j2_template(self.config,
                                          'collections/tiles/index.html', tiles,
-                                         SYSTEM_LOCALE)
+                                         request.locale)
 
             return headers, HTTPStatus.OK, content
 
@@ -3281,7 +3281,7 @@ class API:
                 'now': datetime.now(timezone.utc).strftime(DATETIME_FORMAT)
             }
             response = render_j2_template(self.config, j2_template, data,
-                                          SYSTEM_LOCALE)
+                                          request.locale)
             return headers, HTTPStatus.OK, response
 
         return headers, HTTPStatus.OK, to_json(serialized_jobs,
@@ -3462,7 +3462,7 @@ class API:
                 }
                 content = render_j2_template(
                     self.config, 'jobs/results/index.html',
-                    data, SYSTEM_LOCALE)
+                    data, request.locale)
 
         return headers, HTTPStatus.OK, content
 


### PR DESCRIPTION
# Overview

When switching to a different `lang` of a /jobs page like https://demo.pygeoapi.io/master/jobs?lang=fr, the translation strings weren't being applied. Looking at the `pygeoapi/api.py`, I noticed that the `SYSTEM_LOCALE` was being passed in as the parameter to the `render_j2_template()` function calls, thus ignoring the `?lang=fr` param of the URL. 
The working template returns pass in `request.locale` as the param.

The fix applies to the j2 templates of:
- `collections/tiles/index.html`
- `jobs/results/index.html`
- `jobs/index.html`
- `jobs/job.html`

# Related Issue / Discussion

# Additional Information

As of this PR creation, visiting https://demo.pygeoapi.io/master?lang=fr-CA is not applying the translation. My local version is working with it though.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
