### PR TITLE
Removed empty key on docker-compose file

### DIFF
--- a/docker/examples/elastic/docker-compose.yml
+++ b/docker/examples/elastic/docker-compose.yml
@@ -62,9 +62,6 @@ services:
     ports:
       - 9300:9300
       - 9200:9200
-    environment:
-      # Enabling compatibility mode in ES
-      # https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/migration.html#migration-compat-mode
     volumes:
       - elastic_search_data:/usr/share/elasticsearch/data
 


### PR DESCRIPTION
# Overview

The empty key on docker-compose was generating a YAML error and causing the composition to fail.

```
ERROR: The Compose file './docker-compose.yml' is invalid because: services.elastic_search.environment contains an invalid type, it should be an object, or an array
(pygeoapi)
```

This section is legacy, from when we used the compatibility API of elastic.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
