### PR TITLE
Edr Providers can raise Request Entity Too Large HTTP status

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -68,8 +68,8 @@ from pygeoapi.plugin import load_plugin, PLUGINS
 from pygeoapi.provider.base import (
     ProviderGenericError, ProviderConnectionError, ProviderNotFoundError,
     ProviderInvalidDataError, ProviderInvalidQueryError, ProviderNoDataError,
-    ProviderQueryError, ProviderItemNotFoundError, ProviderTypeError)
-from pygeoapi.provider.base_edr import EdrProviderRequestEntityTooLarge
+    ProviderQueryError, ProviderItemNotFoundError, ProviderTypeError,
+    ProviderRequestEntityTooLarge)
 
 from pygeoapi.provider.tile import (ProviderTileNotFoundError,
                                     ProviderTileQueryError,
@@ -3631,7 +3631,7 @@ class API:
             return self.get_exception(
                 HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
                 'NoApplicableCode', msg)
-        except EdrProviderRequestEntityTooLarge as err:
+        except ProviderRequestEntityTooLarge as err:
             msg = 'query error (check logs)'
             return self.get_exception(
                 HTTPStatus.REQUEST_ENTITY_TOO_LARGE, headers, request.format,

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3632,10 +3632,9 @@ class API:
                 HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
                 'NoApplicableCode', msg)
         except ProviderRequestEntityTooLarge as err:
-            msg = 'query error (check logs)'
             return self.get_exception(
                 HTTPStatus.REQUEST_ENTITY_TOO_LARGE, headers, request.format,
-                'NoApplicableCode', err.request_limit_explanation)
+                'NoApplicableCode', str(err))
 
         if request.format == F_HTML:  # render
             content = render_j2_template(self.config,

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -69,6 +69,7 @@ from pygeoapi.provider.base import (
     ProviderGenericError, ProviderConnectionError, ProviderNotFoundError,
     ProviderInvalidDataError, ProviderInvalidQueryError, ProviderNoDataError,
     ProviderQueryError, ProviderItemNotFoundError, ProviderTypeError)
+from pygeoapi.provider.base_edr import EdrProviderRequestEntityTooLarge
 
 from pygeoapi.provider.tile import (ProviderTileNotFoundError,
                                     ProviderTileQueryError,
@@ -3630,6 +3631,11 @@ class API:
             return self.get_exception(
                 HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
                 'NoApplicableCode', msg)
+        except EdrProviderRequestEntityTooLarge as err:
+            msg = 'query error (check logs)'
+            return self.get_exception(
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE, headers, request.format,
+                'NoApplicableCode', err.request_limit_explanation)
 
         if request.format == F_HTML:  # render
             content = render_j2_template(self.config,

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -69,7 +69,7 @@ from pygeoapi.provider.base import (
     ProviderGenericError, ProviderConnectionError, ProviderNotFoundError,
     ProviderInvalidDataError, ProviderInvalidQueryError, ProviderNoDataError,
     ProviderQueryError, ProviderItemNotFoundError, ProviderTypeError,
-    ProviderRequestEntityTooLarge)
+    ProviderRequestEntityTooLargeError)
 
 from pygeoapi.provider.tile import (ProviderTileNotFoundError,
                                     ProviderTileQueryError,
@@ -3631,7 +3631,7 @@ class API:
             return self.get_exception(
                 HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
                 'NoApplicableCode', msg)
-        except ProviderRequestEntityTooLarge as err:
+        except ProviderRequestEntityTooLargeError as err:
             return self.get_exception(
                 HTTPStatus.REQUEST_ENTITY_TOO_LARGE, headers, request.format,
                 'NoApplicableCode', str(err))

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -317,6 +317,4 @@ class ProviderInvalidDataError(ProviderGenericError):
 
 class ProviderRequestEntityTooLarge(ProviderGenericError):
     """provider request entity too large error"""
-
-    def __init__(self, request_limit_explanation: str):
-        self.request_limit_explanation = request_limit_explanation
+    pass

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -315,6 +315,6 @@ class ProviderInvalidDataError(ProviderGenericError):
     pass
 
 
-class ProviderRequestEntityTooLarge(ProviderGenericError):
+class ProviderRequestEntityTooLargeError(ProviderGenericError):
     """provider request entity too large error"""
     pass

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -313,3 +313,10 @@ class ProviderVersionError(ProviderGenericError):
 class ProviderInvalidDataError(ProviderGenericError):
     """provider invalid data error"""
     pass
+
+
+class ProviderRequestEntityTooLarge(ProviderGenericError):
+    """provider request entity too large error"""
+
+    def __init__(self, request_limit_explanation: str):
+        self.request_limit_explanation = request_limit_explanation

--- a/pygeoapi/provider/base_edr.py
+++ b/pygeoapi/provider/base_edr.py
@@ -29,7 +29,7 @@
 
 import logging
 
-from pygeoapi.provider.base import BaseProvider
+from pygeoapi.provider.base import BaseProvider, ProviderGenericError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -95,3 +95,10 @@ class BaseEDRProvider(BaseProvider):
             return getattr(self, kwargs.get('query_type'))(**kwargs)
         except AttributeError:
             raise NotImplementedError('Query not implemented!')
+
+
+class EdrProviderRequestEntityTooLarge(ProviderGenericError):
+    """provider request entity too large error"""
+
+    def __init__(self, request_limit_explanation: str):
+        self.request_limit_explanation = request_limit_explanation

--- a/pygeoapi/provider/base_edr.py
+++ b/pygeoapi/provider/base_edr.py
@@ -29,7 +29,7 @@
 
 import logging
 
-from pygeoapi.provider.base import BaseProvider, ProviderGenericError
+from pygeoapi.provider.base import BaseProvider
 
 LOGGER = logging.getLogger(__name__)
 
@@ -95,10 +95,3 @@ class BaseEDRProvider(BaseProvider):
             return getattr(self, kwargs.get('query_type'))(**kwargs)
         except AttributeError:
             raise NotImplementedError('Query not implemented!')
-
-
-class EdrProviderRequestEntityTooLarge(ProviderGenericError):
-    """provider request entity too large error"""
-
-    def __init__(self, request_limit_explanation: str):
-        self.request_limit_explanation = request_limit_explanation


### PR DESCRIPTION
# Overview

Allows an EDR provider plugin to raise an exception that results in an [HTTP status code 413 - Request Entity Too Large](https://docs.ogc.org/is/19-086r5/19-086r5.html#toc31). 

The standard states that the response should:

> ... the implementation should return a message explaining the query limits imposed by the server implementation.

This is why the provider must initialize the provider exception with the `request_limit_explanation` argument, which will be propagated to the HTTP response.

# Related Issue / Discussion

Should resolve #1118

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
