### PR TITLE
Process manager generate job ids

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -48,7 +48,6 @@ import logging
 import re
 from typing import Any, Tuple, Union
 import urllib.parse
-import uuid
 
 from dateutil.parser import parse as dateparse
 from pygeofilter.parsers.ecql import parse as parse_ecql_text
@@ -3430,7 +3429,6 @@ class API:
 
         data_dict = data.get('inputs', {})
         LOGGER.debug(data_dict)
-
 
         is_async = data.get('mode', 'auto') == 'async'
         if is_async:

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3431,10 +3431,6 @@ class API:
         data_dict = data.get('inputs', {})
         LOGGER.debug(data_dict)
 
-        job_id = data.get("job_id", str(uuid.uuid1()))
-        url = f"{self.base_url}/jobs/{job_id}"
-
-        headers['Location'] = url
 
         is_async = data.get('mode', 'auto') == 'async'
         if is_async:
@@ -3446,8 +3442,9 @@ class API:
 
         try:
             LOGGER.debug('Executing process')
-            mime_type, outputs, status = self.manager.execute_process(
-                process, job_id, data_dict, is_async)
+            job_id, mime_type, outputs, status = self.manager.execute_process(
+                process, data_dict, is_async)
+            headers['Location'] = f"{self.base_url}/jobs/{job_id}"
         except ProcessorExecuteError as err:
             LOGGER.error(err)
             msg = 'Processing error'

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -283,7 +283,7 @@ class BaseManager:
         else:
             LOGGER.debug('Asynchronous execution')
             result = self._execute_handler_async(p, job_id, data_dict)
-        return job_id, *result
+        return (job_id, *result)
 
     def __repr__(self):
         return f'<BaseManager> {self.name}'

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -27,16 +27,16 @@
 #
 # =================================================================
 
+from datetime import datetime
 import json
 import logging
-import uuid
-from datetime import datetime
 from multiprocessing import dummy
 from pathlib import Path
 from typing import Any, Tuple
+import uuid
 
-from pygeoapi.util import DATETIME_FORMAT, JobStatus
 from pygeoapi.process.base import BaseProcessor
+from pygeoapi.util import DATETIME_FORMAT, JobStatus
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -130,7 +130,7 @@ class BaseManager:
         raise NotImplementedError()
 
     def _execute_handler_async(self, p: BaseProcessor, job_id: str,
-                               data_dict: dict) -> Tuple[None, JobStatus]:
+                               data_dict: dict) -> Tuple[str, None, JobStatus]:
         """
         This private execution handler executes a process in a background
         thread using `multiprocessing.dummy`
@@ -260,7 +260,12 @@ class BaseManager:
 
         return jfmt, outputs, current_status
 
-    def execute_process(self, p, data_dict, is_async=False):
+    def execute_process(
+            self,
+            p,
+            data_dict,
+            is_async=False
+    ) -> Tuple[str, str, Any, JobStatus]:
         """
         Default process execution handler
 

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -27,9 +27,10 @@
 #
 # =================================================================
 
-from datetime import datetime
 import json
 import logging
+import uuid
+from datetime import datetime
 from multiprocessing import dummy
 from pathlib import Path
 from typing import Any, Tuple
@@ -259,24 +260,25 @@ class BaseManager:
 
         return jfmt, outputs, current_status
 
-    def execute_process(self, p, job_id, data_dict, is_async=False):
+    def execute_process(self, p, data_dict, is_async=False):
         """
         Default process execution handler
 
         :param p: `pygeoapi.process` object
-        :param job_id: job identifier
         :param data_dict: `dict` of data parameters
         :param is_async: `bool` specifying sync or async processing.
 
-        :returns: tuple of MIME type, response payload and status
+        :returns: tuple of job_id, MIME type, response payload and status
         """
 
+        job_id = str(uuid.uuid1())
         if not is_async:
             LOGGER.debug('Synchronous execution')
-            return self._execute_handler_sync(p, job_id, data_dict)
+            result = self._execute_handler_sync(p, job_id, data_dict)
         else:
             LOGGER.debug('Asynchronous execution')
-            return self._execute_handler_async(p, job_id, data_dict)
+            result = self._execute_handler_async(p, job_id, data_dict)
+        return job_id, *result
 
     def __repr__(self):
         return f'<BaseManager> {self.name}'

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -28,6 +28,7 @@
 # =================================================================
 
 import logging
+import uuid
 from typing import Any, Tuple
 
 from pygeoapi.process.base import BaseProcessor
@@ -63,17 +64,20 @@ class DummyManager(BaseManager):
 
         return []
 
-    def execute_process(self, p: BaseProcessor, job_id: str, data_dict: dict,
-                        is_async: bool = False) -> Tuple[str, Any, int]:
+    def execute_process(
+            self,
+            p: BaseProcessor,
+            data_dict: dict,
+            is_async: bool = False
+    ) -> Tuple[str, str, Any, JobStatus]:
         """
         Default process execution handler
 
         :param p: `pygeoapi.process` object
-        :param job_id: job identifier
         :param data_dict: `dict` of data parameters
         :param is_async: `bool` specifying sync or async processing.
 
-        :returns: tuple of MIME type, response payload and status
+        :returns: tuple of job_id, MIME type, response payload and status
         """
 
         jfmt = 'application/json'
@@ -93,7 +97,8 @@ class DummyManager(BaseManager):
             current_status = JobStatus.failed
             LOGGER.error(err)
 
-        return jfmt, outputs, current_status
+        job_id = str(uuid.uuid1())
+        return job_id, jfmt, outputs, current_status
 
     def __repr__(self):
         return f'<DummyManager> {self.name}'

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -28,8 +28,8 @@
 # =================================================================
 
 import logging
-import uuid
 from typing import Any, Tuple
+import uuid
 
 from pygeoapi.process.base import BaseProcessor
 from pygeoapi.process.manager.base import BaseManager


### PR DESCRIPTION
# Overview
This PR modifies the pygeoapi process manager to be responsible for generating job ids, as discussed in #1207.

The proposed implementation simply makes the generation of a job's id part of the process manager's set of responsabilities, which means that the job id is now returned from the process manager's `execute_process()` method, rather than it being an input to this method.

# Related Issue / Discussion
- #1207 


# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
