### PR TITLE
Added conformance class for Mapbox Vector Tiles

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -142,7 +142,8 @@ CONFORMANCE = {
         'http://www.opengis.net/spec/ogcapi-maps-1/1.0/conf/core'
     ],
     'tile': [
-        'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core'
+        'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core',
+        'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt'
     ],
     'record': [
         'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/core',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -607,7 +607,7 @@ def test_conformance(config, api_):
 
     assert isinstance(root, dict)
     assert 'conformsTo' in root
-    assert len(root['conformsTo']) == 25
+    assert len(root['conformsTo']) == 26
     assert 'http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs' \
            in root['conformsTo']
 


### PR DESCRIPTION
# Overview

pygeoapi is [serving mvt as an encoding of OGC API Tiles](https://docs.pygeoapi.io/en/latest/data-publishing/ogcapi-tiles.html#providers). According to the [standard](https://docs.ogc.org/is/20-057/20-057.html#toc12), we can advertise the `mvt` conformance class at the conformance declaration.

# Additional Information
OGC API Tiles - Part 1 Core: https://docs.ogc.org/is/20-057/20-057.html

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
