### PR TITLE
Remove duplicate CRS configuration in docs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -189,18 +189,23 @@ default.
               - type: feature # underlying data geospatial type: (allowed values are: feature, coverage, record, tile, edr)
                 default: true  # optional: if not specified, the first provider definition is considered the default
                 name: CSV
-                # transactions: DO NOT ACTIVATE unless you have setup access control beyond pygeoapi
-                editable: true  # optional: if backend is writable, default is false
                 data: tests/data/obs.csv  # required: the data filesystem path or URL, depending on plugin setup
                 id_field: id  # required for vector data, the field corresponding to the ID
                 uri_field: uri # optional field corresponding to the Uniform Resource Identifier (see Linked Data section)
                 time_field: datetimestamp  # optional field corresponding to the temporal property of the dataset
                 title_field: foo # optional field of which property to display as title/label on HTML pages
-                crs: # optional: supported CRSs for parameters 'crs' and 'bbox-crs' (OGC OAPIF Part 2)
-                     # default: http://www.opengis.net/def/crs/OGC/1.3/CRS84
-                    - http://www.opengis.net/def/crs/EPSG/0/4326
-                    - http://www.opengis.net/def/crs/EPSG/0/3857
+                properties:  # optional: only return the following properties, in order
+                    - stn_id
+                    - value
+                # editable transactions: DO NOT ACTIVATE unless you have setup access control beyond pygeoapi
+                editable: true  # optional: if backend is writable, default is false
+                # coordinate reference systems (CRS) section is optional
+                # default CRSs are http://www.opengis.net/def/crs/OGC/1.3/CRS84 (coordinates without height)
+                # and http://www.opengis.net/def/crs/OGC/1.3/CRS84h (coordinates with ellipsoidal height)
+                crs: # supported coordinate reference systems (CRS) for 'crs' and 'bbox-crs' query parameters
                     - http://www.opengis.net/def/crs/EPSG/0/28992
+                    - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+                    - http://www.opengis.net/def/crs/EPSG/0/4326
                 storage_crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84 # optional CRS in which data is stored, default: as 'crs' field
                 storage_crs_coordinate_epoch: : 2017.23 # optional, if storage_crs is a dynamic coordinate reference system
                 format:  # optional default format
@@ -208,17 +213,6 @@ default.
                     mimetype: application/json  # required: format mimetype
                 options:  # optional options to pass to provider (i.e. GDAL creation)
                     option_name: option_value
-                properties:  # optional: only return the following properties, in order
-                    - stn_id
-                    - value
-                # coordinate reference systems (CRS) section is optional
-                # default CRSs are http://www.opengis.net/def/crs/OGC/1.3/CRS84 (coordinates without height)
-                # and http://www.opengis.net/def/crs/OGC/1.3/CRS84h (coordinates with ellipsoidal height)
-                storage_crs: http://www.opengis.net/def/crs/EPSG/0/28992 # CRS of the dataset to publish
-                crs: # supported coordinate reference systems (CRS) for 'crs' query parameter
-                    - http://www.opengis.net/def/crs/EPSG/0/28992
-                    - http://www.opengis.net/def/crs/OGC/1.3/CRS84
-                    - http://www.opengis.net/def/crs/EPSG/0/4326
 
       hello-world:  # name of process
           type: collection  # REQUIRED (collection, process, or stac-collection)


### PR DESCRIPTION
# Overview
- Deduplicate crs configuration in docs
- Move advanced provider configuration to end of example

# Related Issue / Discussion
Noticed when providing docs ref for https://github.com/geopython/pygeoapi/issues/1248

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
