### PR TITLE
add license section to collection if rel=license exists

### DIFF
--- a/pygeoapi/templates/collections/collection.html
+++ b/pygeoapi/templates/collections/collection.html
@@ -30,6 +30,23 @@
           <div id="collection-map"></div>
         </div>
       </div>
+
+      {% set ns = namespace(header_printed=false) %}
+      {% for link in data['links'] %}
+          {% if link['rel'] == 'license' %}
+          {% if not ns.header_printed %}
+          <h3>{% trans %}License{% endtrans %}</h3>
+          {% set ns.header_printed = true %}
+          {% endif %}
+          <ul>
+            <li>
+              <div>
+                <a title="{{ link['title'] }}" href="{{ link['href'] }}">{{ link['title'] or link['href'] }}<a>
+            </li>
+          </ul>
+          {% endif %}
+      {% endfor %}
+
       {% if data['itemType'] == 'feature' or data['itemType'] == 'record' %}
       <h3>{% trans %}Browse{% endtrans %}</h3>
       <ul>


### PR DESCRIPTION
# Overview
Adds an HTML header for Licensing if a collection configuration includes links with `rel=license`.

# Related Issue / Discussion
None
# Additional Information
cc @david-i-berrty
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
