### PR TITLE
Fixing error when retrieving the TMS in vector tiles that do not provide tilejson metadata

### DIFF
--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -54,7 +54,7 @@ This code block shows how to configure pygeoapi to read Mapbox vector tiles, fro
          data: tests/data/tiles/ne_110m_lakes  # local directory tree
          # data: http://localhost:9000/ne_110m_lakes/{z}/{x}/{y}.pbf # tiles stored on a MinIO bucket
          options:
-             metadata_format: raw # default | tilejson
+             metadata_format: default # default | tilejson
              zoom:
                  min: 0
                  max: 5
@@ -75,7 +75,7 @@ This code block shows how to configure pygeoapi to read Mapbox vector tiles, fro
          # if you don't use precision 0, you will be requesting for aggregations which are not supported in the 
          # free version of elastic
          options:
-             metadata_format: raw # default | tilejson
+             metadata_format: default # default | tilejson
              zoom:
                  min: 0
                  max: 5
@@ -94,6 +94,7 @@ This code block shows how to configure pygeoapi to read Mapbox vector tiles, fro
               name: MVT
               data: http://localhost:7800/public.ne_50m_admin_0_countries/{z}/{x}/{y}.pbf
               options:
+                metadata_format: default # default | tilejson
                 zoom:
                     min: 0
                     max: 16

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -257,11 +257,12 @@ class MVTProvider(BaseTileProvider):
         if is_url(self.data):
             url = urlparse(self.data)
             base_url = f'{url.scheme}://{url.netloc}'
-            with requests.Session() as session:
-                session.get(base_url)
-                resp = session.get(f'{base_url}/{layer}/metadata.json')
-                resp.raise_for_status()
-            metadata_json_content = resp.json()
+            if metadata_format == TilesMetadataFormat.TILEJSON:
+                with requests.Session() as session:
+                    session.get(base_url)
+                    resp = session.get(f'{base_url}/{layer}/metadata.json')
+                    resp.raise_for_status()
+                metadata_json_content = resp.json()
         else:
             if not isinstance(self.service_metadata_url, Path):
                 msg = f'Wrong data path configuration: {self.service_metadata_url}'  # noqa


### PR DESCRIPTION
# Overview
When generating the tiles metadata, pygeoapi is looking for a tilejson file. This happens, even when we don't use the `tilejson` metadata format.
Other tile providers like `elasticsearch` and `pg_tiles` do not provide a metadata.json file, and that is ok, because it is a tippecanoe specific thing. For that reason, we support a `default` metadata format.

# Related Issue / Discussion
This problem is summarized in this issue: https://github.com/geopython/pygeoapi/issues/1286 (#1)

# Additional Information
Now that the `default` metadata format is supported for any provider, we could get rid of the TilesMetadataFormat.NONE format.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
