### PR TITLE
Add reference to CGS pygeoapi plugins

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -327,8 +327,10 @@ by downstream applications.
    `ogc-edc`_,Euro Data Cube,coverage provider atop the EDC API
    `nldi_xstool`_,United States Geological Survey,Water data processing
    `pygeometa-plugin`_,pygeometa project,pygeometa as a service
+   `cgs-plugins`_,Center for Geospatial Solutions,feature and processes plugins
 
 
+.. _`cgs-plugins`: https://github.com/cgs-earth/pygeoapi-plugins
 .. _`Cookiecutter`: https://github.com/audreyfeldroy/cookiecutter-pypackage
 .. _`msc-pygeoapi`: https://github.com/ECCC-MSC/msc-pygeoapi
 .. _`pygeoapi-kubernetes-papermill`: https://github.com/eurodatacube/pygeoapi-kubernetes-papermill


### PR DESCRIPTION
# Overview
Add reference in documentation to pygeoapi plugins developed and hosted outside of pygeoapi core

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
