### PR TITLE
support EDR radius queries

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3574,6 +3574,7 @@ class API:
 
         bbox = None
         if query_type == 'cube':
+            LOGGER.debug('Processing cube bbox')
             try:
                 bbox = validate_bbox(request.params.get('bbox'))
                 if not bbox:
@@ -3599,6 +3600,12 @@ class API:
             return self.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'InvalidParameterValue', msg)
+
+        within = within_units = None
+        if query_type == 'radius':
+            LOGGER.debug('Processing within / within-units parameters')
+            within = request.params.get('within')
+            within_units = request.params.get('within-units')
 
         LOGGER.debug('Processing z parameter')
         z = request.params.get('z')
@@ -3650,7 +3657,9 @@ class API:
             select_properties=parameternames,
             wkt=wkt,
             z=z,
-            bbox=bbox
+            bbox=bbox,
+            within=within,
+            within_units=within_units
         )
 
         try:

--- a/pygeoapi/provider/base_edr.py
+++ b/pygeoapi/provider/base_edr.py
@@ -87,6 +87,9 @@ class BaseEDRProvider(BaseProvider):
         :param select_properties: list of parameters
         :param z: vertical level(s)
         :param format_: data format of output
+        :param bbox: bbox geometry (for cube queries)
+        :param within: distance (for radius querires)
+        :param within_units: distance units (for radius querires)
 
         :returns: coverage data as `dict` of CoverageJSON or native format
         """


### PR DESCRIPTION
# Overview
Adds support for EDR API radius queries (`within` and `within-units`).  No updates are made to the xarray EDR provider given the query pattern (which is more focused for discrete data).

# Related Issue / Discussion
None
# Additional Information
cc @petergarnaes 
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
