### PR TITLE
Use upstream encoding for gzip with CSV formatter

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -194,12 +194,16 @@ def gzip(func):
 
     def inner(*args, **kwargs):
         headers, status, content = func(*args, **kwargs)
+        charset = CHARSET[0]
         if F_GZIP in headers.get('Content-Encoding', []):
             try:
-                charset = CHARSET[0]
-                headers['Content-Type'] = \
-                    f"{headers['Content-Type']}; charset={charset}"
-                content = compress(content.encode(charset))
+                if isinstance(content, bytes):
+                    # bytes means Content-Type needs to be set upstream
+                    content = compress(content)
+                else:
+                    headers['Content-Type'] = \
+                        f"{headers['Content-Type']}; charset={charset}"
+                    content = compress(content.encode(charset))
             except TypeError as err:
                 headers.pop('Content-Encoding')
                 LOGGER.error(f'Error in compression: {err}')
@@ -1650,7 +1654,7 @@ class API:
                     HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
                     'NoApplicableCode', msg)
 
-            headers['Content-Type'] = f"{formatter.mimetype}; charset={self.config['server']['encoding']}"  # noqa
+            headers['Content-Type'] = formatter.content_type
 
             if p.filename is None:
                 filename = f'{dataset}.csv'

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1654,7 +1654,7 @@ class API:
                     HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
                     'NoApplicableCode', msg)
 
-            headers['Content-Type'] = formatter.content_type
+            headers['Content-Type'] = formatter.mimetype
 
             if p.filename is None:
                 filename = f'{dataset}.csv'

--- a/pygeoapi/formatter/base.py
+++ b/pygeoapi/formatter/base.py
@@ -45,6 +45,7 @@ class BaseFormatter:
         """
 
         self.mimetype = None
+        self.content_type = None
         self.geom = False
 
         self.name = formatter_def['name']

--- a/pygeoapi/formatter/base.py
+++ b/pygeoapi/formatter/base.py
@@ -45,7 +45,6 @@ class BaseFormatter:
         """
 
         self.mimetype = None
-        self.content_type = None
         self.geom = False
 
         self.name = formatter_def['name']

--- a/pygeoapi/formatter/csv_.py
+++ b/pygeoapi/formatter/csv_.py
@@ -54,8 +54,7 @@ class CSVFormatter(BaseFormatter):
             geom = formatter_def['geom']
 
         super().__init__({'name': 'csv', 'geom': geom})
-        self.mimetype = 'text/csv'
-        self.content_type = 'text/csv; charset=utf-8'
+        self.mimetype = 'text/csv; charset=utf-8'
 
     def write(self, options: dict = {}, data: dict = None) -> str:
         """

--- a/pygeoapi/formatter/csv_.py
+++ b/pygeoapi/formatter/csv_.py
@@ -55,6 +55,7 @@ class CSVFormatter(BaseFormatter):
 
         super().__init__({'name': 'csv', 'geom': geom})
         self.mimetype = 'text/csv'
+        self.content_type = 'text/csv; charset=utf-8'
 
     def write(self, options: dict = {}, data: dict = None) -> str:
         """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -388,8 +388,8 @@ def test_gzip_csv(config, api_):
 
     req_csv = mock_request({'f': 'csv'}, HTTP_ACCEPT_ENCODING=F_GZIP)
     rsp_csv_headers, _, rsp_csv_gzip = api_.get_collection_items(req_csv, 'obs') # noqa
-    assert rsp_csv_headers['Content-Type'] == 'text/csv; charset=utf-16'
-    rsp_csv_ = gzip.decompress(rsp_csv_gzip).decode('utf-16')
+    assert rsp_csv_headers['Content-Type'] == 'text/csv; charset=utf-8'
+    rsp_csv_ = gzip.decompress(rsp_csv_gzip).decode('utf-8')
     assert rsp_csv == rsp_csv_
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -370,6 +370,29 @@ def test_gzip(config, api_):
         gzip.decompress(rsp_gzip_html).decode(enc_16)
 
 
+def test_gzip_csv(config, api_):
+    req_csv = mock_request({'f': 'csv'})
+    rsp_csv_headers, _, rsp_csv = api_.get_collection_items(req_csv, 'obs')
+    assert rsp_csv_headers['Content-Type'] == 'text/csv; charset=utf-8'
+    rsp_csv = rsp_csv.decode('utf-8')
+
+    req_csv = mock_request({'f': 'csv'}, HTTP_ACCEPT_ENCODING=F_GZIP)
+    rsp_csv_headers, _, rsp_csv_gzip = api_.get_collection_items(req_csv, 'obs') # noqa
+    assert rsp_csv_headers['Content-Type'] == 'text/csv; charset=utf-8'
+    rsp_csv_ = gzip.decompress(rsp_csv_gzip).decode('utf-8')
+    assert rsp_csv == rsp_csv_
+
+    # Use utf-16 encoding
+    config['server']['encoding'] = 'utf-16'
+    api_ = API(config)
+
+    req_csv = mock_request({'f': 'csv'}, HTTP_ACCEPT_ENCODING=F_GZIP)
+    rsp_csv_headers, _, rsp_csv_gzip = api_.get_collection_items(req_csv, 'obs') # noqa
+    assert rsp_csv_headers['Content-Type'] == 'text/csv; charset=utf-16'
+    rsp_csv_ = gzip.decompress(rsp_csv_gzip).decode('utf-16')
+    assert rsp_csv == rsp_csv_
+
+
 def test_root(config, api_):
     req = mock_request()
     rsp_headers, code, response = api_.landing_page(req)

--- a/tests/test_csv__formatter.py
+++ b/tests/test_csv__formatter.py
@@ -67,7 +67,7 @@ def test_csv__formatter(fixture):
 
     header = list(reader.fieldnames)
 
-    assert f.mimetype == 'text/csv'
+    assert f.mimetype == 'text/csv; charset=utf-8'
 
     assert len(header) == 5
 


### PR DESCRIPTION
# Overview
- No not try encoding bytes during gzip
- Allow formatter to set Content-Type header upstream if sending encoded bytes
- Add test for gzip and csv

# Related Issue / Discussion
https://github.com/cgs-earth/pygeoapi/actions/runs/4166737095/jobs/7211447200

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
