### PR TITLE
Fixed problem with coordinate order, on leaflet preview of tiles

### DIFF
--- a/pygeoapi/templates/collections/tiles/index.html
+++ b/pygeoapi/templates/collections/tiles/index.html
@@ -131,7 +131,7 @@
       .addTo(map);
 
     map.on('click', clearHighlight);
-    bounds = L.latLngBounds([[{{ data['bounds'][0] }},{{data['bounds'][1]}}],[{{ data['bounds'][2] }},{{data['bounds'][3]}}]])
+    bounds = L.latLngBounds([[{{ data['bounds'][1] }},{{data['bounds'][0]}}],[{{ data['bounds'][3] }},{{data['bounds'][2]}}]])
     map.fitBounds(bounds, maxZoom={{ data['maxzoom']}});
 
     </script>


### PR DESCRIPTION
# Overview

Leaflet [latlngbounds](https://leafletjs.com/reference.html#latlngbounds) uses a different order (lat,lng) from [pygeoapi's extent](https://github.com/geopython/pygeoapi/blob/master/pygeoapi-config.yml#L167). This causes the tiles preview to fit to an incorrect bounding box.

The problem does not affect the other HTML previews (e.g.: collection, features): only tiles.

# Related Issue / Discussion

@vidhav had pointed this issue here:
https://github.com/geopython/pygeoapi/issues/1043

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
