### PR TITLE
EDR bbox parameter support for cube queries

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3888,8 +3888,9 @@ def validate_bbox(value=None) -> list:
 
     bbox = value.split(',')
 
-    if len(bbox) != 4:
-        msg = 'bbox should be 4 values (minx,miny,maxx,maxy)'
+    if len(bbox) not in [4, 6]:
+        msg = 'bbox should be either 4 values (minx,miny,maxx,maxy) ' \
+              'or 6 values (minx,miny,minz,maxx,maxy,maxz)'
         LOGGER.debug(msg)
         raise ValueError(msg)
 
@@ -3901,14 +3902,21 @@ def validate_bbox(value=None) -> list:
         LOGGER.debug(msg)
         raise
 
-    if bbox[1] > bbox[3]:
+    if (len(bbox) == 4 and bbox[1] > bbox[3]) \
+            or (len(bbox) == 6 and bbox[1] > bbox[4]):
         msg = 'miny should be less than maxy'
         LOGGER.debug(msg)
         raise ValueError(msg)
 
-    if bbox[0] > bbox[2]:
+    if (len(bbox) == 4 and bbox[0] > bbox[2]) \
+            or (len(bbox) == 6 and bbox[0] > bbox[3]):
         msg = 'minx is greater than maxx (possibly antimeridian bbox)'
         LOGGER.debug(msg)
+
+    if len(bbox) == 6 and bbox[2] > bbox[5]:
+        msg = 'minz should be less than maxz'
+        LOGGER.debug(msg)
+        raise ValueError(msg)
 
     return bbox
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1732,9 +1732,12 @@ def test_get_collection_edr_query(config, api_):
 
 def test_validate_bbox():
     assert validate_bbox('1,2,3,4') == [1, 2, 3, 4]
+    assert validate_bbox('1,2,3,4,5,6') == [1, 2, 3, 4, 5, 6]
     assert validate_bbox('-142,42,-52,84') == [-142, 42, -52, 84]
     assert (validate_bbox('-142.1,42.12,-52.22,84.4') ==
             [-142.1, 42.12, -52.22, 84.4])
+    assert (validate_bbox('-142.1,42.12,-5.28,-52.22,84.4,7.39') ==
+            [-142.1, 42.12, -5.28, -52.22, 84.4, 7.39])
 
     assert (validate_bbox('177.0,65.0,-177.0,70.0') ==
             [177.0, 65.0, -177.0, 70.0])
@@ -1743,7 +1746,13 @@ def test_validate_bbox():
         validate_bbox('1,2,4')
 
     with pytest.raises(ValueError):
+        validate_bbox('1,2,4,5,6')
+
+    with pytest.raises(ValueError):
         validate_bbox('3,4,1,2')
+
+    with pytest.raises(ValueError):
+        validate_bbox('1,2,6,4,5,3')
 
 
 def test_validate_datetime():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1729,6 +1729,36 @@ def test_get_collection_edr_query(config, api_):
         req, 'icoads-sst', None, 'position')
     assert code == HTTPStatus.NO_CONTENT
 
+    # position no coords
+    req = mock_request({
+        'datetime': '2000-01-17'
+    })
+    rsp_headers, code, response = api_.get_collection_edr_query(
+        req, 'icoads-sst', None, 'position')
+    assert code == HTTPStatus.BAD_REQUEST
+
+    # cube bbox parameter 4 dimensional
+    req = mock_request({
+        'bbox': '0,0,10,10'
+    })
+    rsp_headers, code, response = api_.get_collection_edr_query(
+        req, 'icoads-sst', None, 'cube')
+    assert code == HTTPStatus.OK
+
+    # cube bad bbox parameter
+    req = mock_request({
+        'bbox': '0,0,10'
+    })
+    rsp_headers, code, response = api_.get_collection_edr_query(
+        req, 'icoads-sst', None, 'cube')
+    assert code == HTTPStatus.BAD_REQUEST
+
+    # cube no bbox parameter
+    req = mock_request({})
+    rsp_headers, code, response = api_.get_collection_edr_query(
+        req, 'icoads-sst', None, 'cube')
+    assert code == HTTPStatus.BAD_REQUEST
+
 
 def test_validate_bbox():
     assert validate_bbox('1,2,3,4') == [1, 2, 3, 4]


### PR DESCRIPTION
# Overview

Providers of EDR cube queries can now receive the mandatory parameter bbox, see #1125 for more.

BBOX parameter also expanded to support z-axis. The function validate_bbox is also used by other API endpoints like OGC API Features, but Features can also support z-axis bbox requests: https://docs.opengeospatial.org/is/17-069r4/17-069r4.html#_parameter_bbox

# Related Issue / Discussion

#1125

# Additional Information

Some open questions:
 - The validation of the z-axis in bbox requires it should be increasing, but maybe this requirement is too strict? A z-axis given in pressure layers would be decreasing, right?

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
