### PR TITLE
Elasticsearch: raise error on empty wildcarded indices

### DIFF
--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -99,7 +99,7 @@ class ElasticsearchProvider(BaseProvider):
         """
 
         fields_ = {}
-        ii = self.es.indices.get(index=self.index_name)
+        ii = self.es.indices.get(index=self.index_name, allow_no_indices=False)
 
         LOGGER.debug(f'Response: {ii}')
         try:


### PR DESCRIPTION
# Overview
Force raise error on empty wildcard index match.
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
