### PR TITLE
TinyDB provider: set ["properties"]["extent"]["spatial"]["bbox"] from geometry if not provided

### DIFF
--- a/tests/test_tinydb_catalogue_provider.py
+++ b/tests/test_tinydb_catalogue_provider.py
@@ -190,7 +190,12 @@ def test_transactions_create_no_id(config, data_no_id):
 
     data_got = p.get(new_id)
     assert data_got["id"] == new_id
-    assert data_got["properties"] == json.loads(data_no_id)["properties"]
+    expected_properties = json.loads(data_no_id)["properties"]
+    expected_properties["extent"] = {}
+    expected_properties["extent"]["spatial"] = {}
+    expected_properties["extent"]["spatial"]["bbox"] = \
+        [[100.0, 0.0, 101.0, 1.0]]
+    assert data_got["properties"] == expected_properties
     assert data_got["geometry"] == json.loads(data_no_id)["geometry"]
 
     assert p.update(new_id, json.dumps(data_got))


### PR DESCRIPTION
# Overview

Insertion of a feature in TinyDB that doesn't contain a ["properties"]["extent"]["spatial"]["bbox"]  result in it not being found by get(bbox=). So create automatically that element if not existing

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
