### PR TITLE
Fix api tests in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,8 +91,6 @@ ENV TZ=${TZ} \
     tzdata \
     gunicorn \
     python3-dateutil \
-    python3-flask \
-    python3-flask-cors \
     python3-gevent \
     python3-greenlet \
     python3-pip \

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -4,3 +4,5 @@ pygeofilter[backend-sqlalchemy]
 pygeoif
 pygeometa
 sodapy
+Flask>=2.2.0
+Flask-Cors


### PR DESCRIPTION
The tests have recently been rewritten to use `url_for`, which was changed in flask 2.2.0, so the tests don't pass in previous versions https://flask.palletsprojects.com/en/2.3.x/api/#flask.Flask.url_for

However the python3-flask package for ubuntu only features the ancient version 2.0.1-2ubuntu1.

Therefore this commit switches flask the install to pip, where recent verions are available

References https://github.com/geopython/pygeoapi/issues/1111

# Overview

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
