### PR TITLE
API design rule support

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -18,6 +18,8 @@ pygeoapi configuration contains the following core sections:
 - ``metadata``: server-wide metadata (contact, licensing, etc.)
 - ``resources``: dataset collections, processes and stac-collections offered by the server
 
+The full configuration schema with descriptions of all available properties can be found `here <https://github.com/geopython/pygeoapi/blob/master/pygeoapi/schemas/config/pygeoapi-config-0.x.yml>`_.
+
 .. note::
    `Standard YAML mechanisms <https://en.wikipedia.org/wiki/YAML#Advanced_components>`_ can be used (anchors, references, etc.) for reuse and compactness.
 
@@ -30,6 +32,7 @@ Reference
 ^^^^^^^^^^
 
 The ``server`` section provides directives on binding and high level tuning.
+Please find more information related to API design rules (the property at the bottom of the example below) :ref:`further down<API Design Rules>`.
 
 .. code-block:: yaml
 
@@ -60,6 +63,12 @@ The ``server`` section provides directives on binding and high level tuning.
         name: TinyDB  # plugin name (see pygeoapi.plugin for supported process_manager's)
         connection: /tmp/pygeoapi-process-manager.db  # connection info to store jobs (e.g. filepath)
         output_dir: /tmp/  # temporary file area for storing job results (files)
+
+    api_rules:  # optional API design rules to which pygeoapi should adhere
+        api_version: 1.2.3  # omit to use pygeoapi's software version
+        strict_slashes: true  # trailing slashes will not be allowed and result in a 404
+        url_prefix: 'v{api_major}'  # adds a /v1 prefix to all URL paths
+        version_header: X-API-Version  # add a response header of this name with the API version
 
 
 ``logging``
@@ -286,6 +295,58 @@ Examples:
    curl https://example.org/collections  # resource foo is not advertised
    curl https://example.org/openapi  # resource foo is not advertised
    curl https://example.org/collections/foo  # user can access resource normally
+
+
+API Design Rules
+----------------
+
+Some pygeoapi setups may wish to adhere to specific API design rules that apply at an organization.
+The ``api_rules`` object in the ``server`` section of the configuration can be used for this purpose.
+
+Note that the entire ``api_rules`` object is optional. No rules will be applied if the object is omitted.
+
+The following properties can be set:
+
+``api_version``
+^^^^^^^^^^^^^^^
+
+If specified, this property is a string that defines the semantic version number of the API.
+Note that this number should reflect the state of the *API data model* (request and response object structure, API endpoints, etc.)
+and does not necessarily correspond to the *software* version of pygeoapi. For example, the software could have been
+completely rewritten (which changes the software version number), but the API data model might still be the same as before.
+
+Unfortunately, pygeoapi currently does not offer a way to keep track of the API version.
+This means that you need to set (and maintain) your own version here or leave it empty or unset.
+In the latter case, the software version of pygeoapi will be used instead.
+
+``strict_slashes``
+^^^^^^^^^^^^^^^^^^
+
+Some API rules state that trailing slashes at the end of a URL are not allowed if they point to a specific resource item.
+In that case, you may wish to set this property to ``true``. Doing so will result in a ``404 Not Found`` if a user adds a ``/`` to the end of a URL.
+If omitted or ``false`` (default), it does not matter whether the user omits or adds the ``/`` to the end of the URL.
+
+``url_prefix``
+^^^^^^^^^^^^^^
+
+Set this property to include a prefix in the URL path (e.g. `https://base.com/<my_prefix>/endpoint`).
+Note that you do not need to include slashes (either at the start or the end) here: they will be added automatically.
+
+If you wish to include the API version number (depending on the `api_version`_ property) in the prefix, you can use the following variables:
+
+- ``{api_version}``: full semantic version number
+- ``{api_major}``: major version number
+- ``{api_minor}``: minor version number
+- ``{api_build}``: build number
+
+For example, if the API version is *1.2.3*, then a URL prefix template of ``v{api_major}`` will result in *v1* as the actual prefix.
+
+``version_header``
+^^^^^^^^^^^^^^^^^^
+
+Set this property to add a header to each pygeoapi response that includes the semantic API version (see `api_version`_).
+If omitted, no header will be added. Common names for this header are ``API-Version`` or ``X-API-Version``.
+Note that pygeoapi already adds a ``X-Powered-By`` header by default that includes the software version number.
 
 
 Validating the configuration

--- a/pygeoapi/config.py
+++ b/pygeoapi/config.py
@@ -40,6 +40,14 @@ LOGGER = logging.getLogger(__name__)
 THISDIR = Path(__file__).parent.resolve()
 
 
+def load_schema() -> dict:
+    """ Reads the JSON schema YAML file. """
+    schema_file = THISDIR / 'schemas' / 'config' / 'pygeoapi-config-0.x.yml'
+
+    with schema_file.open() as fh2:
+        return yaml_load(fh2)
+
+
 def validate_config(instance_dict: dict) -> bool:
     """
     Validate pygeoapi configuration against pygeoapi schema
@@ -48,14 +56,8 @@ def validate_config(instance_dict: dict) -> bool:
 
     :returns: `bool` of validation
     """
-
-    schema_file = THISDIR / 'schemas' / 'config' / 'pygeoapi-config-0.x.yml'
-
-    with schema_file.open() as fh2:
-        schema_dict = yaml_load(fh2)
-        jsonschema_validate(json.loads(to_json(instance_dict)), schema_dict)
-
-        return True
+    jsonschema_validate(json.loads(to_json(instance_dict)), load_schema())
+    return True
 
 
 @click.group()

--- a/pygeoapi/django_/settings.py
+++ b/pygeoapi/django_/settings.py
@@ -48,6 +48,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 import os
 # pygeoapi specific
 from pygeoapi.django_app import config
+from pygeoapi.util import get_api_rules
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -166,3 +167,9 @@ STATIC_URL = '/static/'
 
 # pygeoapi specific
 PYGEOAPI_CONFIG = config()
+
+API_RULES = get_api_rules(PYGEOAPI_CONFIG)
+
+# Defaults to True in Django
+# https://docs.djangoproject.com/en/3.2/ref/settings/#append-slash
+APPEND_SLASH = not API_RULES.strict_slashes

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -37,10 +37,8 @@ import click
 from flask import Flask, Blueprint, make_response, request, send_from_directory
 
 from pygeoapi.api import API
-from pygeoapi.util import get_mimetype, yaml_load
+from pygeoapi.util import get_mimetype, yaml_load, get_api_rules
 
-
-CONFIG = None
 
 if 'PYGEOAPI_CONFIG' not in os.environ:
     raise RuntimeError('PYGEOAPI_CONFIG environment variable not set')
@@ -48,14 +46,21 @@ if 'PYGEOAPI_CONFIG' not in os.environ:
 with open(os.environ.get('PYGEOAPI_CONFIG'), encoding='utf8') as fh:
     CONFIG = yaml_load(fh)
 
+API_RULES = get_api_rules(CONFIG)
+
 STATIC_FOLDER = 'static'
 if 'templates' in CONFIG['server']:
     STATIC_FOLDER = CONFIG['server']['templates'].get('static', 'static')
 
 APP = Flask(__name__, static_folder=STATIC_FOLDER, static_url_path='/static')
-APP.url_map.strict_slashes = False
+APP.url_map.strict_slashes = API_RULES.strict_slashes
 
-BLUEPRINT = Blueprint('pygeoapi', __name__, static_folder=STATIC_FOLDER)
+BLUEPRINT = Blueprint(
+    'pygeoapi',
+    __name__,
+    static_folder=STATIC_FOLDER,
+    url_prefix=API_RULES.get_url_prefix('flask')
+)
 
 # CORS: optionally enable from config.
 if CONFIG['server'].get('cors', False):
@@ -117,7 +122,7 @@ def get_response(result: tuple):
     return response
 
 
-@BLUEPRINT.route('/')
+@BLUEPRINT.route('' if API_RULES.strict_slashes else '/')
 def landing_page():
     """
     OGC API landing page endpoint

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -122,7 +122,7 @@ def get_response(result: tuple):
     return response
 
 
-@BLUEPRINT.route('' if API_RULES.strict_slashes else '/')
+@BLUEPRINT.route('/')
 def landing_page():
     """
     OGC API landing page endpoint

--- a/pygeoapi/models/config.py
+++ b/pygeoapi/models/config.py
@@ -1,0 +1,103 @@
+# ****************************** -*-
+# flake8: noqa
+# =================================================================
+#
+# Authors: Sander Schaminee <sander.schaminee@geocat.net>
+#
+# Copyright (c) 2023 Sander Schaminee
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from pydantic import BaseModel, Field
+
+
+class APIRules(BaseModel):
+    """ Pydantic model for API design rules that must be adhered to. """
+    api_version: str = Field(regex=r'^\d+\.\d+\..+$',
+                             description="Semantic API version number.")
+    url_prefix: str = Field(
+        "",
+        description="If set, pygeoapi routes will be prepended with the "
+                    "given URL path prefix (e.g. '/v1'). "
+                    "Defaults to an empty string (no prefix)."
+    )
+    version_header: str = Field(
+        "",
+        description="If set, pygeoapi will set a response header with this "
+                    "name and its value will hold the API version. "
+                    "Defaults to an empty string (i.e. no header). "
+                    "Often 'API-Version' or 'X-API-Version' are used here."
+    )
+    strict_slashes: bool = Field(
+        False,
+        description="If False (default), URL trailing slashes are allowed. "
+                    "If True, pygeoapi will return a 404."
+    )
+
+    @staticmethod
+    def create(**rules_config) -> 'APIRules':
+        """ Returns a new APIRules instance for the current API version
+        and configured rules. """
+        obj = {
+            k: v for k, v in rules_config.items() if k in APIRules.__fields__
+        }
+        # Validation will fail if required `api_version` is missing
+        # or if `api_version` is not a semantic version number
+        return APIRules.parse_obj(obj)
+
+    @property
+    def response_headers(self) -> dict:
+        """ Gets a dictionary of additional response headers for the current
+        API rules. Returns an empty dict if no rules apply. """
+        headers = {}
+        if self.version_header:
+            headers[self.version_header] = self.api_version
+        return headers
+
+    def get_url_prefix(self, style: str = None) -> str:
+        """
+        Returns an API URL prefix to use in all paths.
+        May include a (partial) API version. See docs for syntax.
+        :param style: Set to 'django', 'flask' or 'starlette' to return a
+                      specific prefix formatted for those frameworks.
+                      If not set, only the prefix itself will be returned.
+        """
+        if not self.url_prefix:
+            return ""
+        major, minor, build = self.api_version.split('.')
+        prefix = self.url_prefix.format(
+            api_version=self.api_version,
+            api_major=major,
+            api_minor=minor,
+            api_build=build
+        ).strip('/')
+        style = (style or '').lower()
+        if style == 'django':
+            # Django requires the slash at the end
+            return rf"^{prefix}/"
+        elif style in ('flask', 'starlette'):
+            # Flask and Starlette need the slash in front
+            return f"/{prefix}"
+        # If no format is specified, return only the bare prefix
+        return prefix

--- a/pygeoapi/process/manager/tinydb_.py
+++ b/pygeoapi/process/manager/tinydb_.py
@@ -27,7 +27,12 @@
 #
 # =================================================================
 
-import fcntl
+try:
+    import fcntl
+except ModuleNotFoundError:
+    # When on Windows, fcntl does not exist and file locking is automatic
+    fcntl = None
+
 import json
 import logging
 from pathlib import Path
@@ -65,7 +70,7 @@ class TinyDBManager(BaseManager):
 
         self.db = tinydb.TinyDB(self.connection)
 
-        if mode == 'w':
+        if mode == 'w' and fcntl is not None:
             fcntl.lockf(self.db.storage._handle, fcntl.LOCK_EX)
 
         return True
@@ -110,7 +115,7 @@ class TinyDBManager(BaseManager):
         doc_id = self.db.insert(job_metadata)
         self.db.close()
 
-        return doc_id
+        return doc_id  # noqa
 
     def update_job(self, job_id: str, update_dict: dict) -> bool:
         """
@@ -170,7 +175,7 @@ class TinyDBManager(BaseManager):
         """
         Get a job's status, and actual output of executing the process
 
-        :param jobid: job identifier
+        :param job_id: job identifier
 
         :returns: `tuple` of mimetype and raw output
         """

--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -36,7 +36,8 @@ from requests import Session
 
 from pygeoapi.provider.base import (BaseProvider, ProviderQueryError,
                                     ProviderConnectionError)
-from pygeoapi.util import yaml_load, url_join, get_provider_default
+from pygeoapi.util import (yaml_load, url_join, get_provider_default,
+                           get_base_url)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -114,7 +115,7 @@ class SensorThingsProvider(BaseProvider):
             # Read from pygeoapi config
             with open(os.getenv('PYGEOAPI_CONFIG'), encoding='utf8') as fh:
                 CONFIG = yaml_load(fh)
-                self.rel_link = CONFIG['server']['url']
+                self.rel_link = get_base_url(CONFIG)
 
             for (name, rs) in CONFIG['resources'].items():
                 pvs = rs.get('providers')

--- a/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
+++ b/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
@@ -101,6 +101,24 @@ properties:
                     - name
                     - connection
                     - output_dir
+            api_rules:
+                type: object
+                description: optional API design rules to which pygeoapi should adhere
+                properties:
+                    api_version:
+                        type: string
+                        description: optional semantic API version number override
+                    strict_slashes:
+                        type: boolean
+                        description: whether trailing slashes are allowed in URLs (disallow = True)
+                    url_prefix:
+                        type: string
+                        description: |-
+                            Set to include a prefix in the URL path (e.g. https://base.com/my_prefix/endpoint).
+                            Please refer to the configuration section of the documentation for more info.
+                    version_header:
+                        type: string
+                        description: API version response header (leave empty or unset to omit this header)
         required:
             - bind
             - url

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,11 @@ pytest-env
 coverage
 pyld
 
+# Testing with mock Starlette client
+starlette
+uvicorn[standard]
+httpx
+
 # PEP8
 flake8
 

--- a/tests/pygeoapi-test-config-apirules.yml
+++ b/tests/pygeoapi-test-config-apirules.yml
@@ -1,0 +1,347 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Sander Schaminee <sander.schaminee@geocat.net>
+#
+# Copyright (c) 2019 Tom Kralidis
+# Copyright (c) 2023 Sander Schaminee
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+server:
+    bind:
+        host: 0.0.0.0
+        port: 5000
+    url: http://localhost:5000/api
+    mimetype: application/json; charset=UTF-8
+    encoding: utf-8
+    gzip: false
+    languages:
+        # First language is the default language
+        - en-US
+        - fr-CA
+    cors: true
+    pretty_print: true
+    limit: 10
+    # templates: /path/to/templates
+    map:
+        url: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
+        attribution: '<a href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia maps</a> | Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+    manager:
+        name: TinyDB
+        connection: /tmp/pygeoapi-test-process-manager.db
+        output_dir: /tmp
+    api_rules:
+        strict_slashes: true
+        url_prefix: 'v{api_major}'
+        version_header: 'X-API-Version'
+
+logging:
+    level: DEBUG
+    #logfile: /tmp/pygeoapi.log
+
+metadata:
+    identification:
+        title:
+            en: pygeoapi default instance
+            fr: instance par défaut de pygeoapi
+        description:
+            en: pygeoapi provides an API to geospatial data
+            fr: pygeoapi fournit une API aux données géospatiales
+        keywords:
+            en:
+                - geospatial
+                - data
+                - api
+            fr:
+                - géospatiale
+                - données
+                - api
+        keywords_type: theme
+        terms_of_service: https://creativecommons.org/licenses/by/4.0/
+        url: http://example.org
+    license:
+        name: CC-BY 4.0 license
+        url: https://creativecommons.org/licenses/by/4.0/
+    provider:
+        name: Organization Name
+        url: https://pygeoapi.io
+    contact:
+        name: Lastname, Firstname
+        position: Position Title
+        address: Mailing Address
+        city: City
+        stateorprovince: Administrative Area
+        postalcode: Zip or Postal Code
+        country: Country
+        phone: +xx-xxx-xxx-xxxx
+        fax: +xx-xxx-xxx-xxxx
+        email: you@example.org
+        url: Contact URL
+        hours: Hours of Service
+        instructions: During hours of service.  Off on weekends.
+        role: pointOfContact
+
+resources:
+    obs:
+        type: collection
+        title:
+            en: Observations
+            fr: Observations
+        description:
+            en: My cool observations
+            fr: Mes belles observations
+        keywords:
+            - observations
+            - monitoring
+        links:
+            - type: text/csv
+              rel: canonical
+              title: data
+              href: https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv
+              hreflang: en-US
+            - type: text/csv
+              rel: alternate
+              title: data
+              href: https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv
+              hreflang: en-US
+        linked-data:
+            context:
+                - schema: https://schema.org/
+                  stn_id:
+                      "@id": schema:identifier
+                      "@type": schema:Text
+                  datetime:
+                      "@type": schema:DateTime
+                      "@id": schema:observationDate
+                  value:
+                      "@type": schema:Number
+                      "@id": schema:QuantitativeValue
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: 2000-10-30T18:24:39Z
+                end: 2007-10-30T08:57:29Z
+                trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+        providers:
+            - type: feature
+              name: CSV
+              data: tests/data/obs.csv
+              id_field: id
+              geometry:
+                  x_field: long
+                  y_field: lat
+
+    cmip5:
+        type: collection
+        title: CMIP5 sample
+        description: CMIP5 sample
+        keywords:
+            - cmip5
+            - climate
+        extents:
+            spatial:
+                bbox: [-150,40,-45,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+        links:
+            - type: text/html
+              rel: canonical
+              title: information
+              href: https://open.canada.ca/data/en/dataset/eddd6eaf-34d7-4452-a994-3d928115a68b
+              hreflang: en-CA
+        providers:
+            - type: coverage
+              name: xarray
+              data: tests/data/CMIP5_rcp8.5_annual_abs_latlon1x1_PCP_pctl25_P1Y.nc
+              x_field: lon
+              y_field: lat
+              time_field: time
+              format:
+                  name: NetCDF
+                  mimetype: application/x-netcdf
+
+    naturalearth/lakes:
+        type: collection
+        title:
+            en: Large Lakes
+            fr: Grands Lacs
+        description:
+            en: lakes of the world, public domain
+            fr: lacs du monde, domaine public
+        keywords:
+            - lakes
+        links:
+            - type: text/html
+              rel: canonical
+              title: information
+              href: http://www.naturalearthdata.com/
+              hreflang: en-US
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: 2011-11-11T11:11:11Z
+                end: null  # or empty (either means open ended)
+        providers:
+            - type: feature
+              name: GeoJSON
+              data: tests/data/ne_110m_lakes.geojson
+              id_field: id
+            - type: tile
+              name: MVT
+              # data: http://localhost:9000/ne_110m_lakes/{z}/{x}/{y}
+              data: tests/data/tiles/ne_110m_lakes
+              options:
+                metadata_format: raw # default | tilejson
+                bounds: [[-124.953634,-16.536406],[109.929807,66.969298]]
+                zoom:
+                    min: 0
+                    max: 11
+                schemes:
+                    - WorldCRS84Quad
+              format:
+                    name: pbf
+                    mimetype: application/vnd.mapbox-vector-tile
+
+    gdps-temperature:
+        type: collection
+        title: Global Deterministic Prediction System sample
+        description: Global Deterministic Prediction System sample
+        keywords:
+            - gdps
+            - global
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+        links:
+            - type: text/html
+              rel: canonical
+              title: information
+              href: https://eccc-msc.github.io/open-data/msc-data/nwp_gdps/readme_gdps_en
+              hreflang: en-CA
+        providers:
+            - type: coverage
+              name: rasterio
+              data: tests/data/CMC_glb_TMP_TGL_2_latlon.15x.15_2020081000_P000.grib2
+              options:
+                  DATA_ENCODING: COMPLEX_PACKING
+              format:
+                  name: GRIB
+                  mimetype: application/x-grib2
+
+    icoads-sst:
+        type: collection
+        title: International Comprehensive Ocean-Atmosphere Data Set (ICOADS)
+        description: International Comprehensive Ocean-Atmosphere Data Set (ICOADS)
+        keywords:
+            - icoads
+            - sst
+            - air temperature
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+        links:
+            - type: text/html
+              rel: canonical
+              title: information
+              href: https://psl.noaa.gov/data/gridded/data.coads.1deg.html
+              hreflang: en-US
+        providers:
+            - type: edr
+              name: xarray-edr
+              data: tests/data/coads_sst.nc
+              format:
+                  name: NetCDF
+                  mimetype: application/x-netcdf
+
+    objects:
+        type: collection
+        title: GeoJSON objects
+        description: GeoJSON geometry types for GeoSparql and Schema Geometry conversion.
+        keywords:
+            - shapes
+        links:
+            - type: text/html
+              rel: canonical
+              title: data source
+              href: https://en.wikipedia.org/wiki/GeoJSON
+              hreflang: en-US
+        linked-data:
+            item_template: tests/data/base.jsonld
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: null
+                end: null  # or empty (either means open ended)
+        providers:
+            - type: feature
+              name: GeoJSON
+              data: tests/data/items.geojson
+              id_field: fid
+              uri_field: uri
+
+    mapserver_world_map:
+        type: collection
+        title: MapServer demo WMS world map
+        description: MapServer demo WMS world map
+        keywords:
+            - MapServer
+            - world map
+        links:
+            - type: text/html
+              rel: canonical
+              title: information
+              href: https://demo.mapserver.org
+              hreflang: en-US
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+        providers:
+            - type: map
+              name: WMSFacade
+              data: https://demo.mapserver.org/cgi-bin/msautotest
+              options:
+                  layer: world_latlong
+                  style: default
+              format:
+                    name: png
+                    mimetype: image/png
+
+    hello-world:
+        type: process
+        processor:
+            name: HelloWorld
+
+    pygeometa-metadata-validate:
+        type: process
+        processor:
+            name: pygeometa.pygeoapi_plugin.PygeometaMetadataValidateProcessor

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,13 +39,13 @@ from http import HTTPStatus
 
 from pyld import jsonld
 import pytest
+
 from pygeoapi.api import (
     API, APIRequest, FORMAT_TYPES, validate_bbox, validate_datetime,
-    validate_subset, F_HTML, F_JSON, F_JSONLD, F_GZIP
+    validate_subset, F_HTML, F_JSON, F_JSONLD, F_GZIP, __version__
 )
-from pygeoapi.util import yaml_load
-
-from .util import get_test_file_path, mock_request
+from pygeoapi.util import yaml_load, get_api_rules, get_base_url
+from .util import get_test_file_path, mock_request, mock_flask, mock_starlette
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +53,13 @@ LOGGER = logging.getLogger(__name__)
 @pytest.fixture()
 def config():
     with open(get_test_file_path('pygeoapi-test-config.yml')) as fh:
+        return yaml_load(fh)
+
+
+@pytest.fixture()
+def config_with_rules() -> dict:
+    """ Returns a pygeoapi configuration with default API rules. """
+    with open(get_test_file_path('pygeoapi-test-config-apirules.yml')) as fh:
         return yaml_load(fh)
 
 
@@ -85,6 +92,14 @@ def api_(config):
 def enclosure_api(config_enclosure):
     """ Returns an API instance with a collection with enclosure links. """
     return API(config_enclosure)
+
+
+@pytest.fixture()
+def rules_api(config_with_rules):
+    """ Returns an API instance with URL prefix and strict slashes policy.
+    The API version is extracted from the current version here.
+    """
+    return API(config_with_rules)
 
 
 @pytest.fixture()
@@ -230,6 +245,100 @@ def test_apirequest(api_):
     assert apireq.raw_locale is None
     assert apireq.locale.language == 'de'
     assert apireq.get_response_headers()['Content-Language'] == 'de'
+
+
+def test_apirules_active(config_with_rules, rules_api):
+    assert rules_api.config == config_with_rules
+    rules = get_api_rules(config_with_rules)
+    base_url = get_base_url(config_with_rules)
+
+    # Test Flask
+    flask_prefix = rules.get_url_prefix('flask')
+    with mock_flask('pygeoapi-test-config-apirules.yml') as flask_client:
+        # Test happy path
+        response = flask_client.get(f'{flask_prefix}/conformance')
+        assert response.status_code == 200
+        assert response.headers['X-API-Version'] == __version__
+        assert response.request.url == \
+               flask_client.application.url_for('pygeoapi.conformance')
+        response = flask_client.get(f'{flask_prefix}/static/img/pygeoapi.png')
+        assert response.status_code == 200
+
+        # Test strict slashes
+        response = flask_client.get(f'{flask_prefix}/conformance/')
+        assert response.status_code == 404
+        response = flask_client.get(f'{flask_prefix}/')
+        assert response.status_code == 404
+
+        # Test links on landing page for correct URLs
+        response = flask_client.get(flask_prefix)
+        assert response.status_code == 200
+        assert response.is_json
+        links = response.json['links']
+        assert all(
+            href.startswith(base_url) for href in (rel['href'] for rel in links)  # noqa
+        )
+
+    # Test Starlette
+    starlette_prefix = rules.get_url_prefix('starlette')
+    with mock_starlette('pygeoapi-test-config-apirules.yml') as starlette_client:  # noqa
+        # Test happy path
+        response = starlette_client.get(f'{starlette_prefix}/conformance')
+        assert response.status_code == 200
+        assert response.headers['X-API-Version'] == __version__
+        response = starlette_client.get(f'{starlette_prefix}/static/img/pygeoapi.png')  # noqa
+        assert response.status_code == 200
+
+        # Test strict slashes
+        response = starlette_client.get(f'{starlette_prefix}/conformance/')
+        assert response.status_code == 404
+        response = starlette_client.get(f'{starlette_prefix}/')
+        assert response.status_code == 404
+
+        # Test links on landing page for correct URLs
+        response = starlette_client.get(starlette_prefix)
+        assert response.status_code == 200
+        links = response.json()['links']
+        assert all(
+            href.startswith(base_url) for href in (rel['href'] for rel in links)  # noqa
+        )
+
+
+def test_apirules_inactive(config, api_):
+    assert api_.config == config
+    rules = get_api_rules(config)
+
+    # Test Flask
+    flask_prefix = rules.get_url_prefix('flask')
+    assert flask_prefix == ''
+    with mock_flask('pygeoapi-test-config.yml') as flask_client:
+        # Test happy path
+        response = flask_client.get('/conformance')
+        assert response.status_code == 200
+        assert 'X-API-Version' not in response.headers
+        response = flask_client.get('/static/img/pygeoapi.png')
+        assert response.status_code == 200
+
+        # Test slash redirect
+        response = flask_client.get('/conformance/')
+        assert response.status_code != 404
+        assert 'X-API-Version' not in response.headers
+
+    # Test Starlette
+    starlette_prefix = rules.get_url_prefix('starlette')
+    assert starlette_prefix == ''
+    with mock_starlette('pygeoapi-test-config.yml') as starlette_client:
+        # Test happy path
+        response = starlette_client.get('/conformance')
+        assert response.status_code == 200
+        assert 'X-API-Version' not in response.headers
+        response = starlette_client.get('/static/img/pygeoapi.png')
+        assert response.status_code == 200
+
+        # Test slash redirect
+        response = starlette_client.get('/conformance/')
+        assert response.status_code != 404
+        assert 'X-API-Version' not in response.headers
 
 
 def test_api(config, api_, openapi):


### PR DESCRIPTION
# Overview
This PR adds an optional `api_rules` object to the `server` section of the pygeoapi configuration (YAML). For an example, please check the updated documentation [here](https://github.com/GeoSander/pygeoapi/blob/adr/docs/source/configuration.rst#server). Explanation about the available options can be found [here](https://github.com/GeoSander/pygeoapi/blob/adr/docs/source/configuration.rst#api-design-rules).

The suggested changes affect the API at the highest level (Flask, Starlette, Django). Because the current tests only test the lower level methods in `api.py` but not the routes leading towards them, I have added a [mock client](https://github.com/GeoSander/pygeoapi/blob/adr/tests/util.py#L79) for Flask  and Starlette so we can test API rule adherence or any routing-related things for that matter.

Note that I have also replaced the `@app.route()` decorators in favor of `Route()` in [starlette_app.py](https://github.com/geopython/pygeoapi/pull/1152/files#diff-22b78f4f30605039c367873f702cce35081fb85fe0590b04a9f432c0b43f0db0). This technique was deprecated anyway (it is not even documented anymore in the current Starlette docs) and it proved harder to build in the API rule logic like that.

# Related Issue / Discussion
This PR relates to issue #1134, which contains the rationale behind this change. 

# Additional Information
Since this work is part of a funded [tender](https://www.geonovum.nl/themas/invitation-to-tender) in which [Geonovum](https://www.geonovum.nl/about-us) emphasized that it was very important to them that the work would be incorporated into the core, and also because the suggested changes are optional and non-disruptive, we hope that the community is willing to approve this PR. 

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute feature "API design rule support" to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines.
