### PR TITLE
Create separate tag for jobs in OAS

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -1207,7 +1207,7 @@ def get_oas_30(cfg):
             'get': {
                 'summary': 'Retrieve jobs list',
                 'description': 'Retrieve a list of jobs',
-                'tags': ['server'],
+                'tags': ['jobs'],
                 'operationId': 'getJobs',
                 'responses': {
                     '200': {'$ref': '#/components/responses/200'},
@@ -1221,7 +1221,7 @@ def get_oas_30(cfg):
             'get': {
                 'summary': 'Retrieve job details',
                 'description': 'Retrieve job details',
-                'tags': ['server'],
+                'tags': ['jobs'],
                 'parameters': [
                     name_in_path,
                     {'$ref': '#/components/parameters/f'}
@@ -1236,7 +1236,7 @@ def get_oas_30(cfg):
             'delete': {
                 'summary': 'Cancel / delete job',
                 'description': 'Cancel / delete job',
-                'tags': ['server'],
+                'tags': ['jobs'],
                 'parameters': [
                     name_in_path
                 ],
@@ -1253,7 +1253,7 @@ def get_oas_30(cfg):
             'get': {
                 'summary': 'Retrieve job results',
                 'description': 'Retrive job resiults',
-                'tags': ['server'],
+                'tags': ['jobs'],
                 'parameters': [
                     name_in_path,
                     {'$ref': '#/components/parameters/f'}
@@ -1266,6 +1266,12 @@ def get_oas_30(cfg):
                 }
             }
         }
+
+        tag = {
+            'name': 'jobs',
+            'description': 'Process jobs',
+        }
+        oas['tags'].insert(1, tag)
 
     oas['paths'] = paths
 


### PR DESCRIPTION
Paths for `/jobs**` moved to own tag, `jobs` instead of `server` tag when generating OpenAPI document

# Overview
Currently:
![image](https://github.com/geopython/pygeoapi/assets/40066515/3124563f-f273-461a-8a16-326fcc574416)

With this PR:
![image](https://github.com/geopython/pygeoapi/assets/40066515/9e309c42-7941-4cae-8958-6c6740171989)

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
