### PR TITLE
Make sure that PostgreSQLProvider.get_fields returns valid json schem…

### DIFF
--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -82,7 +82,9 @@ class BaseProvider:
         """
         Get provider field information (names, types)
 
-        :returns: dict of fields
+        Example response: {'field1': 'string', 'field2': 'number'}}
+
+        :returns: dict of field names and their associated JSON Schema typess
         """
 
         raise NotImplementedError()

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -202,12 +202,14 @@ class PostgreSQLProvider(BaseProvider):
             try:
                 python_type = column_type.python_type
             except NotImplementedError:
+                LOGGER.warning(f"Unsupported column type {column_type}")
                 return default_value
             else:
-                return column_type_map.get(
-                    python_type,
-                    default_value,
-                )
+                try:
+                    return column_type_map[python_type]
+                except KeyError:
+                    LOGGER.warning(f"Unsupported column type {column_type}")
+                    return default_value
 
         return {
             str(column.name): {

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -191,24 +191,24 @@ class PostgreSQLProvider(BaseProvider):
         # string, number, integer, object, array, boolean, null,
         # https://json-schema.org/understanding-json-schema/reference/type.html
         column_type_map = {
-            str: "string",
-            float: "number",
-            int: "integer",
-            bool: "boolean",
+            str: 'string',
+            float: 'number',
+            int: 'integer',
+            bool: 'boolean',
         }
-        default_value = "string"
+        default_value = 'string'
 
         def _column_type_to_json_schema_type(column_type):
             try:
                 python_type = column_type.python_type
             except NotImplementedError:
-                LOGGER.warning(f"Unsupported column type {column_type}")
+                LOGGER.warning(f'Unsupported column type {column_type}')
                 return default_value
             else:
                 try:
                     return column_type_map[python_type]
                 except KeyError:
-                    LOGGER.warning(f"Unsupported column type {column_type}")
+                    LOGGER.warning(f'Unsupported column type {column_type}')
                     return default_value
 
         return {

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -308,18 +308,18 @@ def test_query_cql_properties_bbox_filters(config):
 def test_get_fields(config):
     # Arrange
     expected_fields = {
-        'blockage': {'type': 'VARCHAR(80)'},
-        'covered': {'type': 'VARCHAR(80)'},
-        'depth': {'type': 'VARCHAR(80)'},
-        'layer': {'type': 'VARCHAR(80)'},
-        'name': {'type': 'VARCHAR(80)'},
-        'natural': {'type': 'VARCHAR(80)'},
-        'osm_id': {'type': 'INTEGER'},
-        'tunnel': {'type': 'VARCHAR(80)'},
-        'water': {'type': 'VARCHAR(80)'},
-        'waterway': {'type': 'VARCHAR(80)'},
-        'width': {'type': 'VARCHAR(80)'},
-        'z_index': {'type': 'VARCHAR(80)'}
+        'blockage': {'type': 'string'},
+        'covered': {'type': 'string'},
+        'depth': {'type': 'string'},
+        'layer': {'type': 'string'},
+        'name': {'type': 'string'},
+        'natural': {'type': 'string'},
+        'osm_id': {'type': 'integer'},
+        'tunnel': {'type': 'string'},
+        'water': {'type': 'string'},
+        'waterway': {'type': 'string'},
+        'width': {'type': 'string'},
+        'z_index': {'type': 'string'}
     }
 
     # Act


### PR DESCRIPTION
…a types

# Overview

All relevant discussion should be in the issue here: https://github.com/geopython/pygeoapi/issues/1091

This PR makes sure that the postgres provider only provides valid types, however no validation for all get_fields methods has been implemented so far. 

# Related Issue / Discussion
#1091 
# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
