### PR TITLE
OGC API Coverage/RasterioProvider - Support for output formats other than native and covjson

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -327,8 +327,10 @@ by downstream applications.
    `ogc-edc`_,Euro Data Cube,coverage provider atop the EDC API
    `nldi_xstool`_,United States Geological Survey,Water data processing
    `pygeometa-plugin`_,pygeometa project,pygeometa as a service
+   `cgs-plugins`_,Center for Geospatial Solutions,feature and processes plugins
 
 
+.. _`cgs-plugins`: https://github.com/cgs-earth/pygeoapi-plugins
 .. _`Cookiecutter`: https://github.com/audreyfeldroy/cookiecutter-pypackage
 .. _`msc-pygeoapi`: https://github.com/ECCC-MSC/msc-pygeoapi
 .. _`pygeoapi-kubernetes-papermill`: https://github.com/eurodatacube/pygeoapi-kubernetes-papermill

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -909,11 +909,6 @@ class API:
             collection_data = get_provider_default(v['providers'])
             collection_data_type = collection_data['type']
 
-            collection_data_format = None
-
-            if 'format' in collection_data:
-                collection_data_format = collection_data['format']
-
             collection = {
                 'id': k,
                 'title': l10n.translate(v['title'], request.locale),
@@ -1098,16 +1093,9 @@ class API:
                 collection['links'].append({
                     'type': 'application/prs.coverage+json',
                     'rel': f'{OGC_RELTYPES_BASE}/coverage',
-                    'title': 'Coverage data',
+                    'title': 'Coverage data as CoverageJSON',
                     'href': f'{self.get_collections_url()}/{k}/coverage?f={F_JSON}'  # noqa
                 })
-                if collection_data_format is not None:
-                    collection['links'].append({
-                        'type': collection_data_format['mimetype'],
-                        'rel': f'{OGC_RELTYPES_BASE}/coverage',
-                        'title': f"Coverage data as {collection_data_format['name']}",  # noqa
-                        'href': f"{self.get_collections_url()}/{k}/coverage?f={collection_data_format['name']}"  # noqa
-                    })
                 if dataset is not None:
                     LOGGER.debug('Creating extended coverage metadata')
                     try:
@@ -1124,6 +1112,15 @@ class API:
                     except ProviderTypeError:
                         pass
                     else:
+                        for f in p.supported_output_formats:
+                            collection['links'].append(
+                                {
+                                 'type': p.get_format_mimetype(f),
+                                 'rel': f'{OGC_RELTYPES_BASE}/coverage',
+                                 'title': f'Coverage data as {f}',
+                                 'href': f'{self.get_collections_url()}/{k}/coverage?f={f}'  # noqa
+                                 }
+                            )
                         collection['crs'] = [p.crs]
                         collection['domainset'] = p.get_coverage_domainset()
                         collection['rangetype'] = p.get_coverage_rangetype()

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2417,7 +2417,6 @@ class API:
 
         query_args = {}
         format_ = F_JSON
-
         # Force response content type and language (en-US only) headers
         headers = request.get_response_headers(SYSTEM_LOCALE,
                                                FORMAT_TYPES[F_JSON],
@@ -2541,19 +2540,16 @@ class API:
                 HTTPStatus.INTERNAL_SERVER_ERROR, headers, format_,
                 'NoApplicableCode', msg)
 
-        mt = collection_def['format']['name']
-        if format_ == mt:  # native format
-            if p.filename is not None:
-                cd = f'attachment; filename="{p.filename}"'
-                headers['Content-Disposition'] = cd
-
-            headers['Content-Type'] = collection_def['format']['mimetype']
-            return headers, HTTPStatus.OK, data
-        elif format_ == F_JSON:
+        if format_ == F_JSON:
             headers['Content-Type'] = 'application/prs.coverage+json'
             return headers, HTTPStatus.OK, to_json(data, self.pretty_print)
-        else:
-            return self.get_format_exception(request)
+
+        if p.filename is not None:
+            cd = f'attachment; filename="{p.filename}"'
+            headers['Content-Disposition'] = cd
+
+        headers['Content-Type'] = p.get_format_mimetype(format_)
+        return headers, HTTPStatus.OK, data
 
     @gzip
     @pre_process

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -793,11 +793,17 @@ def get_oas_30(cfg):
 
         LOGGER.debug('setting up coverage endpoints')
         try:
-            load_plugin('provider', get_provider_by_type(
-                        collections[k]['providers'], 'coverage'))
+            cp = load_plugin('provider', get_provider_by_type(
+                             collections[k]['providers'], 'coverage'))
 
             coverage_path = f'{collection_name_path}/coverage'
 
+            output_formats = deepcopy(items_f)
+            output_formats['schema']['enum'].extend(
+                f.lower()
+                for f in cp.supported_output_formats
+                if f.lower() not in output_formats
+            )
             paths[coverage_path] = {
                 'get': {
                     'summary': f'Get {title} coverage',
@@ -805,7 +811,7 @@ def get_oas_30(cfg):
                     'tags': [name],
                     'operationId': f'get{name.capitalize()}Coverage',
                     'parameters': [
-                        items_f,
+                        output_formats,
                         items_l,
                         {'$ref': '#/components/parameters/bbox'},
                         {'$ref': '#/components/parameters/bbox-crs'},  # noqa

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -304,7 +304,7 @@ def get_oas_30(cfg):
             'f': {
                 'name': 'f',
                 'in': 'query',
-                'description': 'The optional f parameter indicates the output format which the server shall provide as part of the response document.  The default format is GeoJSON.',  # noqa
+                'description': 'The optional f parameter indicates the output format which the server shall provide as part of the response document.  The default format is JSON.',  # noqa
                 'required': False,
                 'schema': {
                     'type': 'string',
@@ -798,7 +798,10 @@ def get_oas_30(cfg):
 
             coverage_path = f'{collection_name_path}/coverage'
 
-            output_formats = deepcopy(items_f)
+            cov_f = deepcopy(oas['components']['parameters']['f'])
+            output_formats = deepcopy(cov_f)
+            cov_f['schema']['enum'] = ['json', 'html']
+            output_formats['schema']['enum'] = ['json']
             output_formats['schema']['enum'].extend(
                 f.lower()
                 for f in cp.supported_output_formats
@@ -834,7 +837,7 @@ def get_oas_30(cfg):
                     'tags': [name],
                     'operationId': f'get{name.capitalize()}CoverageDomainSet',
                     'parameters': [
-                        items_f,
+                        cov_f,
                         items_l
                     ],
                     'responses': {
@@ -855,7 +858,7 @@ def get_oas_30(cfg):
                     'tags': [name],
                     'operationId': f'get{name.capitalize()}CoverageRangeType',
                     'parameters': [
-                        items_f,
+                        cov_f,
                         items_l
                     ],
                     'responses': {

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -108,34 +108,37 @@ class BaseProvider:
                 self._supported_output_formats.append(f['name'])
         else:
             storage_format_config = provider_def.get('format', dict())
-            self._format_config = {
-                'storage': {
-                    'name': storage_format_config['name'],
-                    'mimetype': storage_format_config['mimetype'],
-                    'options': provider_def.get('options'),
-                },
-            }
-            self._supported_output_formats.append(
-                storage_format_config['name']
-            )
+            if storage_format_config:
+                fmt_name = storage_format_config['name']
+                self._format_config = {
+                    'storage': {
+                        'name': fmt_name,
+                        'mimetype': storage_format_config['mimetype'],
+                        'options': provider_def.get('options'),
+                    },
+                }
+
+                self._supported_output_formats.append(fmt_name)
+            else:
+                self._format_config = {'storage': dict()}
 
     @property
     def storage_format(self):
         """Get the name of the storage format
         """
-        return self._format_config['storage']['name']
+        return self._format_config['storage'].get('name')
 
     @property
     def options(self):
         """Get the options of the storage format
         """
-        return self._format_config['storage']['options']
+        return self._format_config['storage'].get('options')
 
     @property
     def mimetype(self):
         """Get the mimetype of the storage format
         """
-        return self._format_config['storage']['mimetype']
+        return self._format_config['storage'].get('mimetype')
 
     def get_format_options(self, fmt_name):
         """Get the options for a given output format
@@ -149,6 +152,8 @@ class BaseProvider:
 
     @property
     def supported_output_formats(self):
+        """Get the list of supported output formats
+        """
         return list(self._supported_output_formats)
 
     def get_fields(self):

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -103,21 +103,24 @@ class BaseProvider:
                     }
                 )
             for f in self._format_config['supported_output_formats']:
-                self._format_options[f['name']] = f['options']
-                self._format_mimetype[f['name']] = f['mimetype']
+                self._format_options[f['name'].lower()] = f['options']
+                self._format_mimetype[f['name'].lower()] = f['mimetype']
                 self._supported_output_formats.append(f['name'])
         else:
             storage_format_config = provider_def.get('format', dict())
             if storage_format_config:
                 fmt_name = storage_format_config['name']
+                fmt_mimetype = storage_format_config['mimetype']
+                fmt_options = provider_def.get('options')
                 self._format_config = {
                     'storage': {
                         'name': fmt_name,
-                        'mimetype': storage_format_config['mimetype'],
-                        'options': provider_def.get('options'),
+                        'mimetype': fmt_mimetype,
+                        'options': fmt_options,
                     },
                 }
-
+                self._format_mimetype[fmt_name.lower()] = fmt_mimetype
+                self._format_options[fmt_name.lower()] = fmt_options
                 self._supported_output_formats.append(fmt_name)
             else:
                 self._format_config = {'storage': dict()}
@@ -143,12 +146,12 @@ class BaseProvider:
     def get_format_options(self, fmt_name):
         """Get the options for a given output format
         """
-        return self._format_options[fmt_name]
+        return self._format_options[fmt_name.lower()]
 
     def get_format_mimetype(self, fmt_name):
         """Get the mimetype for a given output format
         """
-        return self._format_mimetype[fmt_name]
+        return self._format_mimetype[fmt_name.lower()]
 
     @property
     def supported_output_formats(self):

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -82,7 +82,9 @@ class BaseProvider:
         """
         Get provider field information (names, types)
 
-        :returns: dict of fields
+        Example response: {'field1': 'string', 'field2': 'number'}}
+
+        :returns: dict of field names and their associated JSON Schema typess
         """
 
         raise NotImplementedError()

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -187,13 +187,37 @@ class PostgreSQLProvider(BaseProvider):
         """
         LOGGER.debug('Get available fields/properties')
 
-        fields = {}
-        for column in self.table_model.__table__.columns:
-            fields[str(column.name)] = {'type': str(column.type)}
+        # sql-schema only allows these types, so we need to map from sqlalchemy
+        # string, number, integer, object, array, boolean, null,
+        # https://json-schema.org/understanding-json-schema/reference/type.html
+        column_type_map = {
+            str: 'string',
+            float: 'number',
+            int: 'integer',
+            bool: 'boolean',
+        }
+        default_value = 'string'
 
-        fields.pop(self.geom)  # Exclude geometry column
+        def _column_type_to_json_schema_type(column_type):
+            try:
+                python_type = column_type.python_type
+            except NotImplementedError:
+                LOGGER.warning(f'Unsupported column type {column_type}')
+                return default_value
+            else:
+                try:
+                    return column_type_map[python_type]
+                except KeyError:
+                    LOGGER.warning(f'Unsupported column type {column_type}')
+                    return default_value
 
-        return fields
+        return {
+            str(column.name): {
+                'type': _column_type_to_json_schema_type(column.type)
+            }
+            for column in self.table_model.__table__.columns
+            if column.name != self.geom  # Exclude geometry column
+        }
 
     def get(self, identifier, crs_transform_spec=None, **kwargs):
         """

--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -28,6 +28,7 @@
 # =================================================================
 
 import logging
+import math
 
 from pyproj import CRS, Transformer
 import rasterio
@@ -272,8 +273,8 @@ class RasterioProvider(BaseProvider):
                     out_profile[key] = value
 
             if bbox:  # spatial subset
-                row_start, col_start = src.index(minx, maxy)
-                row_stop, col_stop = src.index(maxx, miny)
+                row_start, col_start = src.index(minx, maxy, op=math.floor)
+                row_stop, col_stop = src.index(maxx, miny, op=math.ceil)
                 window = Window.from_slices(
                     (row_start, row_stop), (col_start, col_stop),
                 )
@@ -284,7 +285,6 @@ class RasterioProvider(BaseProvider):
                 except ValueError as err:
                     LOGGER.error(err)
                     raise ProviderQueryError(err)
-
                 out_profile.update(
                     {
                      'height': window.height,

--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -176,7 +176,7 @@ class RasterioProvider(BaseProvider):
         :returns: coverage data as dict of CoverageJSON or native format
         """
 
-        if format_.lower() not in (
+        if format_ != 'json' and format_.lower() not in (
             f.lower() for f in self.supported_output_formats
         ):
             msg = f'Invalid format: {format_}'

--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -272,7 +272,6 @@ class RasterioProvider(BaseProvider):
                     out_profile[key] = value
 
             if bbox:  # spatial subset
-                LOGGER.error(bbox)
                 row_start, col_start = src.index(minx, maxy)
                 row_stop, col_stop = src.index(maxx, miny)
                 window = Window.from_slices(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1464,8 +1464,8 @@ def test_get_collection_coverage(config, api_):
     assert code == HTTPStatus.OK
     content = json.loads(response)
 
-    assert content['domain']['axes']['x']['num'] == 34
-    assert content['domain']['axes']['y']['num'] == 34
+    assert content['domain']['axes']['x']['num'] == 35
+    assert content['domain']['axes']['y']['num'] == 35
     assert 'TMP' in content['parameters']
     assert 'TMP' in content['ranges']
     assert content['ranges']['TMP']['axisNames'] == ['y', 'x']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1464,8 +1464,8 @@ def test_get_collection_coverage(config, api_):
     assert code == HTTPStatus.OK
     content = json.loads(response)
 
-    assert content['domain']['axes']['x']['num'] == 35
-    assert content['domain']['axes']['y']['num'] == 35
+    assert content['domain']['axes']['x']['num'] == 34
+    assert content['domain']['axes']['y']['num'] == 34
     assert 'TMP' in content['parameters']
     assert 'TMP' in content['ranges']
     assert content['ranges']['TMP']['axisNames'] == ['y', 'x']

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -308,18 +308,18 @@ def test_query_cql_properties_bbox_filters(config):
 def test_get_fields(config):
     # Arrange
     expected_fields = {
-        'blockage': {'type': 'VARCHAR(80)'},
-        'covered': {'type': 'VARCHAR(80)'},
-        'depth': {'type': 'VARCHAR(80)'},
-        'layer': {'type': 'VARCHAR(80)'},
-        'name': {'type': 'VARCHAR(80)'},
-        'natural': {'type': 'VARCHAR(80)'},
-        'osm_id': {'type': 'INTEGER'},
-        'tunnel': {'type': 'VARCHAR(80)'},
-        'water': {'type': 'VARCHAR(80)'},
-        'waterway': {'type': 'VARCHAR(80)'},
-        'width': {'type': 'VARCHAR(80)'},
-        'z_index': {'type': 'VARCHAR(80)'}
+        'blockage': {'type': 'string'},
+        'covered': {'type': 'string'},
+        'depth': {'type': 'string'},
+        'layer': {'type': 'string'},
+        'name': {'type': 'string'},
+        'natural': {'type': 'string'},
+        'osm_id': {'type': 'integer'},
+        'tunnel': {'type': 'string'},
+        'water': {'type': 'string'},
+        'waterway': {'type': 'string'},
+        'width': {'type': 'string'},
+        'z_index': {'type': 'string'}
     }
 
     # Act

--- a/tests/test_rasterio_provider.py
+++ b/tests/test_rasterio_provider.py
@@ -140,21 +140,19 @@ def test_query_output_formats(config):
 
     # Check that output data are returned in the right format and that the
     # dataset values are identical for both queries
-    with (
-        MemoryFile(data_grib) as memfile_grib,
-        MemoryFile(data_gtiff) as memfile_gtiff
-    ):
+    with MemoryFile(data_grib) as memfile_grib:
         with memfile_grib.open() as dataset_grib:
             data_arr_grib = dataset_grib.read()
 
             assert dataset_grib.driver == 'GRIB'
 
+    with MemoryFile(data_gtiff) as memfile_gtiff:
         with memfile_gtiff.open() as dataset_gtiff:
             data_arr_gtiff = dataset_gtiff.read()
 
             assert dataset_gtiff.driver == 'GTiff'
 
-        assert (data_arr_grib == data_arr_gtiff).all()
+    assert (data_arr_grib == data_arr_gtiff).all()
 
     # Check that using unsupported formats as query parameter throws an error
     unsupported_formats = ['PNG', 'foo']

--- a/tests/test_rasterio_provider.py
+++ b/tests/test_rasterio_provider.py
@@ -28,9 +28,10 @@
 # =================================================================
 
 import pytest
-
 import pyproj
+from rasterio.io import MemoryFile
 
+from pygeoapi.provider.base import ProviderInvalidQueryError
 from pygeoapi.provider.rasterio_ import RasterioProvider
 from pygeoapi.util import get_transform_from_crs
 from .util import get_test_file_path
@@ -120,3 +121,43 @@ def test_query_bbox_reprojection(config):
     assert data['domain']['axes']['x']['stop'] == x_stop
     assert data['domain']['axes']['y']['start'] == y_start
     assert data['domain']['axes']['y']['stop'] == y_stop
+
+
+def test_query_output_formats(config):
+    """Test support for multiple output formats.
+    """
+    config['storage_format'] = config['format']
+    config['storage_format']['valid_output_format'] = True
+    config['storage_format']['options'] = config['options']
+    del config['options']
+    config['format'] = [{'name': 'GTiff', 'mimetype': 'image/tiff'}]
+    p = RasterioProvider(config)
+
+    # Query coverage dataset in two different formats (native and another
+    # supported output format)
+    data_grib = p.query(format_='GRIB')
+    data_gtiff = p.query(format_='GTiff')
+
+    # Check that output data are returned in the right format and that the
+    # dataset values are identical for both queries
+    with (
+        MemoryFile(data_grib) as memfile_grib,
+        MemoryFile(data_gtiff) as memfile_gtiff
+    ):
+        with memfile_grib.open() as dataset_grib:
+            data_arr_grib = dataset_grib.read()
+
+            assert dataset_grib.driver == 'GRIB'
+
+        with memfile_gtiff.open() as dataset_gtiff:
+            data_arr_gtiff = dataset_gtiff.read()
+
+            assert dataset_gtiff.driver == 'GTiff'
+
+        assert (data_arr_grib == data_arr_gtiff).all()
+
+    # Check that using unsupported formats as query parameter throws an error
+    unsupported_formats = ['PNG', 'foo']
+    for f in unsupported_formats:
+        with pytest.raises(ProviderInvalidQueryError):
+            p.query(format_=f)


### PR DESCRIPTION
# Overview
The `RasterioProvider` does not allow the end-user to request coverage data in another media type different from the native format of the dataset and CoverageJSON. Not all raster formats are *"compatible"* with each other (e.g. limits data types..), and not all [GDAL raster drivers](https://gdal.org/drivers/raster/index.html) support data creation in their corresponding formats. However, for compatible formats, it would be a nice feature for a service to support these encodings, when requested by the end-users. 

Another use case for such feature is for large datasets that are made of multiple files. Pygeoapi supports a one-to-one mapping between the provided collections and the data files. It is easy to build an index (e.g. VRT file) on multiple raster files. This index could be used as data source for a collection, representing the entire dataset. However, without the possibility to export the data in another format, the API would return the index itself, as mentioned in issue https://github.com/geopython/pygeoapi/issues/1251. Of course, one could argue that a OGC API Tiles service can be built on top of these coverages, but I still think it could be a handy feature to provide for pygeoapi's service administrators. In addition, there is no support coverage tiles yet.

This PR intends to give service administrators the possibility to configure which media types to support for export. Pygeoapi needs a way to identify what is the native format of the data source, whether to support this format or not for export (one does not need to send the end-user an index of the dataset, in addition, these indexes may expose paths to the data files, which may be unfortunate...), and which other data formats to support for export.

I propose to allow configuring a collection's provider as follows, inspired from the `storage_crs`/`crs` configuration for the **Feature** providers:

```yaml

- type: ...
  name: ...
  data: ...
  storage_format: # optional native format
      name: ... # still required
      mimetype: ... # still required
      valid_output_format: True/False # optional, default True
      # Note: options were moved inside the format block
      options: # optional options (i.e. GDAL creation)
          opt1_name: opt1_value
          opt2_name: opt2_value
          ...
  # list of other formats supported for export
  # optional
  format:
      # first additional format
      - name: ... # required
        mimetype: ... # required
        options: # optional options (i.e. GDAL creation)
            opt1_name: opt1_value
            opt2_name: opt2_value
            ...
      # second additional format
      - name: ... # required
        mimetype: ... # required
        options: # optional options (i.e. GDAL creation)
            opt1_name: opt1_value
            opt2_name: opt2_value
            ...
      ...
```
This opens for supporting such feature for other providers and collection types, if ever needed.

# Additional Information
- For the sake of  back compatibility, the PR should still support the current way of configuring a provider, with the `options`  field at the same level as the `format` field, and the `format` mapping representing the metadata for the native format when `storage_format` is missing.
- The service should inform the end-users which formats are supported the collection description.
-  For large datasets, one may need a way to configure the size limit of the requested data (window/subset), so that the server process does not run out of memory when a user request a large coverage subset. This may be the topic of another PR.
- This pull request adds changes from PR https://github.com/geopython/pygeoapi/pull/1218, to ease refactoring of test functions.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
