### PR TITLE
[WIP] Normalize and enhance breadcrumbs

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3648,7 +3648,7 @@ class API:
                     'result': job_output
                 }
                 content = render_j2_template(
-                    self.config, 'jobs/results/index.html',
+                    self.tpl_config, 'jobs/results/index.html',
                     data, request.locale)
 
         return headers, HTTPStatus.OK, content
@@ -4027,7 +4027,7 @@ class API:
         if format_ == F_HTML:
             headers['Content-Type'] = FORMAT_TYPES[F_HTML]
             content = render_j2_template(
-                self.config, 'exception.html', exception, SYSTEM_LOCALE)
+                self.tpl_config, 'exception.html', exception, SYSTEM_LOCALE)
         else:
             content = to_json(exception, self.pretty_print)
 

--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -251,7 +251,7 @@ def geojson2jsonld(cls, data: dict, dataset: str,
     else:
         # Render jsonld template for single item with template configured
         LOGGER.debug(f'Rendering JSON-LD template: {template}')
-        content = render_j2_template(cls.config, template, ldjsonData)
+        content = render_j2_template(cls.tpl_config, template, ldjsonData)
         ldjsonData = json.loads(content)
         return ldjsonData
 


### PR DESCRIPTION
# Overview
Currently, the breadcrumbs (navigational links at the top of the HTML pages) are partially generated (e.g. for STAC) and partially hand-written (i.e. defined in the Jinja HTML templates).
Once #1152 will be merged and **_only_** if API rules have been configured with the `strict_slashes` option set to `true`, this may lead to incorrect `href` values for the links.
In general, most breadcrumb links are relative (starting with `/` or `./`) now, which is inconsistent as most links in pygeoapi are absolute. 

This PR will improve this situation by making the `get_breadcrumbs()` function in `utils.py` more advanced, so that it will return consistent breadcrumbs with absolute URLs.

# Related Issue / Discussion
- #1134 
If API rules state that trailing slashes are **not** allowed, some breadcrumbs in which a trailing slash has now been hard-coded into the HTML template will result in a 404 when clicked.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this enhancement to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
