### PR TITLE
Dockerfile improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
 .github
 .pytest_cache
+.mypy_cache
 build
 dist
 docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@
 #
 # =================================================================
 
-FROM ubuntu:jammy-20230425
+FROM ubuntu:jammy-20231211.1
 
 LABEL maintainer="Just van den Broecke <justb4@gmail.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,6 @@ ENV TZ=${TZ} \
     ${ADD_DEB_PACKAGES}"
 
 WORKDIR /pygeoapi
-ADD . /pygeoapi
 
 # Install operating system dependencies
 RUN \
@@ -120,22 +119,27 @@ RUN \
     && unzip ./SCHEMAS_OPENGIS_NET.zip "ogcapi/*" -d /schemas.opengis.net \
     && rm -f ./SCHEMAS_OPENGIS_NET.zip \
 
-    # Install remaining pygeoapi deps
-    && pip3 install -r requirements-docker.txt \
-    && pip3 install -r requirements-admin.txt \
-
-    # Install pygeoapi
-    && pip3 install -e . \
-
-    # Set default config and entrypoint for Docker Image
-    && cp /pygeoapi/docker/default.config.yml /pygeoapi/local.config.yml \
-    && cp /pygeoapi/docker/entrypoint.sh /entrypoint.sh  \
-
     # Cleanup TODO: remove unused Locales and TZs
     && apt-get remove --purge -y gcc ${DEB_BUILD_DEPS} \
     && apt-get clean \
     && apt autoremove -y  \
     && rm -rf /var/lib/apt/lists/*
+
+ADD requirements-docker.txt requirements-admin.txt /pygeoapi/
+# Install remaining pygeoapi deps
+RUN pip3 install -r requirements-docker.txt \
+    && pip3 install -r requirements-admin.txt
+
+
+ADD . /pygeoapi
+
+ # Install pygeoapi
+RUN pip3 install -e . 
+
+RUN \ 
+    # Set default config and entrypoint for Docker Image
+    cp /pygeoapi/docker/default.config.yml /pygeoapi/local.config.yml \
+    && cp /pygeoapi/docker/entrypoint.sh /entrypoint.sh 
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,14 +127,14 @@ RUN \
 
 ADD requirements-docker.txt requirements-admin.txt /pygeoapi/
 # Install remaining pygeoapi deps
-RUN python3 -m pip install -r requirements-docker.txt \
-    && python3 -m pip install -r requirements-admin.txt
+RUN python3 -m pip install --no-cache-dir -r requirements-docker.txt \
+    && python3 -m pip install --no-cache-dir -r requirements-admin.txt
 
 
 ADD . /pygeoapi
 
  # Install pygeoapi
-RUN python3 -m pip install -e . 
+RUN python3 -m pip install --no-cache-dir -e . 
 
 RUN \ 
     # Set default config and entrypoint for Docker Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@
 # Copyright (c) 2019 Just van den Broecke
 # Copyright (c) 2020 Francesco Bartoli
 # Copyright (c) 2021 Angelos Tzotsos
+# Copyright (c) 2023 Bernhard Mallinger
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -33,7 +34,7 @@
 #
 # =================================================================
 
-FROM ubuntu:jammy 
+FROM ubuntu:jammy-20230425
 
 LABEL maintainer="Just van den Broecke <justb4@gmail.com>"
 
@@ -106,7 +107,6 @@ ADD . /pygeoapi
 # Install operating system dependencies
 RUN \
     apt-get update -y \
-    && apt-get upgrade -y \
     && apt-get --no-install-recommends install -y ${DEB_PACKAGES} ${DEB_BUILD_DEPS}  \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
     && echo "For ${TZ} date=$(date)" && echo "Locale=$(locale)"  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,9 @@ RUN \
     && rm -f ./SCHEMAS_OPENGIS_NET.zip \
 
     # Cleanup TODO: remove unused Locales and TZs
+    # NOTE: this tries to remove gcc, but the actual package gcc-11 can't be
+    #       removed because python3-scipy depends on python3-pythran which
+    #       depends on g++
     && apt-get remove --purge -y gcc ${DEB_BUILD_DEPS} \
     && apt-get clean \
     && apt autoremove -y  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,14 +127,14 @@ RUN \
 
 ADD requirements-docker.txt requirements-admin.txt /pygeoapi/
 # Install remaining pygeoapi deps
-RUN pip3 install -r requirements-docker.txt \
-    && pip3 install -r requirements-admin.txt
+RUN python3 -m pip install -r requirements-docker.txt \
+    && python3 -m pip install -r requirements-admin.txt
 
 
 ADD . /pygeoapi
 
  # Install pygeoapi
-RUN pip3 install -e . 
+RUN python3 -m pip install -e . 
 
 RUN \ 
     # Set default config and entrypoint for Docker Image


### PR DESCRIPTION
# Overview

These changes allow developing locally with the dockerfile by making use of image caches. Previously changing any character in the source code would lead to a rebuild time of several minutes. Now it should only be a matter of seconds.

The base image is now fixed to a specific ubuntu jammy version (currently `jammy-20230425`). This should reduce the image size because before, the old packages were included in the image as well as the update. It should also make the builds more reproducible and give control over when libraries are updated.

Also pip cache is now disabled.

In my local builds, the image size is reduced from 1.21 GB to 1.19 GB by this change.


# Contributions and Licensing

- [ X ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ X ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
