### PR TITLE
PostgreSQL: add numberMatched and numberReturned to query response (#1007)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - python-version: 3.6
           - python-version: 3.7
     env:
       PYGEOAPI_CONFIG: "$(pwd)/pygeoapi-config.yml"
@@ -88,7 +89,6 @@ jobs:
         pip3 install -r requirements-provider.txt
         python3 setup.py install
         pip3 install --upgrade numpy
-        pip3 install "SQLAlchemy<2"
     - name: setup test data ⚙️
       run: |
         python3 tests/load_es_data.py tests/data/ne_110m_populated_places_simple.geojson geonameid

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: 3.6
           - python-version: 3.7
     env:
       PYGEOAPI_CONFIG: "$(pwd)/pygeoapi-config.yml"
@@ -89,6 +88,7 @@ jobs:
         pip3 install -r requirements-provider.txt
         python3 setup.py install
         pip3 install --upgrade numpy
+        #pip3 install --upgrade rasterio==1.1.8
     - name: setup test data ⚙️
       run: |
         python3 tests/load_es_data.py tests/data/ne_110m_populated_places_simple.geojson geonameid

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
         pip3 install -r requirements-provider.txt
         python3 setup.py install
         pip3 install --upgrade numpy
-        #pip3 install --upgrade rasterio==1.1.8
+        pip3 install "SQLAlchemy<2"
     - name: setup test data ⚙️
       run: |
         python3 tests/load_es_data.py tests/data/ne_110m_populated_places_simple.geojson geonameid

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -7,7 +7,7 @@
 #          Colin Blackburn <colb@bgs.ac.uk>
 #
 # Copyright (c) 2018 Jorge Samuel Mendes de Jesus
-# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2023 Tom Kralidis
 # Copyright (c) 2022 John A Stevenson and Colin Blackburn
 #
 # Permission is hereby granted, free of charge, to any person
@@ -122,11 +122,10 @@ class PostgreSQLProvider(BaseProvider):
         :param q: full-text search term(s)
         :param filterq: CQL query as text string
 
-        :returns: GeoJSON FeaturesCollection
+        :returns: GeoJSON FeatureCollection
         """
-        LOGGER.debug('Querying PostGIS')
 
-        # Prepare filters
+        LOGGER.debug('Preparing filters')
         property_filters = self._get_property_filters(properties)
         cql_filters = self._get_cql_filters(filterq)
         bbox_filter = self._get_bbox_filter(bbox)
@@ -134,6 +133,7 @@ class PostgreSQLProvider(BaseProvider):
         selected_properties = self._select_properties_clause(select_properties,
                                                              skip_geometry)
 
+        LOGGER.debug('Querying PostGIS')
         # Execute query within self-closing database Session context
         with Session(self._engine) as session:
             results = (session.query(self.table_model)
@@ -144,25 +144,28 @@ class PostgreSQLProvider(BaseProvider):
                        .options(selected_properties)
                        .offset(offset))
 
-            # Prepare and return feature collection response
+            matched = results.count()
+            if limit < matched:
+                returned = limit
+            else:
+                returned = matched
+
+            LOGGER.debug(f'Found {matched} result(s)')
+
+            LOGGER.debug('Preparing response')
             response = {
                 'type': 'FeatureCollection',
-                'features': []
+                'features': [],
+                'numberMatched': matched,
+                'numberReturned': returned
             }
 
-            if resulttype == "hits":
-                # User requested hit count
-                response['numberMatched'] = results.count()
-                return response
-
-            if not results:
-                # Empty response
+            if resulttype == "hits" or not results:
+                response['numberReturned'] = 0
                 return response
 
             for item in results.limit(limit):
-                response['features'].append(
-                    self._sqlalchemy_to_feature(item)
-                )
+                response['features'].append(self._sqlalchemy_to_feature(item))
 
         return response
 
@@ -189,7 +192,7 @@ class PostgreSQLProvider(BaseProvider):
 
         :param identifier: feature id
 
-        :returns: GeoJSON FeaturesCollection
+        :returns: GeoJSON FeatureCollection
         """
         LOGGER.debug(f'Get item by ID: {identifier}')
 

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -6,7 +6,7 @@
 #          Colin Blackburn <colb@bgs.ac.uk>
 #
 # Copyright (c) 2019 Just van den Broecke
-# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2023 Tom Kralidis
 # Copyright (c) 2022 John A Stevenson and Colin Blackburn
 #
 # Permission is hereby granted, free of charge, to any person
@@ -101,7 +101,7 @@ def test_query_with_property_filter(config):
     stream_features = list(
         filter(lambda feature: feature['properties']['waterway'] == 'stream',
                features))
-    assert (len(features) == len(stream_features))
+    assert len(features) == len(stream_features)
 
     feature_collection = p.query(limit=50)
     features = feature_collection.get('features')
@@ -111,8 +111,10 @@ def test_query_with_property_filter(config):
     other_features = list(
         filter(lambda feature: feature['properties']['waterway'] != 'stream',
                features))
-    assert (len(features) != len(stream_features))
-    assert (len(other_features) != 0)
+    assert len(features) != len(stream_features)
+    assert len(other_features) != 0
+    assert feature_collection['numberMatched'] == 14776
+    assert feature_collection['numberReturned'] == 50
 
 
 def test_query_with_config_properties(config):


### PR DESCRIPTION
# Overview
Adds `numberMatched` and `numberReturned` to PostgreSQL result sets.
# Related Issue / Discussion
#1007 
# Additional Information
This PR also:
- pins SQLAlchemy in CI to `<2` (pending pygeofilter updates in https://github.com/geopython/pygeofilter/issues/67)
- removes Python 3.6 from the CI matrix
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
