### PR TITLE
Allow STA entity to be included in data url

### DIFF
--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -93,7 +93,11 @@ class SensorThingsProvider(BaseProvider):
             self.entity = provider_def['entity']
             self._url = url_join(self.data, self.entity)
         except KeyError:
-            raise RuntimeError('name/type/data are required')
+            if self.data.split('/').pop() in ENTITY:
+                self.entity = self.data.split('/').pop()
+                self._url = self.data
+            else:
+                raise RuntimeError('Entity type required')
 
         # Default id
         if self.id_field is None or not self.id_field:

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -37,9 +37,8 @@ def config():
     return {
         'name': 'SensorThings',
         'type': 'feature',
-        'data': 'http://localhost:8888/FROST-Server/v1.1/',
+        'data': 'http://localhost:8888/FROST-Server/v1.1/Datastreams',
         'rel_link': 'http://localhost:5000',
-        'entity': 'Datastreams',
         'intralink': True,
         'time_field': 'phenomenonTime'
     }
@@ -88,6 +87,7 @@ def test_query_datastreams(config):
 def test_query_observations(config):
     config['properties'] = ['Datastream', 'phenomenonTime',
                             'FeatureOfInterest', 'result']
+    config['data'] = 'http://localhost:8888/FROST-Server/v1.1/'
     config['entity'] = 'Observations'
     p = SensorThingsProvider(config)
 


### PR DESCRIPTION
# Overview
This PR allows the STA entity for a collection to be URL encoded instead of a required field for the provider. Using some wis2box tooling to update pygeoapi config and this allows for the configuration block to be generated without adding another optional field to [this function](https://github.com/wmo-im/wis2box/blob/9d7e35706725ef60c3ec0951d8089f3567b06c62/wis2box-management/wis2box/api/config/pygeoapi.py#L132-L139). 

Best practice is probably to keep these separate so I am leaving this out of the documentation. 

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
