### PR TITLE
Accept additional arguments for get(...)

### DIFF
--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -131,7 +131,7 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def get(self, identifier):
+    def get(self, identifier, **kwargs):
         """
         query the provider by id
 


### PR DESCRIPTION
# Overview
pygeoapi sends additional parameters to the providers, such as `language`. `BaseProvider` should accept them. 

# Related Issue / Discussion
Fix #1061

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute bugfix #1061 to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
