### PR TITLE
Case-insensitive headers for execute_process

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3548,9 +3548,7 @@ class API:
 
         try:
             execution_mode = RequestedProcessExecutionMode(
-                request.headers.get('Prefer',
-                    request.headers.get('prefer')
-                )
+                request.headers.get('Prefer', request.headers.get('prefer'))
             )
         except ValueError:
             execution_mode = None


### PR DESCRIPTION
# Overview
The [api.execute_process method](https://github.com/geopython/pygeoapi/blob/953b6fa74d2ce292d8f566c4f4d3bcb4161d6e95/pygeoapi/api.py#LL3549C9-L3553C34) uses the `Perfer` headers field to determine the execution_mode for the process. The current implementation uses a case sensitive `Perfer`, but headers fields are generally case insensitive. I found my client was sending the `prefer` field as lowercase, which resulted in my processes being run synchronously in spite of requesting async. This PR changes the default argument of the dict.get command for 'Prefer' to try looking up 'prefer' if it cannot find the capital version of the field in the headers dictionary, thus allowing either case to trigger asynchronous execution.

# Related Issue / Discussion

# Additional Information
See [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#section-5.1) on field names. 

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
