### PR TITLE
Fix setting default templates

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -75,11 +75,10 @@ from pygeoapi.provider.tile import (ProviderTileNotFoundError,
                                     ProviderTileQueryError,
                                     ProviderTilesetIdNotFoundError)
 from pygeoapi.models.cql import CQLModel
-from pygeoapi.util import (dategetter, DATETIME_FORMAT,
+from pygeoapi.util import (dategetter, DATETIME_FORMAT, to_json,
                            filter_dict_by_key_value, get_provider_by_type,
                            get_provider_default, get_typed_value, JobStatus,
-                           json_serial, render_j2_template, str2bool,
-                           TEMPLATES, to_json)
+                           json_serial, render_j2_template, str2bool)
 
 from pygeoapi.models.provider.base import TilesMetadataFormat
 
@@ -634,9 +633,6 @@ class API:
         # Process language settings (first locale is default!)
         self.locales = l10n.get_locales(config)
         self.default_locale = self.locales[0]
-
-        if 'templates' not in self.config['server']:
-            self.config['server']['templates'] = {'path': TEMPLATES}
 
         if 'pretty_print' not in self.config['server']:
             self.config['server']['pretty_print'] = False

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -75,10 +75,11 @@ from pygeoapi.provider.tile import (ProviderTileNotFoundError,
                                     ProviderTileQueryError,
                                     ProviderTilesetIdNotFoundError)
 from pygeoapi.models.cql import CQLModel
-from pygeoapi.util import (dategetter, DATETIME_FORMAT, to_json,
+from pygeoapi.util import (dategetter, DATETIME_FORMAT,
                            filter_dict_by_key_value, get_provider_by_type,
                            get_provider_default, get_typed_value, JobStatus,
-                           json_serial, render_j2_template, str2bool)
+                           json_serial, render_j2_template, str2bool,
+                           TEMPLATES, to_json)
 
 from pygeoapi.models.provider.base import TilesMetadataFormat
 
@@ -633,6 +634,9 @@ class API:
         # Process language settings (first locale is default!)
         self.locales = l10n.get_locales(config)
         self.default_locale = self.locales[0]
+
+        if 'templates' not in self.config['server']:
+            self.config['server']['templates'] = {'path': TEMPLATES}
 
         if 'pretty_print' not in self.config['server']:
             self.config['server']['pretty_print'] = False

--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -225,13 +225,13 @@ def geojson2jsonld(config: dict, data: dict, dataset: str,
 
         for i, feature in enumerate(data['features']):
             # Get URI for each feature
-            identifier = feature.get(id_field,
-                                     feature['properties'].get(id_field, ''))
-            if not is_url(str(identifier)):
-                identifier = f"{config['server']['url']}/collections/{dataset}/items/{feature['id']}"  # noqa
+            identifier_ = feature.get(id_field,
+                                      feature['properties'].get(id_field, ''))
+            if not is_url(str(identifier_)):
+                identifier_ = f"{config['server']['url']}/collections/{dataset}/items/{feature['id']}"  # noqa
 
             data['features'][i] = {
-                '@id': identifier,
+                '@id': identifier_,
                 'type': 'schema:Place'
             }
 

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -327,10 +327,10 @@ def render_j2_template(config: dict, template: Path,
     :returns: string of rendered template
     """
 
-    template_paths = {TEMPLATES, '.'}
+    template_paths = [TEMPLATES, '.']
     try:
         templates = config['server']['templates']['path']
-        template_paths.add(templates)
+        template_paths.insert(0, templates)
         LOGGER.debug(f'using custom templates: {templates}')
     except (KeyError, TypeError):
         LOGGER.debug(f'using default templates: {TEMPLATES}')


### PR DESCRIPTION
# Overview
- Preserve template priority. Sets are unordered. Replace set of Jinja2 search paths with list and insert custom templates to first search path.
- Do not add default paths to App configuration dictionary. This means the `render_j2_template` function always thinks it is being passed custom templates, even if the template path is the default.  

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/pull/868

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
