### PR TITLE
Refactored process manager to know about processes

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -62,26 +62,26 @@ from pygeoapi.formatter.base import FormatterSerializationError
 from pygeoapi.linked_data import (geojson2jsonld, jsonldify,
                                   jsonldify_collection)
 from pygeoapi.log import setup_logger
-from pygeoapi.process.base import (
-    ProcessorExecuteError,
-    ProcessorGenericError,
-)
-from pygeoapi.process.manager import get_manager
+from pygeoapi.models.cql import CQLModel
+from pygeoapi.models.provider.base import TilesMetadataFormat
 from pygeoapi.plugin import (
     InvalidPluginError,
     load_plugin,
     PLUGINS,
 )
+from pygeoapi.process.base import (
+    ProcessorExecuteError,
+    ProcessorGenericError,
+)
+from pygeoapi.process.manager import get_manager
 from pygeoapi.provider.base import (
     ProviderGenericError, ProviderConnectionError, ProviderNotFoundError,
     ProviderInvalidDataError, ProviderInvalidQueryError, ProviderNoDataError,
     ProviderQueryError, ProviderItemNotFoundError, ProviderTypeError,
     ProviderRequestEntityTooLargeError)
-
 from pygeoapi.provider.tile import (ProviderTileNotFoundError,
                                     ProviderTileQueryError,
                                     ProviderTilesetIdNotFoundError)
-from pygeoapi.models.cql import CQLModel
 from pygeoapi.util import (dategetter, RequestedProcessExecutionMode,
                            DATETIME_FORMAT, UrlPrefetcher,
                            filter_dict_by_key_value, get_provider_by_type,
@@ -91,7 +91,6 @@ from pygeoapi.util import (dategetter, RequestedProcessExecutionMode,
                            get_crs_from_uri, get_supported_crs_list,
                            CrsTransformSpec, transform_bbox)
 
-from pygeoapi.models.provider.base import TilesMetadataFormat
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -1130,7 +1130,7 @@ def get_oas_30(cfg):
                 LOGGER.debug(f'Skipping hidden layer: {k}')
                 continue
             name = l10n.translate(k, locale_)
-            p = load_plugin('process', v['processor'])
+            p = process_manager.get_processor(k)
 
             md_desc = l10n.translate(p.metadata['description'], locale_)
             process_name_path = f'/processes/{name}'

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -45,6 +45,7 @@ from pygeoapi import l10n
 from pygeoapi.plugin import load_plugin
 from pygeoapi.models.openapi import OAPIFormat
 from pygeoapi.provider.base import ProviderTypeError, SchemaType
+from pygeoapi.process.manager import get_manager
 from pygeoapi.util import (filter_dict_by_key_value, get_provider_by_type,
                            filter_providers_by_type, to_json, yaml_load,
                            get_api_rules, get_base_url)
@@ -1104,9 +1105,9 @@ def get_oas_30(cfg):
             }
         }
 
-    processes = filter_dict_by_key_value(cfg['resources'], 'type', 'process')
+    process_manager = get_manager(cfg)
 
-    if processes:
+    if len(process_manager.processes) > 0:
         paths['/processes'] = {
             'get': {
                 'summary': 'Processes',
@@ -1124,7 +1125,7 @@ def get_oas_30(cfg):
         }
         LOGGER.debug('setting up processes')
 
-        for k, v in processes.items():
+        for k, v in process_manager.processes.items():
             if k.startswith('_'):
                 LOGGER.debug(f'Skipping hidden layer: {k}')
                 continue

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -42,10 +42,10 @@ from jsonschema import validate as jsonschema_validate
 import yaml
 
 from pygeoapi import l10n
-from pygeoapi.plugin import load_plugin
 from pygeoapi.models.openapi import OAPIFormat
-from pygeoapi.provider.base import ProviderTypeError, SchemaType
+from pygeoapi.plugin import load_plugin
 from pygeoapi.process.manager import get_manager
+from pygeoapi.provider.base import ProviderTypeError, SchemaType
 from pygeoapi.util import (filter_dict_by_key_value, get_provider_by_type,
                            filter_providers_by_type, to_json, yaml_load,
                            get_api_rules, get_base_url)

--- a/pygeoapi/process/manager/__init__.py
+++ b/pygeoapi/process/manager/__init__.py
@@ -44,8 +44,8 @@ def get_manager(config: Dict):
 
     :returns: The pygeoapi process manager object
     """
-    manager_conf = config.get("server", {}).get(
-        "manager",
+    manager_conf = config.get('server', {}).get(
+        'manager',
         {
             'name': 'Dummy',
             'connection': None,
@@ -53,10 +53,10 @@ def get_manager(config: Dict):
         }
     )
     processes_conf = {}
-    for id_, resource_conf in config.get("resources", {}).items():
-        if resource_conf.get("type") == "process":
+    for id_, resource_conf in config.get('resources', {}).items():
+        if resource_conf.get('type') == 'process':
             processes_conf[id_] = resource_conf
-    manager_conf["processes"] = processes_conf
-    if manager_conf.get("name") == "Dummy":
+    manager_conf['processes'] = processes_conf
+    if manager_conf.get('name') == 'Dummy':
         LOGGER.info('Starting dummy manager')
-    return load_plugin("process_manager", manager_conf)
+    return load_plugin('process_manager', manager_conf)

--- a/pygeoapi/process/manager/__init__.py
+++ b/pygeoapi/process/manager/__init__.py
@@ -1,8 +1,10 @@
 # =================================================================
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Ricardo Garcia Silva <ricardo.garcia.silva@gmail.com>
 #
 # Copyright (c) 2019 Tom Kralidis
+#           (c) 2023 Ricardo Garcia Silva
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -26,3 +28,35 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # =================================================================
+
+import logging
+from typing import Dict
+
+from pygeoapi.plugin import load_plugin
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_manager(config: Dict):
+    """Instantiate process manager from the supplied configuration.
+
+    :param config: pygeoapi configuration
+
+    :returns: The pygeoapi process manager object
+    """
+    manager_conf = config.get("server", {}).get(
+        "manager",
+        {
+            'name': 'Dummy',
+            'connection': None,
+            'output_dir': None
+        }
+    )
+    processes_conf = {}
+    for id_, resource_conf in config.get("resources", {}).items():
+        if resource_conf.get("type") == "process":
+            processes_conf[id_] = resource_conf
+    manager_conf["processes"] = processes_conf
+    if manager_conf.get("name") == "Dummy":
+        LOGGER.info('Starting dummy manager')
+    return load_plugin("process_manager", manager_conf)

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -67,7 +67,7 @@ class BaseManager:
         self.connection = manager_def.get('connection')
         self.output_dir = manager_def.get('output_dir')
         self.processes = {}
-        for id_, process_conf in manager_def.get("processes", {}).items():
+        for id_, process_conf in manager_def.get('processes', {}).items():
             self.processes[id_] = dict(process_conf)
 
         if self.output_dir is not None:
@@ -96,11 +96,11 @@ class BaseManager:
         try:
             process_conf = self.processes[process_id]
         except KeyError as exc:
-            msg = "Invalid process identifier"
+            msg = 'Invalid process identifier'
             LOGGER.warning(msg)
             raise ProcessorGenericError(msg) from exc
         else:
-            return load_plugin("process", process_conf["processor"])
+            return load_plugin('process', process_conf['processor'])
 
     def add_job(self, job_metadata: dict) -> str:
         """

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -31,7 +31,6 @@ import logging
 from typing import Any, Dict, Optional, Tuple
 import uuid
 
-from pygeoapi.process.base import BaseProcessor
 from pygeoapi.process.manager.base import BaseManager
 from pygeoapi.util import (
     RequestedProcessExecutionMode,
@@ -69,14 +68,14 @@ class DummyManager(BaseManager):
 
     def execute_process(
             self,
-            p: BaseProcessor,
-            data_dict: dict,
+            process_id: str,
+            data_dict: Dict,
             execution_mode: Optional[RequestedProcessExecutionMode] = None
     ) -> Tuple[str, str, Any, JobStatus, Optional[Dict[str, str]]]:
         """
         Default process execution handler
 
-        :param p: `pygeoapi.process` object
+        :param process_id: identifier of the process to be executed
         :param data_dict: `dict` of data parameters
         :param execution_mode: requested execution mode
 
@@ -95,6 +94,7 @@ class DummyManager(BaseManager):
                 LOGGER.debug('Dummy manager does not support asynchronous')
                 LOGGER.debug('Forcing synchronous execution')
 
+        p = self.get_processor(process_id)
         try:
             jfmt, outputs = p.execute(data_dict)
             current_status = JobStatus.successful


### PR DESCRIPTION
# Overview
This PR modifies the base process manager class in order to have it accept the configuration of known processes during initialization.

With the proposed implementation the process manager know becomes aware of existing processes and can be treated as the source of truth whenever there is a need to retrieve process-related details. Additional implementation details:

- Added the `pygeoapi.process.manager.get_manager(pygeoapi_config)` factory function, which becomes the standard way of getting the manager object - this function reads the pygeoapi config and gets both the manager and whatever processes defined therein, and then calls `pygeoapi.plugins.load_plugin()`.
- Added a `get_processor(process_id)` method to the base manager class, which can be used whenever there is a need to get a process instance. This is a fix for #1201 and contributes to making the process manager fully responsible for managing processes and jobs

# Related Issue / Discussion
- fixes #1213
- fixes #1201


# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
