### PR TITLE
ogc api processes subscriber

### DIFF
--- a/docs/source/data-publishing/ogcapi-processes.rst
+++ b/docs/source/data-publishing/ogcapi-processes.rst
@@ -108,6 +108,12 @@ Processing examples
        -H "Prefer: respond-async"
        -d "{\"inputs\":{\"name\": \"hi there2\"}}"
 
+   # execute a job for the ``hello-world`` process with a success subscriber
+   curl -X POST http://localhost:5000/processes/hello-world/execution \
+       -H "Content-Type: application/json" \
+       -d "{\"inputs\":{\"name\": \"hi there2\"}, \
+            \"subscriber\": {\"successUri\": \"https://www.example.com/success\"}}"
+
 
 .. _`OGC API - Processes`: https://ogcapi.ogc.org/processes
 .. _`sample`: https://github.com/geopython/pygeoapi/blob/master/pygeoapi/process/hello_world.py

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -86,7 +86,7 @@ from pygeoapi.util import (dategetter, RequestedProcessExecutionMode,
                            TEMPLATES, to_json, get_api_rules, get_base_url,
                            get_crs_from_uri, get_supported_crs_list,
                            modify_pygeofilter, CrsTransformSpec,
-                           transform_bbox)
+                           transform_bbox, Subscriber)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -3490,6 +3490,13 @@ class API:
         data_dict = data.get('inputs', {})
         LOGGER.debug(data_dict)
 
+        subscriber_dict = data.get('subscriber', {})
+        subscriber = Subscriber(
+            successUri=subscriber_dict.get('successUri'),
+            inProgressUri=subscriber_dict.get('inProgressUri'),
+            failedUri=subscriber_dict.get('failedUri'),
+        )
+
         try:
             execution_mode = RequestedProcessExecutionMode(
                 request.headers.get('Prefer', request.headers.get('prefer'))
@@ -3499,7 +3506,11 @@ class API:
         try:
             LOGGER.debug('Executing process')
             result = self.manager.execute_process(
-                process_id, data_dict, execution_mode=execution_mode)
+                process_id,
+                data_dict,
+                execution_mode=execution_mode,
+                subscriber=subscriber,
+            )
             job_id, mime_type, outputs, status, additional_headers = result
             headers.update(additional_headers or {})
             headers['Location'] = f'{self.base_url}/jobs/{job_id}'

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3491,12 +3491,22 @@ class API:
         data_dict = data.get('inputs', {})
         LOGGER.debug(data_dict)
 
-        subscriber_dict = data.get('subscriber', {})
-        subscriber = Subscriber(
-            successUri=subscriber_dict.get('successUri'),
-            inProgressUri=subscriber_dict.get('inProgressUri'),
-            failedUri=subscriber_dict.get('failedUri'),
-        )
+        subscriber = None
+        subscriber_dict = data.get('subscriber')
+        if subscriber_dict:
+            try:
+                success_uri = subscriber_dict['successUri']
+            except KeyError:
+                return self.get_exception(
+                    HTTPStatus.BAD_REQUEST, headers, request.format,
+                    'MissingParameterValue', 'Missing successUri')
+            else:
+                subscriber = Subscriber(
+                    # NOTE: successUri is mandatory according to the standard
+                    successUri=success_uri,
+                    inProgressUri=subscriber_dict.get('inProgressUri'),
+                    failedUri=subscriber_dict.get('failedUri'),
+                )
 
         try:
             execution_mode = RequestedProcessExecutionMode(

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -174,6 +174,7 @@ CONFORMANCE = {
         'http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/core',
         'http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/json',
         'http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/oas30'
+        'http://www.opengis.net/spec/ogcapi-processes-1/1.0/conf/callback',
     ],
     'edr': [
         'http://www.opengis.net/spec/ogcapi-edr-1/1.0/conf/core'

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3503,9 +3503,9 @@ class API:
             else:
                 subscriber = Subscriber(
                     # NOTE: successUri is mandatory according to the standard
-                    successUri=success_uri,
-                    inProgressUri=subscriber_dict.get('inProgressUri'),
-                    failedUri=subscriber_dict.get('failedUri'),
+                    success_uri=success_uri,
+                    in_progress_uri=subscriber_dict.get('inProgressUri'),
+                    failed_uri=subscriber_dict.get('failedUri'),
                 )
 
         try:

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -182,7 +182,7 @@ class BaseManager:
 
     def _execute_handler_async(self, p: BaseProcessor, job_id: str,
                                data_dict: dict,
-                               subscriber: Optional[Subscriber],
+                               subscriber: Optional[Subscriber] = None,
                                ) -> Tuple[str, None, JobStatus]:
         """
         This private execution handler executes a process in a background
@@ -206,7 +206,7 @@ class BaseManager:
 
     def _execute_handler_sync(self, p: BaseProcessor, job_id: str,
                               data_dict: dict,
-                              subscriber: Optional[Subscriber],
+                              subscriber: Optional[Subscriber] = None,
                               ) -> Tuple[str, Any, JobStatus]:
         """
         Synchronous execution handler

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -348,6 +348,7 @@ class BaseManager:
         :param data_dict: `dict` of data parameters
         :param execution_mode: `str` optionally specifying sync or async
                                processing.
+        :param subscriber: `Subscriber` optionally specifying callback urls
 
         :raises UnknownProcessError: if the input process_id does not
                                      correspond to a known process

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -37,6 +37,7 @@ from multiprocessing import dummy
 from pathlib import Path
 from typing import Any, Dict, Tuple, Optional, OrderedDict
 import uuid
+
 import requests
 
 from pygeoapi.plugin import load_plugin

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -240,8 +240,8 @@ class BaseManager:
         }
 
         self.add_job(job_metadata)
-        if subscriber and subscriber.inProgressUri:
-            response = requests.post(subscriber.inProgressUri, json={})
+        if subscriber and subscriber.in_progress_uri:
+            response = requests.post(subscriber.in_progress_uri, json={})
             LOGGER.debug(
                 'In progress notification response: {response.status_code}'
             )
@@ -290,7 +290,7 @@ class BaseManager:
             self.update_job(job_id, job_update_metadata)
 
             if subscriber:
-                response = requests.post(subscriber.successUri, json=outputs)
+                response = requests.post(subscriber.success_uri, json=outputs)
                 LOGGER.debug(
                     f'Success notification response: {response.status_code}'
                 )
@@ -326,8 +326,8 @@ class BaseManager:
 
             self.update_job(job_id, job_metadata)
 
-            if subscriber and subscriber.failedUri:
-                response = requests.post(subscriber.failedUri, json={})
+            if subscriber and subscriber.failed_uri:
+                response = requests.post(subscriber.failed_uri, json={})
                 LOGGER.debug(
                     f'Failed notification response: {response.status_code}'
                 )

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -85,7 +85,7 @@ class BaseManager:
         for id_, process_conf in manager_def.get('processes', {}).items():
             self.processes[id_] = dict(process_conf)
 
-    def get_processor(self, process_id: str) -> Optional[BaseProcessor]:
+    def get_processor(self, process_id: str) -> BaseProcessor:
         """Instantiate a processor.
 
         :param process_id: Identifier of the process

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -289,7 +289,7 @@ class BaseManager:
 
             self.update_job(job_id, job_update_metadata)
 
-            if subscriber and subscriber.successUri:
+            if subscriber:
                 response = requests.post(subscriber.successUri, json=outputs)
                 LOGGER.debug(
                     f'Success notification response: {response.status_code}'

--- a/pygeoapi/process/manager/mongodb_.py
+++ b/pygeoapi/process/manager/mongodb_.py
@@ -45,6 +45,7 @@ class MongoDBManager(BaseManager):
     def __init__(self, manager_def):
         super().__init__(manager_def)
         self.is_async = True
+        self.supports_subscribing = True
 
     def _connect(self):
         try:

--- a/pygeoapi/process/manager/tinydb_.py
+++ b/pygeoapi/process/manager/tinydb_.py
@@ -61,6 +61,7 @@ class TinyDBManager(BaseManager):
 
         super().__init__(manager_def)
         self.is_async = True
+        self.supports_subscribing = True
 
     @contextmanager
     def _db(self):

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -591,6 +591,17 @@ class JobStatus(Enum):
     dismissed = 'dismissed'
 
 
+@dataclass(frozen=True)
+class Subscriber:
+    """Store subscriber urls as defined in:
+
+    https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/subscriber.yaml  # noqa
+    """
+    successUri: Optional[str]
+    inProgressUri: Optional[str]
+    failedUri: Optional[str]
+
+
 def read_data(path: Union[Path, str]) -> Union[bytes, str]:
     """
     helper function to read data (file or network)

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -597,9 +597,9 @@ class Subscriber:
 
     https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/subscriber.yaml  # noqa
     """
-    successUri: str
-    inProgressUri: Optional[str]
-    failedUri: Optional[str]
+    success_uri: str
+    in_progress_uri: Optional[str]
+    failed_uri: Optional[str]
 
 
 def read_data(path: Union[Path, str]) -> Union[bytes, str]:

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -597,7 +597,7 @@ class Subscriber:
 
     https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/subscriber.yaml  # noqa
     """
-    successUri: Optional[str]
+    successUri: str
     inProgressUri: Optional[str]
     failedUri: Optional[str]
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1744,9 +1744,9 @@ def test_execute_process(config, api_):
             'name': 'Test'
         },
         'subscriber': {
-            'successUri': 'invalid://example.com/success',
-            'inProgressUri': 'invalid://example.com/inProgress',
-            'failedUri': 'invalid://example.com/failed',
+            'successUri': 'https://example.com/success',
+            'inProgressUri': 'https://example.com/inProgress',
+            'failedUri': 'https://example.com/failed',
         }
     }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,6 +36,7 @@ import logging
 import time
 import gzip
 from http import HTTPStatus
+from unittest import mock
 
 from pyld import jsonld
 import pytest
@@ -1738,6 +1739,16 @@ def test_execute_process(config, api_):
             'name': None
         }
     }
+    req_body_7 = {
+        'inputs': {
+            'name': 'Test'
+        },
+        'subscriber': {
+            'successUri': 'invalid://example.com/success',
+            'inProgressUri': 'invalid://example.com/inProgress',
+            'failedUri': 'invalid://example.com/failed',
+        }
+    }
 
     cleanup_jobs = set()
 
@@ -1864,6 +1875,24 @@ def test_execute_process(config, api_):
     response = json.loads(response)
     assert isinstance(response, dict)
     assert code == HTTPStatus.CREATED
+
+    cleanup_jobs.add(tuple(['hello-world',
+                            rsp_headers['Location'].split('/')[-1]]))
+
+    req = mock_request(data=req_body_7)
+    with mock.patch(
+        'pygeoapi.process.manager.base.requests.post'
+    ) as post_mocker:
+        rsp_headers, code, response = api_.execute_process(req, 'hello-world')
+    assert code == HTTPStatus.OK
+    post_mocker.assert_any_call(
+        req_body_7['subscriber']['inProgressUri'], json={}
+    )
+    post_mocker.assert_any_call(
+        req_body_7['subscriber']['successUri'],
+        json={'id': 'echo', 'value': 'Hello Test!'}
+    )
+    assert post_mocker.call_count == 2
 
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))


### PR DESCRIPTION
# Overview

 Add support for OGC API Processes Subscriber

The subscription URLs are passed to the manager, which
then has to call them appropriately.

By default, managers have the attribute `supports_subscribing`
set to `False` in order to not break the API for these. The
subscriptions are only passed to if this is set to `True`

# Related Issue / Discussion

https://github.com/geopython/pygeoapi/issues/1285

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
