### PR TITLE
OGC API Features Part 4 fixes: create without id + options

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1999,6 +1999,7 @@ class API:
         Adds an item to a collection
 
         :param request: A request object
+        :param action: an action among 'create', 'update', 'delete', 'options'
         :param dataset: dataset name
 
         :returns: tuple of headers, status code, content
@@ -2036,6 +2037,15 @@ class API:
                 return self.get_exception(
                     HTTPStatus.BAD_REQUEST, headers, request.format,
                     'InvalidParameterValue', msg)
+
+        if action == 'options':
+            headers['Allow'] = 'HEAD, GET'
+            if p.editable:
+                if identifier is None:
+                    headers['Allow'] += ', POST'
+                else:
+                    headers['Allow'] += ', PUT, DELETE'
+            return headers, HTTPStatus.OK, ''
 
         if not p.editable:
             msg = 'Collection is not editable'

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -179,9 +179,11 @@ def collection_queryables(collection_id=None):
 
 
 @BLUEPRINT.route('/collections/<path:collection_id>/items',
-                 methods=['GET', 'POST'])
+                 methods=['GET', 'POST', 'OPTIONS'],
+                 provide_automatic_options=False)
 @BLUEPRINT.route('/collections/<path:collection_id>/items/<path:item_id>',
-                 methods=['GET', 'PUT', 'DELETE'])
+                 methods=['GET', 'PUT', 'DELETE', 'OPTIONS'],
+                 provide_automatic_options=False)
 def collection_items(collection_id, item_id=None):
     """
     OGC API collections items endpoint
@@ -205,6 +207,9 @@ def collection_items(collection_id, item_id=None):
                 else:
                     return get_response(
                         api_.post_collection_items(request, collection_id))
+        elif request.method == 'OPTIONS':
+            return get_response(
+                api_.manage_collection_item(request, 'options', collection_id))
 
     elif request.method == 'DELETE':
         return get_response(
@@ -213,6 +218,10 @@ def collection_items(collection_id, item_id=None):
     elif request.method == 'PUT':
         return get_response(
             api_.manage_collection_item(request, 'update',
+                                        collection_id, item_id))
+    elif request.method == 'OPTIONS':
+        return get_response(
+            api_.manage_collection_item(request, 'options',
                                         collection_id, item_id))
     else:
         return get_response(

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -195,6 +195,7 @@ class BaseProvider:
         raise NotImplementedError()
 
     def _load_and_prepare_item(self, item, identifier=None,
+                               accept_missing_identifier=False,
                                raise_if_exists=True):
         """
         Helper function to load a record, detect its idenfier and prepare
@@ -202,6 +203,9 @@ class BaseProvider:
 
         :param item: `str` of incoming item data
         :param identifier: `str` of item identifier (optional)
+        :param accept_missing_identifier: `bool` of whether a missing
+                                          identifier in item is valid
+                                          (typically for a create() method)
         :param raise_if_exists: `bool` of whether to check if record
                                  already exists
 
@@ -238,7 +242,7 @@ class BaseProvider:
                 except KeyError:
                     LOGGER.debug('Cannot find properties.identifier')
 
-        if identifier2 is None:
+        if identifier2 is None and not accept_missing_identifier:
             msg = 'Missing identifier (id or properties.identifier)'
             LOGGER.error(msg)
             raise ProviderInvalidDataError(msg)
@@ -248,7 +252,7 @@ class BaseProvider:
             LOGGER.error(msg)
             raise ProviderInvalidDataError(msg)
 
-        if raise_if_exists:
+        if identifier2 is not None and raise_if_exists:
             LOGGER.debug('Querying database whether item exists')
             try:
                 _ = self.get(identifier2)

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -32,6 +32,7 @@ from typing import Dict
 from collections import OrderedDict
 import json
 import logging
+import uuid
 
 from elasticsearch import Elasticsearch, exceptions, helpers
 from elasticsearch_dsl import Search, Q
@@ -399,7 +400,12 @@ class ElasticsearchProvider(BaseProvider):
         :returns: identifier of created item
         """
 
-        identifier, json_data = self._load_and_prepare_item(item)
+        identifier, json_data = self._load_and_prepare_item(
+            item, accept_missing_identifier=True)
+        if identifier is None:
+            # If there is no incoming identifier, allocate a random one
+            identifier = str(uuid.uuid4())
+            json_data["id"] = identifier
 
         LOGGER.debug(f'Inserting data with identifier {identifier}')
         _ = self.es.index(index=self.index_name, id=identifier, body=json_data)

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -30,6 +30,7 @@
 import logging
 import re  # noqa
 import os
+import uuid
 
 from tinydb import TinyDB, Query, where
 
@@ -245,7 +246,12 @@ class TinyDBCatalogueProvider(BaseProvider):
         :returns: identifier of newly created item
         """
 
-        identifier, json_data = self._load_and_prepare_item(item)
+        identifier, json_data = self._load_and_prepare_item(
+            item, accept_missing_identifier=True)
+        if identifier is None:
+            # If there is no incoming identifier, allocate a random one
+            identifier = str(uuid.uuid4())
+            json_data["id"] = identifier
 
         try:
             json_data['properties']['_metadata-anytext'] = ''.join([

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -242,12 +242,14 @@ async def get_collection_items_tiles(request: Request, collection_id=None,
         tile_matrix, tileRow, tileCol))
 
 
-@app.route('/collections/{collection_id:path}/items', methods=['GET', 'POST'])
-@app.route('/collections/{collection_id:path}/items/', methods=['GET', 'POST'])
+@app.route('/collections/{collection_id:path}/items',
+           methods=['GET', 'POST', 'OPTIONS'])
+@app.route('/collections/{collection_id:path}/items/',
+           methods=['GET', 'POST', 'OPTIONS'])
 @app.route('/collections/{collection_id:path}/items/{item_id:path}',
-           methods=['GET', 'PUT', 'DELETE'])
+           methods=['GET', 'PUT', 'DELETE', 'OPTIONS'])
 @app.route('/collections/{collection_id:path}/items/{item_id:path}/',
-           methods=['GET', 'PUT', 'DELETE'])
+           methods=['GET', 'PUT', 'DELETE', 'OPTIONS'])
 async def collection_items(request: Request, collection_id=None, item_id=None):
     """
     OGC API collections items endpoint
@@ -278,6 +280,9 @@ async def collection_items(request: Request, collection_id=None, item_id=None):
                 else:
                     return get_response(
                         api_.post_collection_items(request, collection_id))
+        elif request.method == 'OPTIONS':
+            return get_response(
+                api_.manage_collection_item(request, 'options', collection_id))
 
     elif request.method == 'DELETE':
         return get_response(
@@ -286,6 +291,10 @@ async def collection_items(request: Request, collection_id=None, item_id=None):
     elif request.method == 'PUT':
         return get_response(
             api_.manage_collection_item(request, 'update',
+                                        collection_id, item_id))
+    elif request.method == 'OPTIONS':
+        return get_response(
+            api_.manage_collection_item(request, 'options',
                                         collection_id, item_id))
     else:
         return get_response(api_.get_collection_item(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,6 +30,7 @@
 #
 # =================================================================
 
+import copy
 import json
 import logging
 import time
@@ -871,6 +872,42 @@ def test_get_collection_items(config, api_):
     rsp_headers, code, response = api_.get_collection_items(req, 'obs')
 
     assert code == HTTPStatus.BAD_REQUEST
+
+
+def test_manage_collection_item_read_only_options_req(config, api_):
+    """Test OPTIONS request on a read-only items endpoint"""
+    req = mock_request()
+    _, code, _ = api_.manage_collection_item(req, 'options', 'foo')
+    assert code == HTTPStatus.NOT_FOUND
+
+    req = mock_request()
+    rsp_headers, code, _ = api_.manage_collection_item(req, 'options', 'obs')
+    assert code == HTTPStatus.OK
+    assert rsp_headers['Allow'] == 'HEAD, GET'
+
+    req = mock_request()
+    rsp_headers, code, _ = api_.manage_collection_item(
+        req, 'options', 'obs', 'ressource_id')
+    assert code == HTTPStatus.OK
+    assert rsp_headers['Allow'] == 'HEAD, GET'
+
+
+def test_manage_collection_item_editable_options_req(config):
+    """Test OPTIONS request on a editable items endpoint"""
+    config = copy.deepcopy(config)
+    config['resources']['obs']['providers'][0]['editable'] = True
+    api_ = API(config)
+
+    req = mock_request()
+    rsp_headers, code, _ = api_.manage_collection_item(req, 'options', 'obs')
+    assert code == HTTPStatus.OK
+    assert rsp_headers['Allow'] == 'HEAD, GET, POST'
+
+    req = mock_request()
+    rsp_headers, code, _ = api_.manage_collection_item(
+        req, 'options', 'obs', 'ressource_id')
+    assert code == HTTPStatus.OK
+    assert rsp_headers['Allow'] == 'HEAD, GET, PUT, DELETE'
 
 
 def test_describe_collections_enclosures(config_enclosure, enclosure_api):


### PR DESCRIPTION
# Overview

Two bug fixes for OGC API Features Part 4:
- Create/POST: accept incoming feature without id
- OPTIONS: return Allow header with values consistent of editable/read-only status of the collection

# Related Issue / Discussion

For the "Create/POST: accept incoming feature without id" fix:
    The spec mentions:
    
    Requirement 4: /req/create-replace-delete/insert-response-rid
    If the operation completes successfully, the server SHALL assign
    a new, unique identifier within the collection for the newly added resource.
    
    and
    
    Permission 4: /per/create-replace-delete/rid
    If the representation of the resource submitted in the request body
    contained a resource identifier, the server MAY use this identifier
    as the new resource identifier in the collection or the server MAY
    ignore the value and assign its own identifier for the resource.
    
    Currently pygeopapi implements the first part of permission 4 (accepting
    and using the identifier from the incomping feature), but errors out
    when it is missing, which is against requirement 4.

# Additional Information

Those fixes are done in preparation of developing corresponding client functionality in QGIS.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
