### PR TITLE
default item transactions to GeoJSON payloads

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -538,7 +538,7 @@ def get_oas_30(cfg):
                     'requestBody': {
                         'description': 'Adds item to collection',
                         'content': {
-                            'application/json': {
+                            'application/geo+json': {
                                 'schema': {}
                             }
                         },
@@ -672,7 +672,7 @@ def get_oas_30(cfg):
                     'requestBody': {
                         'description': 'Updates item in collection',
                         'content': {
-                            'application/json': {
+                            'application/geo+json': {
                                 'schema': {}
                             }
                         },


### PR DESCRIPTION
# Overview
Default to GeoJSON payloads for items transactions in OpenAPI.
# Related Issue / Discussion
This is also required on SwaggerUI given default content type of `application/json` will kick into CQL mode instead.
# Additional Information
Will be updated once https://github.com/opengeospatial/ogcapi-features/issues/771 is properly addressed.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
