### PR TITLE
feat(OGRProvider): allow to use 'geom_field' in the config for OGR pr…

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -178,7 +178,7 @@ The OGR provider requires a recent (3+) version of GDAL to be installed.
          - type: feature
            name: OGR
            data:
-             source_type: 
+             source_type: ESRIJSON
              source: https://map.bgs.ac.uk/arcgis/rest/services/GeoIndex_Onshore/boreholes/MapServer/0/query?where=BGS_ID+%3D+BGS_ID&outfields=*&orderByFields=BGS_ID+ASC&f=json
              source_srs: EPSG:27700
              target_srs: EPSG:4326

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -178,7 +178,7 @@ The OGR provider requires a recent (3+) version of GDAL to be installed.
          - type: feature
            name: OGR
            data:
-             source_type: ESRIJSON
+             source_type: 
              source: https://map.bgs.ac.uk/arcgis/rest/services/GeoIndex_Onshore/boreholes/MapServer/0/query?where=BGS_ID+%3D+BGS_ID&outfields=*&orderByFields=BGS_ID+ASC&f=json
              source_srs: EPSG:27700
              target_srs: EPSG:4326
@@ -194,6 +194,20 @@ The OGR provider requires a recent (3+) version of GDAL to be installed.
                  CPL_DEBUG: NO
            id_field: BGS_ID
            layer: ESRIJSON
+
+.. code-block:: yaml
+
+    providers:
+         - type: feature
+           name: OGR
+           data:
+             source_type: PostgreSQL
+             source: "PG: host=127.0.0.1 dbname=test user=postgres password=postgres"
+             source_srs: EPSG:4326
+             target_srs: EPSG:4326 # Can be used to transform/reproject the data
+           id_field: osm_id
+           layer: osm.hotosm_bdi_waterways # Value follows a 'my_schema.my_table' structure
+           geom_field: foo_geom
 
 
 

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -475,8 +475,6 @@ class OGRProvider(BaseProvider):
         json_feature = ogr_feature.ExportToJson(as_object=True)
         if skip_geometry:
             json_feature['geometry'] = None
-        elif geom is not None:
-            json_feature['geometry'] = json.loads(geom.ExportToJson())
         else:
             json_feature['geometry'] = json.loads(geom.ExportToJson())
         try:


### PR DESCRIPTION
# Overview
This PR enables to specify a geometry field "geom_field" in the configuration file, in the same way as with the PostgreSQL provider, but when using the OGRProvider. OGR can be used with many different data sources, some of them may have records/features that can be represented by multiple geometries. "geom_field" can be used to choose which field to use for the features' geometry.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute the ogr-provider-multiple-geoms feature branch to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
