### PR TITLE
Added conformance classes for OGC API - Common - part 1

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -116,7 +116,11 @@ SYSTEM_LOCALE = l10n.Locale('en', 'US')
 CONFORMANCE = {
     'common': [
         'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core',
-        'http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections'
+        'http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections',
+        'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page',
+        'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json',
+        'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/html',
+        'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30'
     ],
     'feature': [
         'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -607,7 +607,7 @@ def test_conformance(config, api_):
 
     assert isinstance(root, dict)
     assert 'conformsTo' in root
-    assert len(root['conformsTo']) == 26
+    assert len(root['conformsTo']) == 30
     assert 'http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs' \
            in root['conformsTo']
 


### PR DESCRIPTION
# Overview

pygeoapi satisfies the following requirements of OGC API - Common - part 1 (Core):

- [Landing Page Requirement Class](https://docs.ogc.org/is/19-072/19-072.html#rc_landing-page-section)
- [Encoding Requirement Classes](https://docs.ogc.org/is/19-072/19-072.html#_0dcf8ce8-50bc-456a-a6e7-5a76d72e6f03), for JSON and HTML.
- [OpenAPI Requirement Class](https://docs.ogc.org/is/19-072/19-072.html#rc_oas30-section)

This PR adds these conformance classes to the list of conformance classes advertised by pygeoapi.

# Additional Information

OGC API - Common - Part 1: Core Standard: https://docs.ogc.org/is/19-072/19-072.html

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
