### PR TITLE
support paths in item IDs

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -378,4 +378,8 @@ Data access examples
    ``.../items`` queries which return an alternative representation to GeoJSON (which prompt a download)
    will have the response filename matching the collection name and appropriate file extension (e.g. ``my-dataset.csv``)
 
+.. note::
+   provider `id_field` values support slashes (i.e. ``my/cool/identifier``). The client request would then
+   be responsible for encoding the identifier accordingly (i.e. ``http://localhost:5000/collections/foo/items/my%2Fcool%2Fidentifier``)
+
 .. _`OGC API - Features`: https://www.ogc.org/standards/ogcapi-features

--- a/docs/source/data-publishing/ogcapi-records.rst
+++ b/docs/source/data-publishing/ogcapi-records.rst
@@ -96,5 +96,9 @@ Metadata search examples
 * fetch a specific record
   * http://localhost:5000/collections/my-metadata/items/123
 
+.. note::
+   provider `id_field` values support slashes (i.e. ``my/cool/identifier``). The client request would then
+   be responsible for encoding the identifier accordingly (i.e. ``http://localhost:5000/collections/my-metadata/items/my%2Fcool%2Fidentifier``)
+
 .. _`OGC API - Records`: https://www.ogc.org/standards/ogcapi-records
 .. _`OGC API - Records GeoJSON Features`: https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/schemas/recordGeoJSON.yaml

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -180,7 +180,7 @@ def collection_queryables(collection_id=None):
 
 @BLUEPRINT.route('/collections/<path:collection_id>/items',
                  methods=['GET', 'POST'])
-@BLUEPRINT.route('/collections/<path:collection_id>/items/<item_id>',
+@BLUEPRINT.route('/collections/<path:collection_id>/items/<path:item_id>',
                  methods=['GET', 'PUT', 'DELETE'])
 def collection_items(collection_id, item_id=None):
     """

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -244,9 +244,9 @@ async def get_collection_items_tiles(request: Request, collection_id=None,
 
 @app.route('/collections/{collection_id:path}/items', methods=['GET', 'POST'])
 @app.route('/collections/{collection_id:path}/items/', methods=['GET', 'POST'])
-@app.route('/collections/{collection_id:path}/items/{item_id}',
+@app.route('/collections/{collection_id:path}/items/{item_id:path}',
            methods=['GET', 'PUT', 'DELETE'])
-@app.route('/collections/{collection_id:path}/items/{item_id}/',
+@app.route('/collections/{collection_id:path}/items/{item_id:path}/',
            methods=['GET', 'PUT', 'DELETE'])
 async def collection_items(request: Request, collection_id=None, item_id=None):
     """


### PR DESCRIPTION
# Overview
Adds support for item identifiers with paths (i.e. `/collections/{collectionId}/items/my%2Fidentifier`)
# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
