### PR TITLE
1204 oapi process execution use prefer header

### DIFF
--- a/docs/source/data-publishing/ogcapi-processes.rst
+++ b/docs/source/data-publishing/ogcapi-processes.rst
@@ -37,6 +37,9 @@ manages job execution.  The manager concept is implemented as part of the pygeoa
 based on `TinyDB`_ for simplicity.  Custom manager plugins can be developed for more
 advanced job management capabilities (e.g. Kubernetes, databases, etc.).
 
+In keeping with the OGC API - Processes specification, asynchronous process execution
+can be requested by including the ``Prefer: respond-async`` HTTP header in the request
+
 
 .. code-block:: yaml
 
@@ -73,20 +76,37 @@ To summarize how pygeoapi processes and managers work together::
 Processing examples
 -------------------
 
-* list all processes
-  * http://localhost:5000/processes
-* describe the ``hello-world`` process
-  * http://localhost:5000/processes/hello-world
-* show all jobs
-  * http://localhost:5000/jobs
-* execute a job for the ``hello-world`` process
-  * ``curl -X POST "http://localhost:5000/processes/hello-world/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"name\": \"hi there2\"}}"``
-* execute a job for the ``hello-world`` process with a raw response (default)
-  * ``curl -X POST "http://localhost:5000/processes/hello-world/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"name\": \"hi there2\"}}"``
-* execute a job for the ``hello-world`` process with a response document
-  * ``curl -X POST "http://localhost:5000/processes/hello-world/execution" -H "Content-Type: application/json" -d "{\"inputs\":{\"name\": \"hi there2\"},\"response\":\"document\"}"``
-* execute a job for the ``hello-world`` process in asynchronous mode
-  * ``curl -X POST "http://localhost:5000/processes/hello-world/execution" -H "Content-Type: application/json" -d "{\"mode\": \"async\", \"inputs\":{\"name\": \"hi there2\"}}"``
+.. code-block:: sh
+
+   # list all processes
+   curl http://localhost:5000/processes
+
+   # describe the ``hello-world`` process
+   curl http://localhost:5000/processes/hello-world
+
+   # show all jobs
+   curl http://localhost:5000/jobs
+
+   # execute a job for the ``hello-world`` process
+   curl -X POST http://localhost:5000/processes/hello-world/execution \
+       -H "Content-Type: application/json" \
+       -d "{\"inputs\":{\"name\": \"hi there2\"}}"
+
+   # execute a job for the ``hello-world`` process with a raw response (default)
+   curl -X POST http://localhost:5000/processes/hello-world/execution \
+       -H "Content-Type: application/json" \
+       -d "{\"inputs\":{\"name\": \"hi there2\"}}"
+
+   # execute a job for the ``hello-world`` process with a response document
+   curl -X POST http://localhost:5000/processes/hello-world/execution \
+       -H "Content-Type: application/json" \
+       -d "{\"inputs\":{\"name\": \"hi there2\"},\"response\":\"document\"}"
+
+   # execute a job for the ``hello-world`` process in asynchronous mode
+   curl -X POST http://localhost:5000/processes/hello-world/execution \
+       -H "Content-Type: application/json" \
+       -H "Prefer: respond-async"
+       -d "{\"inputs\":{\"name\": \"hi there2\"}}"
 
 .. todo:: add more examples once OAProc implementation is complete
 

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3549,7 +3549,7 @@ class API:
             execution_result = self.manager.execute_process(
                 process, data_dict, execution_mode=execution_mode)
             job_id, mime_type, outputs, status, additional_headers = execution_result
-            headers.update(additional_headers)
+            headers.update(additional_headers or {})
             headers['Location'] = f"{self.base_url}/jobs/{job_id}"
         except ProcessorExecuteError as err:
             LOGGER.error(err)

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3546,9 +3546,9 @@ class API:
             execution_mode = None
         try:
             LOGGER.debug('Executing process')
-            execution_result = self.manager.execute_process(
+            result = self.manager.execute_process(
                 process, data_dict, execution_mode=execution_mode)
-            job_id, mime_type, outputs, status, additional_headers = execution_result
+            job_id, mime_type, outputs, status, additional_headers = result
             headers.update(additional_headers or {})
             headers['Location'] = f"{self.base_url}/jobs/{job_id}"
         except ProcessorExecuteError as err:

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3507,12 +3507,6 @@ class API:
                 HTTPStatus.NOT_FOUND, headers,
                 request.format, 'NoSuchProcess', msg)
 
-        if not self.manager:
-            msg = 'Process manager is undefined'
-            return self.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR, headers,
-                request.format, 'NoApplicableCode', msg)
-
         process = load_plugin('process',
                               processes_config[process_id]['processor'])
 

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3541,7 +3541,7 @@ class API:
 
         try:
             execution_mode = RequestedProcessExecutionMode(
-                request.headers.get("Prefer"))
+                request.headers.get('Prefer'))
         except ValueError:
             execution_mode = None
         try:
@@ -3550,7 +3550,7 @@ class API:
                 process, data_dict, execution_mode=execution_mode)
             job_id, mime_type, outputs, status, additional_headers = result
             headers.update(additional_headers or {})
-            headers['Location'] = f"{self.base_url}/jobs/{job_id}"
+            headers['Location'] = f'{self.base_url}/jobs/{job_id}'
         except ProcessorExecuteError as err:
             LOGGER.error(err)
             msg = 'Processing error'

--- a/pygeoapi/process/base.py
+++ b/pygeoapi/process/base.py
@@ -52,6 +52,9 @@ class BaseProcessor:
         """
         execute the process
 
+        :param data: Dict with the input data that the process needs in order
+                     to execute
+
         :returns: tuple of MIME type and process response
         """
 

--- a/pygeoapi/process/base.py
+++ b/pygeoapi/process/base.py
@@ -48,7 +48,7 @@ class BaseProcessor:
         self.name = processor_def['name']
         self.metadata = process_metadata
 
-    def execute(self) -> Tuple[str, Any]:
+    def execute(self, data: dict) -> Tuple[str, Any]:
         """
         execute the process
 

--- a/pygeoapi/process/hello_world.py
+++ b/pygeoapi/process/hello_world.py
@@ -50,6 +50,7 @@ PROCESS_METADATA = {
               'renvoie en sortie. Destiné à démontrer un processus '
               'simple avec une seule entrée littérale.',
     },
+    'jobControlOptions': ['sync-execute', 'async-execute'],
     'keywords': ['hello world', 'example', 'echo'],
     'links': [{
         'type': 'text/html',

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -290,16 +290,19 @@ class BaseManager:
             if self.is_async and process_supports_async:
                 LOGGER.debug('Asynchronous execution')
                 handler = self._execute_handler_async
-                response_headers = {"Preference-Applied": "respond-async"}
+                response_headers = {
+                    "Preference-Applied": RequestedProcessExecutionMode.respond_async.value}
             else:
                 LOGGER.debug('Synchronous execution')
                 handler = self._execute_handler_sync
-                response_headers = {"Preference-Applied": "respond-sync"}
+                response_headers = {
+                    "Preference-Applied": RequestedProcessExecutionMode.wait.value}
         elif execution_mode == RequestedProcessExecutionMode.wait:
             # client wants sync - pygeoapi implicitly always support sync execution mode
             LOGGER.debug('Synchronous execution')
             handler = self._execute_handler_sync
-            response_headers = {"Preference-Applied": "respond-sync"}
+            response_headers = {
+                "Preference-Applied": RequestedProcessExecutionMode.wait.value}
         else:  # client has no preference
             # according to the OAPI - Processes spec we ought to respond with sync
             LOGGER.debug('Synchronous execution')

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -270,7 +270,7 @@ class BaseManager:
             p: BaseProcessor,
             data_dict: dict,
             execution_mode: Optional[RequestedProcessExecutionMode] = None
-    ) -> tuple[str, Any, JobStatus, Optional[Dict[str, str]]]:
+    ) -> Tuple[str, Any, JobStatus, Optional[Dict[str, str]]]:
         """
         Default process execution handler
 

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -289,21 +289,21 @@ class BaseManager:
             # client wants async - do we support it?
             process_supports_async = (
                 ProcessExecutionMode.async_execute.value in p.metadata.get(
-                    "jobControlOptions", []
+                    'jobControlOptions', []
                 )
             )
             if self.is_async and process_supports_async:
                 LOGGER.debug('Asynchronous execution')
                 handler = self._execute_handler_async
                 response_headers = {
-                    "Preference-Applied": (
+                    'Preference-Applied': (
                         RequestedProcessExecutionMode.respond_async.value)
                 }
             else:
                 LOGGER.debug('Synchronous execution')
                 handler = self._execute_handler_sync
                 response_headers = {
-                    "Preference-Applied": (
+                    'Preference-Applied': (
                         RequestedProcessExecutionMode.wait.value)
                 }
         elif execution_mode == RequestedProcessExecutionMode.wait:
@@ -311,7 +311,7 @@ class BaseManager:
             LOGGER.debug('Synchronous execution')
             handler = self._execute_handler_sync
             response_headers = {
-                "Preference-Applied": RequestedProcessExecutionMode.wait.value}
+                'Preference-Applied': RequestedProcessExecutionMode.wait.value}
         else:  # client has no preference
             # according to OAPI - Processes spec we ought to respond with sync
             LOGGER.debug('Synchronous execution')

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -32,7 +32,7 @@ import json
 import logging
 from multiprocessing import dummy
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any, Tuple, Optional
 import uuid
 
 from pygeoapi.util import (
@@ -268,8 +268,8 @@ class BaseManager:
             self,
             p: BaseProcessor,
             data_dict: dict,
-            execution_mode: RequestedProcessExecutionMode | None = None
-    ) -> tuple[str, str, Any, JobStatus, dict[str, str] | None]:
+            execution_mode: Optional[RequestedProcessExecutionMode] = None
+    ) -> tuple[str, str, Any, JobStatus, Optional[dict[str, str]]]:
         """
         Default process execution handler
 

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -275,7 +275,8 @@ class BaseManager:
 
         :param p: `pygeoapi.process` object
         :param data_dict: `dict` of data parameters
-        :param execution_mode: `str` optionally specifying sync or async processing.
+        :param execution_mode: `str` optionally specifying sync or async
+        processing.
 
         :returns: tuple of job_id, MIME type, response payload, status and
                   optionally additional HTTP headers to include in the final
@@ -291,25 +292,29 @@ class BaseManager:
                 LOGGER.debug('Asynchronous execution')
                 handler = self._execute_handler_async
                 response_headers = {
-                    "Preference-Applied": RequestedProcessExecutionMode.respond_async.value}
+                    "Preference-Applied": (
+                        RequestedProcessExecutionMode.respond_async.value)
+                }
             else:
                 LOGGER.debug('Synchronous execution')
                 handler = self._execute_handler_sync
                 response_headers = {
-                    "Preference-Applied": RequestedProcessExecutionMode.wait.value}
+                    "Preference-Applied": (
+                        RequestedProcessExecutionMode.wait.value)
+                }
         elif execution_mode == RequestedProcessExecutionMode.wait:
-            # client wants sync - pygeoapi implicitly always support sync execution mode
+            # client wants sync - pygeoapi implicitly supports sync mode
             LOGGER.debug('Synchronous execution')
             handler = self._execute_handler_sync
             response_headers = {
                 "Preference-Applied": RequestedProcessExecutionMode.wait.value}
         else:  # client has no preference
-            # according to the OAPI - Processes spec we ought to respond with sync
+            # according to OAPI - Processes spec we ought to respond with sync
             LOGGER.debug('Synchronous execution')
             handler = self._execute_handler_sync
             response_headers = None
-        # TODO: the handler's response could also be allowed to include more HTTP
-        #  headers
+        # TODO: handler's response could also be allowed to include more HTTP
+        # headers
         mime_type, outputs, status = handler(p, job_id, data_dict)
         return job_id, mime_type, outputs, status, response_headers
 

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -38,6 +38,7 @@ import uuid
 from pygeoapi.util import (
     DATETIME_FORMAT,
     JobStatus,
+    ProcessExecutionMode,
     RequestedProcessExecutionMode,
 )
 from pygeoapi.process.base import BaseProcessor
@@ -286,8 +287,11 @@ class BaseManager:
         job_id = str(uuid.uuid1())
         if execution_mode == RequestedProcessExecutionMode.respond_async:
             # client wants async - do we support it?
-            process_supports_async = "execute-async" in p.metadata.get(
-                "jobControlOptions", [])
+            process_supports_async = (
+                ProcessExecutionMode.async_execute.value in p.metadata.get(
+                    "jobControlOptions", []
+                )
+            )
             if self.is_async and process_supports_async:
                 LOGGER.debug('Asynchronous execution')
                 handler = self._execute_handler_async

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -32,7 +32,7 @@ import json
 import logging
 from multiprocessing import dummy
 from pathlib import Path
-from typing import Any, Tuple, Optional
+from typing import Any, Dict, Tuple, Optional
 import uuid
 
 from pygeoapi.util import (
@@ -269,7 +269,7 @@ class BaseManager:
             p: BaseProcessor,
             data_dict: dict,
             execution_mode: Optional[RequestedProcessExecutionMode] = None
-    ) -> tuple[str, str, Any, JobStatus, Optional[dict[str, str]]]:
+    ) -> tuple[str, Any, JobStatus, Optional[Dict[str, str]]]:
         """
         Default process execution handler
 

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -28,7 +28,7 @@
 # =================================================================
 
 import logging
-from typing import Any, Tuple
+from typing import Any, Dict, Optional, Tuple
 import uuid
 
 from pygeoapi.process.base import BaseProcessor
@@ -71,8 +71,8 @@ class DummyManager(BaseManager):
             self,
             p: BaseProcessor,
             data_dict: dict,
-            execution_mode: RequestedProcessExecutionMode | None = None
-    ) -> Tuple[str, str, Any, JobStatus, dict[str, str] | None]:
+            execution_mode: Optional[RequestedProcessExecutionMode] = None
+    ) -> Tuple[str, str, Any, JobStatus, Optional[Dict[str, str]]]:
         """
         Default process execution handler
 

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -90,7 +90,7 @@ class DummyManager(BaseManager):
         response_headers = None
         if execution_mode is not None:
             response_headers = {
-                "Preference-Applied": RequestedProcessExecutionMode.wait.value}
+                'Preference-Applied': RequestedProcessExecutionMode.wait.value}
             if execution_mode == RequestedProcessExecutionMode.respond_async:
                 LOGGER.debug('Dummy manager does not support asynchronous')
                 LOGGER.debug('Forcing synchronous execution')

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -548,6 +548,11 @@ def get_provider_default(providers: list) -> dict:
     return default
 
 
+class ProcessExecutionMode(Enum):
+    sync_execute = "sync-execute"
+    async_execute = "async-execute"
+
+
 class RequestedProcessExecutionMode(Enum):
     wait = "wait"
     respond_async = "respond-async"

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -548,6 +548,11 @@ def get_provider_default(providers: list) -> dict:
     return default
 
 
+class RequestedProcessExecutionMode(Enum):
+    wait = "wait"
+    respond_async = "respond-async"
+
+
 class JobStatus(Enum):
     """
     Enum for the job status options specified in the WPS 2.0 specification

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -549,13 +549,13 @@ def get_provider_default(providers: list) -> dict:
 
 
 class ProcessExecutionMode(Enum):
-    sync_execute = "sync-execute"
-    async_execute = "async-execute"
+    sync_execute = 'sync-execute'
+    async_execute = 'async-execute'
 
 
 class RequestedProcessExecutionMode(Enum):
-    wait = "wait"
-    respond_async = "respond-async"
+    wait = 'wait'
+    respond_async = 'respond-async'
 
 
 class JobStatus(Enum):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1794,8 +1794,7 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    req_body_1['mode'] = 'async'
-    req = mock_request(data=req_body_1)
+    req = mock_request(data=req_body_1, HTTP_Prefer="respond-async")
     rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     assert 'Location' in rsp_headers

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1794,7 +1794,7 @@ def test_execute_process(config, api_):
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
 
-    req = mock_request(data=req_body_1, HTTP_Prefer="respond-async")
+    req = mock_request(data=req_body_1, HTTP_Prefer='respond-async')
     rsp_headers, code, response = api_.execute_process(req, 'hello-world')
 
     assert 'Location' in rsp_headers
@@ -1846,7 +1846,7 @@ def test_delete_job(api_):
     rsp_headers, code, response = api_.delete_job(job_id)
     assert code == HTTPStatus.NOT_FOUND
 
-    req = mock_request(data=req_body_async, HTTP_Prefer="respond-async")
+    req = mock_request(data=req_body_async, HTTP_Prefer='respond-async')
     rsp_headers, code, response = api_.execute_process(
         req, 'hello-world')
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1824,7 +1824,6 @@ def test_delete_job(api_):
     }
 
     req_body_async = {
-        'mode': 'async',
         'inputs': {
             'name': 'Async Test Deletion'
         }
@@ -1847,7 +1846,7 @@ def test_delete_job(api_):
     rsp_headers, code, response = api_.delete_job(job_id)
     assert code == HTTPStatus.NOT_FOUND
 
-    req = mock_request(data=req_body_async)
+    req = mock_request(data=req_body_async, HTTP_Prefer="respond-async")
     rsp_headers, code, response = api_.execute_process(
         req, 'hello-world')
 


### PR DESCRIPTION
# Overview
This PR modifies OAPI - Process request handling in order to extract execution mode from the `Prefer` HTTP header of the request, as discussed in #1204.

# Related Issue / Discussion
- fixes #1204
- fixes #1191 - this is a small fix that just adds the parameter to the base class' method, as discussed in the issue

# Additional Information
In addition to getting the requested execution mode from the HTTP request's `Prefer` header, the proposed implementation also delegates decision about which execution mode to use to the process manager.

Additionally, and in compliance with the OAPI - Processes spec, when there is a `Prefer` header in the HTTP request, pygeoapi now replies back with a `Preference-Applied` response header too.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
