### PR TITLE
Update wording on OGC API - Tiles documentation, to be more aligned with the standard

### DIFF
--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -1,10 +1,10 @@
 .. _ogcapi-tiles:
 
-Publishing map tiles to OGC API - Tiles
+Publishing tiles to OGC API - Tiles
 =======================================
 
 `OGC API - Tiles`_ provides access to geospatial data in the form of tiles
-(map, vector, etc.).
+(map, vector, coverage, etc.).
 
 pygeoapi can publish tiles from local or remote data sources (including cloud
 object storage or a tile service). To integrate tiles from a local data source, it is assumed


### PR DESCRIPTION
- Updated "Publishing map tiles to OGC API - Tiles" to "Publishing tiles to OGC API - Tiles". The previous title could be misleading, as this standard supports publishing different types of tiles, other than maps.

- Added "coverage" as another type of tiles that the standard supports.

# Overview
![Screenshot from 2023-04-24 09-49-06](https://user-images.githubusercontent.com/1038897/233947074-66d3d3ac-310b-4534-8ce8-a6f865054bda.png)

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/1227

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
