### PR TITLE
Upgrading elastisearch.py lib in docker image

### DIFF
--- a/docker/examples/elastic/ES/Dockerfile
+++ b/docker/examples/elastic/ES/Dockerfile
@@ -53,7 +53,7 @@ RUN echo "http.host: 0.0.0.0" >> config/elasticsearch.yml
 RUN echo "discovery.type: single-node" >> config/elasticsearch.yml
 
 RUN     apt install -y python3 python3-pip python3-setuptools python-typing \
-        && pip3 install --upgrade pip elasticsearch==7.17.1 elasticsearch-dsl \
+        && pip3 install --upgrade pip elasticsearch==8.4.0 elasticsearch-dsl \
 	&& apt clean packages
 
 USER elasticsearch

--- a/docker/examples/elastic/docker-compose.yml
+++ b/docker/examples/elastic/docker-compose.yml
@@ -63,7 +63,6 @@ services:
       - 9300:9300
       - 9200:9200
     environment:
-      ELASTIC_CLIENT_APIVERSIONING: 1
       # Enabling compatibility mode in ES
       # https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/migration.html#migration-compat-mode
     volumes:


### PR DESCRIPTION
# Overview
Upgrading elasticsearch.py library installed in Docker image of the Elasticsearch example to 8.4.0.

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/1161

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
