### PR TITLE
fix(OGRProvider_init): make the 'id_field' attribute mandatory in provider config

### DIFF
--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -171,6 +171,13 @@ class OGRProvider(BaseProvider):
 
         self._load_source_helper(self.data_def['source_type'])
 
+        # ID field is required
+        self.id_field = provider_def.get('id_field')
+        if not self.id_field:
+            msg = 'Need explicit \'id_field\' attr in provider config'
+            LOGGER.error(msg)
+            raise Exception(msg)
+
         # Layer name is required
         self.layer_name = provider_def.get('layer')
         if not self.layer_name:


### PR DESCRIPTION
# Overview
As for the 'layer' attribute, the 'id_field' should be specified in the configuration file for the OGRProvider. The 'get' method of a OGRProvider instance (e.g. when requesting a single feature) needs the feature ID when setting an attribute filter on the layer. If the 'id_field' attribute is omitted in the configuration file, the error thrown is more explicit.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute the ogr-provider-id-field branch to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I agree to the pygeoapi Contributions and Licensing Guidelines
