### PR TITLE
update main copyright statement (#1303)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright &copy; 2018-2023 Tom Kralidis
+Copyright &copy; 2018-2023 pygeoapi development team
 
 * * *
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -2,7 +2,7 @@ Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Source: https://github.com/geopython/pygeoapi
 
 Files: *
-Copyright: Copyright 2019 Tom Kralidis
+Copyright: Copyright 2018-2023 pygeoapi development team
 License: MIT
  Permission is hereby granted, free of charge, to any person
  obtaining a copy of this software and associated documentation

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,7 +100,7 @@ master_doc = 'index'
 # General information about the project.
 # General information about the project.
 project = 'pygeoapi'
-author = 'pygeoapi team'
+author = 'pygeoapi development team'
 license = 'This work is licensed under a Creative Commons Attribution 4.0 International License'  # noqa
 copyright = '2018-2023, ' + author + ' ' + license
 


### PR DESCRIPTION
# Overview
This PR sets the main copyright statements in `LICENSE.md` and `debian/copyright` to `pygeoapi development team`.
# Related Issue / Discussion
#1303
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
