### PR TITLE
add OAMaps datetime to OpenAPI (#1095)

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -977,6 +977,7 @@ def get_oas_30(cfg):
                     'operationId': 'getMap',
                     'parameters': [
                         {'$ref': f"{OPENAPI_YAML['oapif']}#/components/parameters/bbox"},  # noqa
+                        {'$ref': f"{OPENAPI_YAML['oapif']}#/components/parameters/datetime"},  # noqa
                         {
                             'name': 'width',
                             'in': 'query',


### PR DESCRIPTION
# Overview
Adds `datetime` parameter to OAMaps based resources in OpenAPI document.
# Related Issue / Discussion
#1956
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
