### PR TITLE
Avoid internal server error when no format requested in get_collection_item

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2362,17 +2362,20 @@ class API:
             'href': f'{self.get_collections_url()}/{dataset}'
         }])
 
+        link_request_format = (
+            request.format if request.format is not None else F_JSON
+        )
         if 'prev' in content:
             content['links'].append({
                 'rel': 'prev',
-                'type': FORMAT_TYPES[request.format],
-                'href': f"{self.get_collections_url()}/{dataset}/items/{content['prev']}?f={request.format}"  # noqa
+                'type': FORMAT_TYPES[link_request_format],
+                'href': f"{self.get_collections_url()}/{dataset}/items/{content['prev']}?f={link_request_format}"  # noqa
             })
         if 'next' in content:
             content['links'].append({
                 'rel': 'next',
-                'type': FORMAT_TYPES[request.format],
-                'href': f"{self.get_collections_url()}/{dataset}/items/{content['next']}?f={request.format}"  # noqa
+                'type': FORMAT_TYPES[link_request_format],
+                'href': f"{self.get_collections_url()}/{dataset}/items/{content['next']}?f={link_request_format}"  # noqa
             })
 
         # Set response language to requested provider locale


### PR DESCRIPTION
# Overview

Previously, request.format was assumed to always be defined when generating `prev` and `next` links.

This commit changes this by using json as default format. This supports the use case of curl nicely, but we could also choose e.g. html.

This branch is not yet tested because I didn't manage to find/produce test data for single items which have next/previous links.


# Related Issue / Discussion

Fixes https://github.com/geopython/pygeoapi/issues/1272

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
