### PR TITLE
Use SQLalchemy URL parser

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -260,6 +260,24 @@ Must have PostGIS installed.
          table: hotosm_bdi_waterways
          geom_field: foo_geom
 
+The PostgreSQL provider is also able to connect to Cloud SQL databases.
+
+.. code-block:: yaml
+
+   providers:
+       - type: feature
+         name: PostgreSQL
+         data:
+             host: /cloudsql/INSTANCE_CONNECTION_NAME # e.g. 'project:region:instance'
+             dbname: reference
+             user: postgres
+             password: postgres
+         id_field: id
+         table: states
+
+This is what a configuration for `Google Cloud SQL`_ connection looks like. The ``host``
+block contains the necessary socket connection information.
+
 This provider has support for the CQL queries as indicated in the Provider table above.
 
 .. seealso::
@@ -408,4 +426,5 @@ Data access examples
    provider `id_field` values support slashes (i.e. ``my/cool/identifier``). The client request would then
    be responsible for encoding the identifier accordingly (i.e. ``http://localhost:5000/collections/foo/items/my%2Fcool%2Fidentifier``)
 
+.. _`Google Cloud SQL`: https://cloud.google.com/sql
 .. _`OGC API - Features`: https://www.ogc.org/standards/ogcapi-features

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -54,6 +54,7 @@ from geoalchemy2.shape import to_shape
 from pygeofilter.backends.sqlalchemy.evaluate import to_filter
 import shapely
 from sqlalchemy import create_engine, MetaData, PrimaryKeyConstraint, asc, desc
+from sqlalchemy.engine import URL
 from sqlalchemy.exc import InvalidRequestError, OperationalError
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session, load_only
@@ -245,11 +246,13 @@ class PostgreSQLProvider(BaseProvider):
         try:
             engine = _ENGINE_STORE[engine_store_key]
         except KeyError:
-            conn_str = (
-                'postgresql+psycopg2://'
-                f'{self.db_user}:{self._db_password}@'
-                f'{self.db_host}:{self.db_port}/'
-                f'{self.db_name}'
+            conn_str = URL.create(
+                'postgresql+psycopg2',
+                username=self.db_user,
+                password=self._db_password,
+                host=self.db_host,
+                port=self.db_port,
+                database=self.db_name
             )
             engine = create_engine(
                 conn_str,

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -308,7 +308,7 @@ def test_instantiation(config):
     ({'table': 'bad_table'}, ProviderQueryError,
      'Table.*not found in schema.*'),
     ({'data': {'bad': 'data'}}, ProviderConnectionError,
-     r'Could not connect to .*None:\*\*\*@'),
+     r'Could not connect to postgresql\+psycopg2:\/\/:5432 \(password hidden\).'), # noqa
     ({'id_field': 'bad_id'}, ProviderQueryError,
      r'No such id_field column \(bad_id\) on osm.hotosm_bdi_waterways.'),
 ])


### PR DESCRIPTION

# Overview
- Use SQL Alchemy URL creation instead of passing a string to create_engine function
- Add Cloud SQL example to docs

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/1157

# Additional Information
Produces (and allows) the socket connection `postgresql+psycopg2://***:***@/cloudsql/geoconnex-us:us-central1:reference-features.s.PGSQL.5432/reference` instead of `postgresql+psycopg2://***:***@/cloudsql/geoconnex-us:us-central1:reference-features:5432/reference`.

This is currently implemented [here](https://github.com/internetofwater/geoconnex.us/blob/be98d9f0239421468b0f19cf5d2b06e7f5e99e6b/pygeoapi/pygeoapi.config.yml#L109-L120), serving https://reference.geoconnex.dev/

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
