### PR TITLE
EDR cube query with bbox parameter

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3588,6 +3588,17 @@ class API:
         LOGGER.debug('Processing z parameter')
         z = request.params.get('z')
 
+        bbox = None
+        if query_type == 'cube':
+            try:
+                bbox = validate_bbox(request.params.get('bbox'))
+                if not bbox:
+                    raise ValueError('bbox parameter required by cube queries')
+            except ValueError as err:
+                return self.get_exception(
+                    HTTPStatus.BAD_REQUEST, headers, request.format,
+                    'InvalidParameterValue', str(err))
+
         LOGGER.debug('Loading provider')
         try:
             p = load_plugin('provider', get_provider_by_type(
@@ -3634,7 +3645,8 @@ class API:
             datetime_=datetime_,
             select_properties=parameternames,
             wkt=wkt,
-            z=z
+            z=z,
+            bbox=bbox
         )
 
         try:

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3888,8 +3888,8 @@ def validate_bbox(value=None) -> list:
 
     bbox = value.split(',')
 
-    if len(bbox) != 4:
-        msg = 'bbox should be 4 values (minx,miny,maxx,maxy)'
+    if len(bbox) != 4 or len(bbox) != 6:
+        msg = 'bbox should be either 4 values (minx,miny,maxx,maxy) or 6 values (minx,miny,minz,maxx,maxy,maxz)'
         LOGGER.debug(msg)
         raise ValueError(msg)
 


### PR DESCRIPTION
# Overview

Providers of EDR cube queries can now receive the mandatory parameter `bbox`, see #1125 for more.

BBOX parameter also expanded to support z-axis. The function `validate_bbox` is also used by other API endpoints like OGC API Features, but Features can also support z-axis bbox requests: https://docs.opengeospatial.org/is/17-069r4/17-069r4.html#_parameter_bbox

# Related Issue / Discussion

#1125 

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
