### PR TITLE
Added TileMatrixSet definition to the tilesets response

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1147,6 +1147,7 @@ class API:
 
             if tile:
                 # TODO: translate
+
                 LOGGER.debug('Adding tile links')
                 collection['links'].append({
                     'type': FORMAT_TYPES[F_JSON],
@@ -2760,6 +2761,7 @@ class API:
                 'dataType': 'vector',
                 'links': []
             }
+            tile_matrix['links'].append(matrix.tileMatrixSetDefinition)
             tile_matrix['links'].append({
                 'type': FORMAT_TYPES[F_JSON],
                 'rel': request.get_linkrel(F_JSON),
@@ -2772,6 +2774,7 @@ class API:
                 'title': f'{dataset} - {matrix.tileMatrixSet} - {F_HTML}',
                 'href': f'{self.get_collections_url()}/{dataset}/tiles/{matrix.tileMatrixSet}?f={F_HTML}'  # noqa
             })
+
             tiles['tilesets'].append(tile_matrix)
 
         metadata_format = p.options['metadata_format']

--- a/pygeoapi/models/provider/base.py
+++ b/pygeoapi/models/provider/base.py
@@ -71,18 +71,33 @@ class TileMatrixSetEnumType(BaseModel):
     tileMatrixSet: str
     tileMatrixSetURI: str
     crs: str
+    tileMatrixSetDefinition: dict
 
 
 class TileMatrixSetEnum(Enum):
     WORLDCRS84QUAD = TileMatrixSetEnumType(
         tileMatrixSet="WorldCRS84Quad",
         tileMatrixSetURI="http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json",  # noqa
-        crs="http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+        crs="http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+        tileMatrixSetDefinition=
+            {
+                'type': 'application/json',
+                'rel': 'http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme',
+                'title': 'WorldCRS84QuadTileMatrixSet definition (as JSON)',
+                'href': 'https://raw.githubusercontent.com/opengeospatial/2D-Tile-Matrix-Set/master/registry/json/WorldCRS84Quad.json'  # authoritative TMS definition
+            }
         )
     WEBMERCATORQUAD = TileMatrixSetEnumType(
         tileMatrixSet="WebMercatorQuad",
         tileMatrixSetURI="http://schemas.opengis.net/tms/1.0/json/examples/WebMercatorQuad.json",  # noqa
-        crs="http://www.opengis.net/def/crs/EPSG/0/3857"
+        crs="http://www.opengis.net/def/crs/EPSG/0/3857",
+        tileMatrixSetDefinition=
+            {
+                'type': 'application/json',
+                'rel': 'http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme',
+                'title': 'WebMercatorQuadTileMatrixSet definition (as JSON)',
+                'href': 'https://raw.githubusercontent.com/opengeospatial/2D-Tile-Matrix-Set/master/registry/json/WebMercatorQuad.json'  # authoritative TMS definition
+            }
         )
 
 


### PR DESCRIPTION
Adding a TMS definition for `WorldCRS84Quad` and `WebMercatorQuad`.
Please note that as pygeoapi does not publish these definitions, I am using the ones from the OGC Naming Authority.

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/issues/1289

# Additional Information
OGC API - Tiles (Core): https://docs.ogc.org/is/20-057/20-057.html#toc32

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
