### PR TITLE
Allow Sqlite provider to return None as a geometry if it is missing.

### DIFF
--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -148,13 +148,17 @@ class SQLiteGPKGProvider(BaseProvider):
         if row_data:
             rd = dict(row_data)  # sqlite3.Row is doesnt support pop
             feature = {
-                'type': 'Feature'
+                'type': 'Feature',
+                'geometry': None
             }
-            feature["geometry"] = json.loads(
-                rd.pop(f'AsGeoJSON({self.geom_col})')
-                )
-            if skip_geometry:
-                feature["geometry"] = None
+
+            try:
+                if not skip_geometry:
+                    feature['geometry'] = json.loads(
+                        rd.pop(f'AsGeoJSON({self.geom_col})')
+                    )
+            except TypeError:
+                LOGGER.warning('Missing geometry')
 
             feature['properties'] = rd
             feature['id'] = feature['properties'].pop(self.id_field)


### PR DESCRIPTION
# Overview
The sqlite/gpkg provider errors out if one of the features has `None` geometry. This PR leaves features without geometry in line with the other pygeoapi providers with `"geometry": None` if not provided. 

# Related Issue / Discussion

# Additional Information

For example the first item in the collecton: [https://reference.geoconnex.us/collections/pws/items/055294304](https://reference.geoconnex.us/collections/pws/items/055294304), has geometry, but the second, [https://reference.geoconnex.us/collections/pws/items/070000013](https://reference.geoconnex.us/collections/pws/items/070000013) does not. This means that the [/items](https://reference.geoconnex.us/collections/pws/items) does not work. 

Not sure if this is relevant or worth adding to the integration tests, but would be nice to have the GPKG not throw unnecessary 500's.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
