### PR TITLE
Return numberMatched if included in STA response

### DIFF
--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -249,9 +249,13 @@ class SensorThingsProvider(BaseProvider):
 
         # Make features
         response = self._get_response(url=self._url, params=params)
-        v = response.get('value')
+
+        matched = response.get('@iot.count')
+        if matched:
+            fc['numberMatched'] = matched
 
         # Query if values are less than expected
+        v = response.get('value')
         while len(v) < limit:
             try:
                 LOGGER.debug('Fetching next set of values')


### PR DESCRIPTION
# Overview
Attempt to return `@iot.count` in included in response. Including the query param `'$count' = 'true'` is costly on the SensorThings API endpoint when accessing the Observations entity collection. Some STA endpoints are including the count as a default as a way to avoid costly API requests.

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/1007

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
