### PR TITLE
Process manager instantiates processor

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3512,8 +3512,6 @@ class API:
                 HTTPStatus.NOT_FOUND, headers,
                 request.format, 'NoSuchProcess', msg)
 
-        process = self.manager.get_processor(process_id)
-
         data = request.data
         if not data:
             # TODO not all processes require input, e.g. time-dependent or
@@ -3552,7 +3550,7 @@ class API:
         try:
             LOGGER.debug('Executing process')
             result = self.manager.execute_process(
-                process, data_dict, execution_mode=execution_mode)
+                process_id, data_dict, execution_mode=execution_mode)
             job_id, mime_type, outputs, status, additional_headers = result
             headers.update(additional_headers or {})
             headers['Location'] = f'{self.base_url}/jobs/{job_id}'

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3285,9 +3285,7 @@ class API:
                         'InvalidParameterValue', msg)
 
             for key in relevant_processes:
-                p = load_plugin(
-                    'process', self.manager.processes[key]['processor'])
-
+                p = self.manager.get_processor(key)
                 p2 = l10n.translate_struct(deepcopy(p.metadata),
                                            request.locale)
 
@@ -3514,8 +3512,7 @@ class API:
                 HTTPStatus.NOT_FOUND, headers,
                 request.format, 'NoSuchProcess', msg)
 
-        process = load_plugin('process',
-                              self.manager.processes[process_id]['processor'])
+        process = self.manager.get_processor(process_id)
 
         data = request.data
         if not data:

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -1132,8 +1132,7 @@ def get_oas_30(cfg):
                 LOGGER.debug(f'Skipping hidden layer: {k}')
                 continue
             name = l10n.translate(k, locale_)
-            p = load_plugin('process', v['processor'])
-
+            p = process_manager.get_processor(k)
             md_desc = l10n.translate(p.metadata['description'], locale_)
             process_name_path = f'/processes/{name}'
             tag = {

--- a/pygeoapi/process/manager/__init__.py
+++ b/pygeoapi/process/manager/__init__.py
@@ -1,8 +1,10 @@
 # =================================================================
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
 #
 # Copyright (c) 2019 Tom Kralidis
+#           (c) 2023 Ricardo Garcia Silva
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -26,3 +28,36 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # =================================================================
+
+import logging
+from typing import Dict
+
+from pygeoapi.plugin import load_plugin
+from pygeoapi.process.manager.base import BaseManager
+
+LOGGER = logging.getLogger(__name__)
+
+
+def get_manager(config: Dict) -> BaseManager:
+    """Instantiate process manager from the supplied configuration.
+
+    :param config: pygeoapi configuration
+
+    :returns: The pygeoapi process manager object
+    """
+    manager_conf = config.get('server', {}).get(
+        'manager',
+        {
+            'name': 'Dummy',
+            'connection': None,
+            'output_dir': None
+        }
+    )
+    processes_conf = {}
+    for id_, resource_conf in config.get('resources', {}).items():
+        if resource_conf.get('type') == 'process':
+            processes_conf[id_] = resource_conf
+    manager_conf['processes'] = processes_conf
+    if manager_conf.get('name') == 'Dummy':
+        LOGGER.info('Starting dummy manager')
+    return load_plugin('process_manager', manager_conf)

--- a/pygeoapi/process/manager/__init__.py
+++ b/pygeoapi/process/manager/__init__.py
@@ -1,10 +1,8 @@
 # =================================================================
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
-#          Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
 #
 # Copyright (c) 2019 Tom Kralidis
-#           (c) 2023 Ricardo Garcia Silva
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -28,36 +26,3 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # =================================================================
-
-import logging
-from typing import Dict
-
-from pygeoapi.plugin import load_plugin
-from pygeoapi.process.manager.base import BaseManager
-
-LOGGER = logging.getLogger(__name__)
-
-
-def get_manager(config: Dict) -> BaseManager:
-    """Instantiate process manager from the supplied configuration.
-
-    :param config: pygeoapi configuration
-
-    :returns: The pygeoapi process manager object
-    """
-    manager_conf = config.get('server', {}).get(
-        'manager',
-        {
-            'name': 'Dummy',
-            'connection': None,
-            'output_dir': None
-        }
-    )
-    processes_conf = {}
-    for id_, resource_conf in config.get('resources', {}).items():
-        if resource_conf.get('type') == 'process':
-            processes_conf[id_] = resource_conf
-    manager_conf['processes'] = processes_conf
-    if manager_conf.get('name') == 'Dummy':
-        LOGGER.info('Starting dummy manager')
-    return load_plugin('process_manager', manager_conf)

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -298,31 +298,34 @@ class BaseManager:
 
     def execute_process(
             self,
-            p: BaseProcessor,
+            process_id: str,
             data_dict: dict,
             execution_mode: Optional[RequestedProcessExecutionMode] = None
     ) -> Tuple[str, Any, JobStatus, Optional[Dict[str, str]]]:
         """
         Default process execution handler
 
-        :param p: `pygeoapi.process` object
+        :param process_id: process identifier
         :param data_dict: `dict` of data parameters
         :param execution_mode: `str` optionally specifying sync or async
         processing.
 
+        :raises: UnknownProcessError if the input process_id does not
+                 correspond to a known process
         :returns: tuple of job_id, MIME type, response payload, status and
                   optionally additional HTTP headers to include in the final
                   response
         """
 
         job_id = str(uuid.uuid1())
+        processor = self.get_processor(process_id)
         if execution_mode == RequestedProcessExecutionMode.respond_async:
+            job_control_options = processor.metadata.get(
+                'jobControlOptions', [])
             # client wants async - do we support it?
             process_supports_async = (
-                ProcessExecutionMode.async_execute.value in p.metadata.get(
-                    'jobControlOptions', []
+                ProcessExecutionMode.async_execute.value in job_control_options
                 )
-            )
             if self.is_async and process_supports_async:
                 LOGGER.debug('Asynchronous execution')
                 handler = self._execute_handler_async
@@ -350,7 +353,7 @@ class BaseManager:
             response_headers = None
         # TODO: handler's response could also be allowed to include more HTTP
         # headers
-        mime_type, outputs, status = handler(p, job_id, data_dict)
+        mime_type, outputs, status = handler(processor, job_id, data_dict)
         return job_id, mime_type, outputs, status, response_headers
 
     def __repr__(self):

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -80,6 +80,23 @@ class BaseManager:
         for id_, process_conf in manager_def.get('processes', {}).items():
             self.processes[id_] = dict(process_conf)
 
+    def get_processor(self, process_id: str) -> Optional[BaseProcessor]:
+        """Instantiate a processor.
+
+        :param process_id: Identifier of the process
+
+        :raise UnknownProcessError: if the processor cannot be created
+        :returns: instance of the processor
+        """
+
+        try:
+            process_conf = self.processes[process_id]
+        except KeyError as err:
+            raise UnknownProcessError(
+                'Invalid process identifier') from err
+        else:
+            return load_plugin('process', process_conf['processor'])
+
     def get_jobs(self, status: JobStatus = None) -> list:
         """
         Get process jobs, optionally filtered by status
@@ -338,6 +355,10 @@ class BaseManager:
 
     def __repr__(self):
         return f'<BaseManager> {self.name}'
+
+
+class UnknownProcessError(Exception):
+    pass
 
 
 def get_manager(config: Dict) -> BaseManager:

--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -31,7 +31,6 @@ import logging
 from typing import Any, Dict, Optional, Tuple
 import uuid
 
-from pygeoapi.process.base import BaseProcessor
 from pygeoapi.process.manager.base import BaseManager
 from pygeoapi.util import (
     RequestedProcessExecutionMode,
@@ -69,14 +68,14 @@ class DummyManager(BaseManager):
 
     def execute_process(
             self,
-            p: BaseProcessor,
+            process_id: str,
             data_dict: dict,
             execution_mode: Optional[RequestedProcessExecutionMode] = None
     ) -> Tuple[str, str, Any, JobStatus, Optional[Dict[str, str]]]:
         """
         Default process execution handler
 
-        :param p: `pygeoapi.process` object
+        :param process_id: process identifier
         :param data_dict: `dict` of data parameters
         :param execution_mode: requested execution mode
 
@@ -95,8 +94,9 @@ class DummyManager(BaseManager):
                 LOGGER.debug('Dummy manager does not support asynchronous')
                 LOGGER.debug('Forcing synchronous execution')
 
+        processor = self.get_processor(process_id)
         try:
-            jfmt, outputs = p.execute(data_dict)
+            jfmt, outputs = processor.execute(data_dict)
             current_status = JobStatus.successful
         except Exception as err:
             outputs = {

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,3 +1,31 @@
+# =================================================================
+#
+# Authors: Ricardo Garcia Silva <ricardo.garcia.silva@geobyond.it>
+#
+# Copyright (c) 2023 Ricardo Garcia Silva
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
 from typing import Dict
 
 import pytest

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -2,7 +2,10 @@ from typing import Dict
 
 import pytest
 
-from pygeoapi.process.manager.base import get_manager
+from pygeoapi.process.manager.base import (
+    get_manager,
+    UnknownProcessError,
+)
 
 
 @pytest.fixture()
@@ -29,3 +32,16 @@ def test_get_manager(config):
     manager = get_manager(config)
     assert manager.name == config['server']['manager']['name']
     assert 'hello-world' in manager.processes
+
+
+def test_get_processor(config):
+    manager = get_manager(config)
+    process_id = 'hello-world'
+    processor = manager.get_processor(process_id)
+    assert processor.metadata["id"] == process_id
+
+
+def test_get_processor_raises_exception(config):
+    manager = get_manager(config)
+    with pytest.raises(expected_exception=UnknownProcessError):
+        manager.get_processor('foo')

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,6 +1,6 @@
 # =================================================================
 #
-# Authors: Ricardo Garcia Silva <ricardo.garcia.silva@geobyond.it>
+# Authors: Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
 #
 # Copyright (c) 2023 Ricardo Garcia Silva
 #


### PR DESCRIPTION
# Overview

**NOTE: This PR builds upon #1277 - Please review it first**

This PR implements the `get_processor()` method on the `BaseManager` class, thus making the manager responsible for instantiating a processor, as discussed in #1201. The base manager still calls `load_plugin` internally, but this is now an implementation detail, which means that custom managers could use an alternative method for loading processes, if needed. 

# Related Issue / Discussion
- Fixes #1201 


# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
