### PR TITLE
#1110 - disable build for test and upgrade action versions

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -13,7 +13,7 @@ on:
     
 env:
   DOCKER_REPOSITORY: geopython/pygeoapi
-  DOCKER_TEST_IMAGE: geopython/pygeoapi:test
+#  DOCKER_TEST_IMAGE: geopython/pygeoapi:test
 
 jobs:
   on-success:
@@ -25,33 +25,33 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2.0.0
+        uses: docker/setup-qemu-action@v2.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2.0.0
+        uses: docker/setup-buildx-action@v2.2.1
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2.1.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and export to Docker
-        uses: docker/build-push-action@v3.1.1
-        with:
-          context: .
-          load: true
-          tags: ${{ env.DOCKER_TEST_IMAGE }}
+#      - name: Build and export to Docker
+#        uses: docker/build-push-action@v3.1.1
+#        with:
+#          context: .
+#          load: true
+#          tags: ${{ env.DOCKER_TEST_IMAGE }}
 
 #      - name: pygeoapi Unit Tests with Docker Image ⚙️
 #        run: |
@@ -63,20 +63,20 @@ jobs:
         with:
           images: |
             ${{ env.DOCKER_REPOSITORY }}
-            ghcr.io/${{ github.repository }}   
+            ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
-      
+
       - name: Build and push Docker images
-        uses: docker/build-push-action@v3.1.1
+        uses: docker/build-push-action@v3.3.0
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+#          cache-from: type=gha
+#          cache-to: type=gha,mode=max
           platforms: linux/arm64, linux/amd64
   
   on-failure:


### PR DESCRIPTION
# Overview
Disable build for test (test is skipped anyway) and upgrade all Action versions.

# Related Issue / Discussion
Issue #1110

# Additional Information
See discussion [after these comments](https://github.com/geopython/pygeoapi/pull/1093#issuecomment-1387271180) on #1093. We should at least get the Docker build/push working again. Then work on #1105.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
