### PR TITLE
Fix display of job parameters

### DIFF
--- a/pygeoapi/templates/jobs/job.html
+++ b/pygeoapi/templates/jobs/job.html
@@ -27,7 +27,8 @@
                 <pre id="job-parameters"></pre>
               </div>
               <script>
-                document.getElementById('job-parameters').innerHTML = JSON.stringify({{ data['jobs']['parameters']}}, undefined, 2);
+                var parameters = {{ data['jobs']['parameters'] | tojson }};
+                document.getElementById('job-parameters').innerHTML = JSON.stringify(JSON.parse(parameters), undefined, 2);
               </script>
               {% endif %}
               <div class="duration">


### PR DESCRIPTION

# Overview

Here we have JS code which parses the parameters
as json, so they must not be escaped.

I've noticed that right now, quotes are escaped as &#34; which makes it invalid json and you get a JS error

It's not 100% clear to me what caused this, but probably a jinja update or this change: 997a83530e1c1f614287b20d516ca6f87dd9d2bd

The implementation uses tojson from jinja which already has an `indent` parameter, but for some reason it didn't indent it, so this still uses indention in JS.


# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
