### PR TITLE
fix tile link relations (#1262)

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1130,6 +1130,13 @@ class API:
 
             try:
                 tile = get_provider_by_type(v['providers'], 'tile')
+                p = load_plugin('provider', tile)
+            except ProviderConnectionError:
+                msg = 'connection error (check logs)'
+                return self.get_exception(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    headers, request.format,
+                    'NoApplicableCode', msg)
             except ProviderTypeError:
                 tile = None
 
@@ -1138,13 +1145,13 @@ class API:
                 LOGGER.debug('Adding tile links')
                 collection['links'].append({
                     'type': FORMAT_TYPES[F_JSON],
-                    'rel': 'tiles',
+                    'rel': f'http://www.opengis.net/def/rel/ogc/1.0/tilesets-{p.tile_type}',  # noqa
                     'title': 'Tiles as JSON',
                     'href': f'{self.get_collections_url()}/{k}/tiles?f={F_JSON}'  # noqa
                 })
                 collection['links'].append({
                     'type': FORMAT_TYPES[F_HTML],
-                    'rel': 'tiles',
+                    'rel': f'http://www.opengis.net/def/rel/ogc/1.0/tilesets-{p.tile_type}',  # noqa
                     'title': 'Tiles as HTML',
                     'href': f'{self.get_collections_url()}/{k}/tiles?f={F_HTML}'  # noqa
                 })

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -60,6 +60,9 @@ class MVTProvider(BaseTileProvider):
         """
 
         super().__init__(provider_def)
+
+        self.tile_type = 'vector'
+
         if is_url(self.data):
             url = urlparse(self.data)
             baseurl = f'{url.scheme}://{url.netloc}'

--- a/pygeoapi/provider/tile.py
+++ b/pygeoapi/provider/tile.py
@@ -53,6 +53,7 @@ class BaseTileProvider:
         self.format_type = provider_def['format']['name']
         self.mimetype = provider_def['format']['mimetype']
         self.options = provider_def.get('options')
+        self.tile_type = None
         self.fields = {}
 
     def get_layer(self):


### PR DESCRIPTION
# Overview
Fixes tile link relations by adding a `tile_type` (vector, coverage, map) to tile providers.

# Related Issue / Discussion
#1262 
# Additional Information
No additional configuration is required by the user.
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
