### PR TITLE
Normalize breadcrumbs

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -102,7 +102,37 @@ def test_get_breadcrumbs():
     breadcrumbs = util.get_breadcrumbs(path)
 
     assert len(breadcrumbs) == 5
-    assert breadcrumbs[3]['href'] == 'dataset/model-run/forecast-hour'
+    assert breadcrumbs[0] == {'href': '.', 'title': 'Home'}
+    assert breadcrumbs[3]['href'] == './dataset/model-run/forecast-hour'
+    assert breadcrumbs[3]['title'] == 'Forecast Hour'
+    assert breadcrumbs[4]['href'] == './dataset/model-run/forecast-hour/variable.grib2'  # noqa
+    assert breadcrumbs[4]['title'] == 'Variable'
+
+    breadcrumbs = util.get_breadcrumbs(path, root_label='Root')
+    assert breadcrumbs[0]['title'] == 'Root'
+
+    root = 'http://localhost:8000'
+    breadcrumbs = util.get_breadcrumbs(path, root)
+    assert breadcrumbs[0]['href'] == root
+    assert breadcrumbs[1]['href'] == f'{root}/dataset'
+
+    root = 'http://localhost:8000/path'
+    breadcrumbs = util.get_breadcrumbs(path, root)
+    assert breadcrumbs[0]['href'] == root
+    assert breadcrumbs[1]['href'] == f'{root}/dataset'
+
+    breadcrumbs = util.get_breadcrumbs(f'{path}?lang=en&f=json', f'{root}?lang=en#main')  # noqa
+    assert breadcrumbs[0]['href'] == root
+    assert breadcrumbs[1]['href'] == f'{root}/dataset'
+
+    path = 'dataset/model-run/forecast-hour/variable.grib2'
+    breadcrumbs = util.get_breadcrumbs(path, endpoint_label='Test Variable')
+    assert breadcrumbs[-1]['title'] == 'Test Variable'
+
+    path = 'dataset/model-run/forecast-hour/'
+    breadcrumbs = util.get_breadcrumbs(path)
+    assert breadcrumbs[-1]['href'] == './dataset/model-run/forecast-hour'
+    assert breadcrumbs[-1]['title'] == 'forecast-hour'
 
 
 def test_path_basename():


### PR DESCRIPTION
# Overview
Currently, the breadcrumbs (navigational links at the top of the HTML pages) are partially automated (e.g. for STAC) and partially hand-written (i.e. defined in the Jinja HTML templates).
Once #1152 will be merged **and only if API rules will be configured with the `strict_slashes` option set to `true`**, this may lead to incorrect `href` values for the links.
In general, most breadcrumb links are relative (starting with '/' or './') now, which is inconsistent as most links in pygeoapi are absolute. 

This PR will improve this situation by making the `get_breadcrumbs()` function in `utils.py` more advanced, so that it will return consistent breadcrumbs with absolute URLs.

# Related Issue / Discussion
This relates to PR #1152. If API rules state that trailing slashes are **not** allowed, some breadcrumbs in which a trailing slash has now been hard-coded into the HTML template will result in a 404 when clicked.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this enhancement to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
