### PR TITLE
add HTTP OPTIONS handling to Django

### DIFF
--- a/pygeoapi/django_/views.py
+++ b/pygeoapi/django_/views.py
@@ -147,6 +147,9 @@ def collection_items(request: HttpRequest, collection_id: str) -> HttpResponse:
             else:
                 response_ = _feed_response(request, 'post_collection_items',
                                            request, collection_id)
+    elif request.method == 'OPTIONS':
+        response_ = _feed_response(request, 'manage_collection_item',
+                                   request, 'options', collection_id)
 
     response = _to_django_response(*response_)
 
@@ -214,6 +217,10 @@ def collection_item(request: HttpRequest,
             request, 'manage_collection_item', request, 'delete',
             collection_id, item_id
         )
+    elif request.method == 'OPTIONS':
+        response_ = _feed_response(
+            request, 'manage_collection_item', request, 'options',
+            collection_id, item_id)
 
     response = _to_django_response(*response_)
 


### PR DESCRIPTION
# Overview
Add HTTP OPTIONS handling for `.../items` and `.../items/{featureId}` for Django.

# Related Issue / Discussion
#1187
# Additional Information
cc @rouault 
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
