### PR TITLE
Remove usage of flask path parameters in process-related routes

### DIFF
--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -342,7 +342,7 @@ def collection_map(collection_id, style_id=None):
 
 
 @BLUEPRINT.route('/processes')
-@BLUEPRINT.route('/processes/<path:process_id>')
+@BLUEPRINT.route('/processes/<process_id>')
 def get_processes(process_id=None):
     """
     OGC API - Processes description endpoint
@@ -375,7 +375,7 @@ def get_jobs(job_id=None):
             return get_response(api_.get_jobs(request, job_id))
 
 
-@BLUEPRINT.route('/processes/<path:process_id>/execution', methods=['POST'])
+@BLUEPRINT.route('/processes/<process_id>/execution', methods=['POST'])
 def execute_process_jobs(process_id):
     """
     OGC API - Processes execution endpoint


### PR DESCRIPTION
# Overview
This PR removes the usage of [flask path converters](https://flask.palletsprojects.com/en/2.3.x/quickstart/#variable-rules) from process-related routes.

# Related Issue / Discussion
- fixes #1193 

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
