### PR TITLE
Process manager now knows about existing processes

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -65,7 +65,7 @@ from pygeoapi.linked_data import (geojson2jsonld, jsonldify,
                                   jsonldify_collection)
 from pygeoapi.log import setup_logger
 from pygeoapi.process.base import ProcessorExecuteError
-from pygeoapi.process.manager import get_manager
+from pygeoapi.process.manager.base import get_manager
 from pygeoapi.plugin import load_plugin, PLUGINS
 from pygeoapi.provider.base import (
     ProviderGenericError, ProviderConnectionError, ProviderNotFoundError,

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -2,9 +2,11 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 # Authors: Francesco Bartoli <xbartolone@gmail.com>
+# Authors: Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
 #
 # Copyright (c) 2022 Tom Kralidis
 # Copyright (c) 2022 Francesco Bartoli
+# Copyright (c) 2023 Ricardo Garcia Silva
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -42,8 +44,9 @@ from jsonschema import validate as jsonschema_validate
 import yaml
 
 from pygeoapi import l10n
-from pygeoapi.plugin import load_plugin
 from pygeoapi.models.openapi import OAPIFormat
+from pygeoapi.plugin import load_plugin
+from pygeoapi.process.manager import get_manager
 from pygeoapi.provider.base import ProviderTypeError, SchemaType
 from pygeoapi.util import (filter_dict_by_key_value, get_provider_by_type,
                            filter_providers_by_type, to_json, yaml_load,
@@ -1104,9 +1107,9 @@ def get_oas_30(cfg):
             }
         }
 
-    processes = filter_dict_by_key_value(cfg['resources'], 'type', 'process')
+    process_manager = get_manager(cfg)
 
-    if processes:
+    if len(process_manager.processes) > 0:
         paths['/processes'] = {
             'get': {
                 'summary': 'Processes',
@@ -1124,7 +1127,7 @@ def get_oas_30(cfg):
         }
         LOGGER.debug('setting up processes')
 
-        for k, v in processes.items():
+        for k, v in process_manager.processes.items():
             if k.startswith('_'):
                 LOGGER.debug(f'Skipping hidden layer: {k}')
                 continue

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -46,7 +46,7 @@ import yaml
 from pygeoapi import l10n
 from pygeoapi.models.openapi import OAPIFormat
 from pygeoapi.plugin import load_plugin
-from pygeoapi.process.manager import get_manager
+from pygeoapi.process.manager.base import get_manager
 from pygeoapi.provider.base import ProviderTypeError, SchemaType
 from pygeoapi.util import (filter_dict_by_key_value, get_provider_by_type,
                            filter_providers_by_type, to_json, yaml_load,

--- a/pygeoapi/process/manager/__init__.py
+++ b/pygeoapi/process/manager/__init__.py
@@ -1,8 +1,10 @@
 # =================================================================
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
 #
 # Copyright (c) 2019 Tom Kralidis
+#           (c) 2023 Ricardo Garcia Silva
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -26,3 +28,36 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # =================================================================
+
+import logging
+from typing import Dict
+
+from pygeoapi.plugin import load_plugin
+from pygeoapi.process.manager.base import BaseManager
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_manager(config: Dict) -> BaseManager:
+    """Instantiate process manager from the supplied configuration.
+
+    :param config: pygeoapi configuration
+
+    :returns: The pygeoapi process manager object
+    """
+    manager_conf = config.get('server', {}).get(
+        'manager',
+        {
+            'name': 'Dummy',
+            'connection': None,
+            'output_dir': None
+        }
+    )
+    processes_conf = {}
+    for id_, resource_conf in config.get('resources', {}).items():
+        if resource_conf.get('type') == 'process':
+            processes_conf[id_] = resource_conf
+    manager_conf['processes'] = processes_conf
+    if manager_conf.get('name') == 'Dummy':
+        LOGGER.info('Starting dummy manager')
+    return load_plugin('process_manager', manager_conf)

--- a/pygeoapi/process/manager/__init__.py
+++ b/pygeoapi/process/manager/__init__.py
@@ -1,10 +1,8 @@
 # =================================================================
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
-#          Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
 #
 # Copyright (c) 2019 Tom Kralidis
-#           (c) 2023 Ricardo Garcia Silva
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -28,36 +26,3 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # =================================================================
-
-import logging
-from typing import Dict
-
-from pygeoapi.plugin import load_plugin
-from pygeoapi.process.manager.base import BaseManager
-
-LOGGER = logging.getLogger(__name__)
-
-
-def get_manager(config: Dict) -> BaseManager:
-    """Instantiate process manager from the supplied configuration.
-
-    :param config: pygeoapi configuration
-
-    :returns: The pygeoapi process manager object
-    """
-    manager_conf = config.get('server', {}).get(
-        'manager',
-        {
-            'name': 'Dummy',
-            'connection': None,
-            'output_dir': None
-        }
-    )
-    processes_conf = {}
-    for id_, resource_conf in config.get('resources', {}).items():
-        if resource_conf.get('type') == 'process':
-            processes_conf[id_] = resource_conf
-    manager_conf['processes'] = processes_conf
-    if manager_conf.get('name') == 'Dummy':
-        LOGGER.info('Starting dummy manager')
-    return load_plugin('process_manager', manager_conf)

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -27,12 +27,13 @@
 #
 # =================================================================
 
+import collections
 from datetime import datetime
 import json
 import logging
 from multiprocessing import dummy
 from pathlib import Path
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Dict, Tuple, Optional, OrderedDict
 import uuid
 
 from pygeoapi.util import (
@@ -48,6 +49,7 @@ LOGGER = logging.getLogger(__name__)
 
 class BaseManager:
     """generic Manager ABC"""
+    processes: OrderedDict[str, Dict]
 
     def __init__(self, manager_def: dict):
         """
@@ -65,6 +67,15 @@ class BaseManager:
 
         if self.output_dir is not None:
             self.output_dir = Path(self.output_dir)
+
+        # Note: There are two different things named OrderedDict here - one
+        # is coming from typing.OrderedDict (type annotation), the other is
+        # coming from collections.OrderedDict (actual type we want to use here)
+        # - this will not be needed anymore when pygeoapi moves to requiring
+        # Python 3.9 as the minimum supported Python version
+        self.processes = collections.OrderedDict()
+        for id_, process_conf in manager_def.get('processes', {}).items():
+            self.processes[id_] = dict(process_conf)
 
     def get_jobs(self, status: JobStatus = None) -> list:
         """

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 import pytest
 
-from pygeoapi.process.manager import get_manager
+from pygeoapi.process.manager.base import get_manager
 
 
 @pytest.fixture()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,31 @@
+from typing import Dict
+
+import pytest
+
+from pygeoapi.process.manager import get_manager
+
+
+@pytest.fixture()
+def config() -> Dict:
+    return {
+        'server': {
+            'manager': {
+                'name': 'TinyDB',
+                'output_dir': '/tmp',
+            }
+        },
+        'resources': {
+            'hello-world': {
+                'type': 'process',
+                'processor': {
+                    'name': 'HelloWorld'
+                }
+            }
+        }
+    }
+
+
+def test_get_manager(config):
+    manager = get_manager(config)
+    assert manager.name == config['server']['manager']['name']
+    assert 'hello-world' in manager.processes


### PR DESCRIPTION
# Overview

This PR makes the process manager aware of existing processes, as discussed in #1213.

It introduces two main changes:

- There is now a `processes` property on the `BaseManager` class. This property holds the configuration of known processes and can be referred to whenever there is a need to know which processes exist.

- The `get_manager()` function is introduced as the way to instantiate the process manager. This function accepts the main pygeoapi config dict as an input and is able to instantiate the process manager and provide it with the configuration of any processes defined in the config dict.

With this PR, the manager is responsible for letting the rest of pygeoapi codebase know which processes exist. The base implementation still reads processes from the main pygeoapi config file, but this is now an implementation detail, which means that custom managers could use an alternative method for specifying processes, if needed.

# Related Issue / Discussion

- fixes #1213 

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
