### PR TITLE
fix(starlette_app): rename app -> APP in uvicorn.run call

### DIFF
--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -613,7 +613,7 @@ def serve(ctx, server=None, debug=False):
     if debug:
         log_level = 'debug'
     uvicorn.run(
-        "pygeoapi.starlette_app:app",
+        "pygeoapi.starlette_app:APP",
         reload=True,
         log_level=log_level,
         loop='asyncio',


### PR DESCRIPTION
# Overview
Rename `app` to `APP` in `uvicorn.run()` call inside the `serve` function so that `pygeoapi serve --starlette` does not throw an error.

# Additional Information
No additional information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
