### PR TITLE
fix importlib_metadata issue with entry_points(group="pygeoapi") being unsupported

### DIFF
--- a/pygeoapi/__init__.py
+++ b/pygeoapi/__init__.py
@@ -50,7 +50,20 @@ def _find_plugins():
     """
 
     def decorator(click_group):
-        for entry_point in entry_points(group="pygeoapi"):
+        try:
+            found_entrypoints = entry_points(group="pygeoapi")
+        except TypeError:
+            # earlier versions of importlib_metadata did not have the
+            # `group` kwarg. More detail:
+            #
+            # https://github.com/geopython/pygeoapi/issues/1241#issuecomment-1536128897  # noqa: E501
+            for group, entries in entry_points().items():
+                if group == "pygeoapi":
+                    found_entrypoints = entries
+                    break
+            else:
+                found_entrypoints = []
+        for entry_point in found_entrypoints:
             try:
                 click_group.add_command(entry_point.load())
             except Exception as err:


### PR DESCRIPTION
This PR fixes the issue that arises when trying to use a feature of `importlib_metadata` that does not exist on older versions.

The proposed implementation is a workaround that tries to use the current version of the `entry_points()` function and upon failure falls back to the older implementation.

# Related Issue / Discussion

- fixes #1241


# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
