### PR TITLE
Improve tinydb locking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,7 @@ jobs:
         pytest tests/test_socrata_provider.py
         pytest tests/test_sqlite_geopackage_provider.py
         pytest tests/test_tinydb_catalogue_provider.py
+        pytest tests/test_tinydb_manager_for_parallel_requests.py
         pytest tests/test_util.py
         pytest tests/test_xarray_netcdf_provider.py
         pytest tests/test_xarray_zarr_provider.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ shapely<2.0
 SQLAlchemy<2.0.0
 tinydb
 unicodecsv
+filelock

--- a/tests/test_tinydb_manager_for_parallel_requests.py
+++ b/tests/test_tinydb_manager_for_parallel_requests.py
@@ -112,7 +112,7 @@ def test_async_hello_world_process_parallel(api_, config):
     query = Query()
     for process_out in processes_out.values():
         try:
-            assert process_out['http_status'] == 201
+            assert process_out['http_status'] == 200
             job_id = process_out['headers']['Location'].split('/')[-1]
             job_dict = db.search(query.identifier == job_id)[0]
             assert job_dict["identifier"] == job_id
@@ -120,7 +120,7 @@ def test_async_hello_world_process_parallel(api_, config):
             assert job_dict["mimetype"] == process_out['headers'][
                 'Content-Type']
             try:
-                with open(f'{index_name.parent()}/hello-world-{job_id}') as fh:
+                with open(f'{index_name.parent}/hello-world-{job_id}') as fh:
                     out_json = json.load(fh)
                     assert out_json["id"] == "echo"
                     assert out_json["value"] == "Hello World! Hello"


### PR DESCRIPTION
# Overview

The tests for parallel access sometimes failed with the previous
implementation. I'm currently not 100% sure why, but it might have
to do with the fact that the file is already created in the TinyDB
constructor which was not protected by a lock.

Also not protecting the reads can read to invalid reads in the case
when a read and a write happen simultaneously and the read catches
partially written data.

This implementation allows for fewer concurrency but is quite simple,
so we should be able to be confident about its safety.

Also the TinyDB manager is not intended for high performance and its
IO operations are orders of magnitude faster than requests over the
network or process executions anyway.



# Related Issue / Discussion
Fixes https://github.com/geopython/pygeoapi/issues/1258

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
