### PR TITLE
Speed enhancements for EDR provider

### DIFF
--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -69,7 +69,6 @@ class XarrayProvider(BaseProvider):
                     open_func = xarray.open_dataset
 
             self._data = open_func(self.data)
-            self._data = _convert_float32_to_float64(self._data)
             self._coverage_properties = self._get_coverage_properties()
 
             self.axes = [self._coverage_properties['x_axis_label'],
@@ -393,6 +392,9 @@ class XarrayProvider(BaseProvider):
 
             cj['parameters'][pm['id']] = parameter
 
+        data = data.fillna(None)
+        data = _convert_float32_to_float64(data)
+
         try:
             for key in cj['parameters'].keys():
                 cj['ranges'][key] = {
@@ -405,8 +407,6 @@ class XarrayProvider(BaseProvider):
                               metadata['width'],
                               metadata['time_steps']]
                 }
-
-                data = data.fillna(None)
                 cj['ranges'][key]['values'] = data[key].values.flatten().tolist()  # noqa
         except IndexError as err:
             LOGGER.warning(err)


### PR DESCRIPTION
# Overview
The `_convert_float32_to_float64` function was originally called in the `__init__` for the `XarrayProvider`. This function loops through all variables in an xarray datset and converts the float type. When this is called in the `__init__` function on the entire dataset, you lose the benefits of lazy loading. Moving this function call to the `gen_covjson` method only performs the float conversion on variables necessary for the request, and does not call the function at all during the build process.
 
Second, this work moves filling null data in the xarray dataset from outside of a loop to just ahead of the loop in `gen_covjson`, because the `fillna()` function impacts the entire dataset, so there is no need to re-call the function repeatedly. 

# Related Issue / Discussion

# Additional Information
Moving the `_convert_float_32_to_float64` has sped up some initial builds I have done in testing by several minutes. When testing in a docker container with very large zarr files, the original code base failed to build due to the size of the file, but was able to build quickly with the function moved.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute EDR speed enhancements to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
