### PR TITLE
Generate openapi job endpoint definitions without checking for manager

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -1150,70 +1150,69 @@ def get_oas_30(cfg):
                 }
             }
 
-        if has_manager:
-            paths['/jobs'] = {
-                'get': {
-                    'summary': 'Retrieve jobs list',
-                    'description': 'Retrieve a list of jobs',
-                    'tags': ['server'],
-                    'operationId': 'getJobs',
-                    'responses': {
-                        '200': {'$ref': '#/components/responses/200'},
-                        '404': {'$ref': f"{OPENAPI_YAML['oapip']}/responses/NotFound.yaml"},  # noqa
-                        'default': {'$ref': '#/components/responses/default'}
-                    }
+        paths['/jobs'] = {
+            'get': {
+                'summary': 'Retrieve jobs list',
+                'description': 'Retrieve a list of jobs',
+                'tags': ['server'],
+                'operationId': 'getJobs',
+                'responses': {
+                    '200': {'$ref': '#/components/responses/200'},
+                    '404': {'$ref': f"{OPENAPI_YAML['oapip']}/responses/NotFound.yaml"},  # noqa
+                    'default': {'$ref': '#/components/responses/default'}
                 }
             }
+        }
 
-            paths['/jobs/{jobId}'] = {
-                'get': {
-                    'summary': 'Retrieve job details',
-                    'description': 'Retrieve job details',
-                    'tags': ['server'],
-                    'parameters': [
-                        name_in_path,
-                        {'$ref': '#/components/parameters/f'}
-                    ],
-                    'operationId': 'getJob',
-                    'responses': {
-                        '200': {'$ref': '#/components/responses/200'},
-                        '404': {'$ref': f"{OPENAPI_YAML['oapip']}/responses/NotFound.yaml"},  # noqa
-                        'default': {'$ref': '#/components/responses/default'}  # noqa
-                    }
-                },
-                'delete': {
-                    'summary': 'Cancel / delete job',
-                    'description': 'Cancel / delete job',
-                    'tags': ['server'],
-                    'parameters': [
-                        name_in_path
-                    ],
-                    'operationId': 'deleteJob',
-                    'responses': {
-                        '204': {'$ref': '#/components/responses/204'},
-                        '404': {'$ref': f"{OPENAPI_YAML['oapip']}/responses/NotFound.yaml"},  # noqa
-                        'default': {'$ref': '#/components/responses/default'}  # noqa
-                    }
-                },
-            }
+        paths['/jobs/{jobId}'] = {
+            'get': {
+                'summary': 'Retrieve job details',
+                'description': 'Retrieve job details',
+                'tags': ['server'],
+                'parameters': [
+                    name_in_path,
+                    {'$ref': '#/components/parameters/f'}
+                ],
+                'operationId': 'getJob',
+                'responses': {
+                    '200': {'$ref': '#/components/responses/200'},
+                    '404': {'$ref': f"{OPENAPI_YAML['oapip']}/responses/NotFound.yaml"},  # noqa
+                    'default': {'$ref': '#/components/responses/default'}  # noqa
+                }
+            },
+            'delete': {
+                'summary': 'Cancel / delete job',
+                'description': 'Cancel / delete job',
+                'tags': ['server'],
+                'parameters': [
+                    name_in_path
+                ],
+                'operationId': 'deleteJob',
+                'responses': {
+                    '204': {'$ref': '#/components/responses/204'},
+                    '404': {'$ref': f"{OPENAPI_YAML['oapip']}/responses/NotFound.yaml"},  # noqa
+                    'default': {'$ref': '#/components/responses/default'}  # noqa
+                }
+            },
+        }
 
-            paths['/jobs/{jobId}/results'] = {
-                'get': {
-                    'summary': 'Retrieve job results',
-                    'description': 'Retrive job resiults',
-                    'tags': ['server'],
-                    'parameters': [
-                        name_in_path,
-                        {'$ref': '#/components/parameters/f'}
-                    ],
-                    'operationId': 'getJobResults',
-                    'responses': {
-                        '200': {'$ref': '#/components/responses/200'},
-                        '404': {'$ref': f"{OPENAPI_YAML['oapip']}/responses/NotFound.yaml"},  # noqa
-                        'default': {'$ref': '#/components/responses/default'}  # noqa
-                    }
+        paths['/jobs/{jobId}/results'] = {
+            'get': {
+                'summary': 'Retrieve job results',
+                'description': 'Retrive job resiults',
+                'tags': ['server'],
+                'parameters': [
+                    name_in_path,
+                    {'$ref': '#/components/parameters/f'}
+                ],
+                'operationId': 'getJobResults',
+                'responses': {
+                    '200': {'$ref': '#/components/responses/200'},
+                    '404': {'$ref': f"{OPENAPI_YAML['oapip']}/responses/NotFound.yaml"},  # noqa
+                    'default': {'$ref': '#/components/responses/default'}  # noqa
                 }
             }
+        }
 
     oas['paths'] = paths
 


### PR DESCRIPTION
# Overview

This PR removes the test for the existence of a job manager when generating openapi definition. As discussed in #1200, checking for the existence of processes ought to be enough to decide whether to generate job related endpoints

# Related Issue / Discussion

- #1200 

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
