### PR TITLE
Added default parameter for Field function

### DIFF
--- a/pygeoapi/models/config.py
+++ b/pygeoapi/models/config.py
@@ -34,8 +34,11 @@ from pydantic import BaseModel, Field
 
 class APIRules(BaseModel):
     """ Pydantic model for API design rules that must be adhered to. """
-    api_version: str = Field(regex=r'^\d+\.\d+\..+$',
-                             description="Semantic API version number.")
+    api_version: str = Field(
+        "",
+        regex=r'^\d+\.\d+\..+$',
+        description="Semantic API version number."
+    )
     url_prefix: str = Field(
         "",
         description="If set, pygeoapi routes will be prepended with the "


### PR DESCRIPTION
# Overview

This pull request resolves the Python TypeError issue that occurs during the  pygeoapi openapi generate  step. The error is caused by a missing required positional argument  default  in the  Field()  function call. 

# Related Issue
https://github.com/geopython/pygeoapi/issues/1335

**Changes Made:** 
 
- Added the missing  default  argument to the  Field()  function call in the  pygeoapi/models/config.py  file. 
- Tested the solution on Ubuntu 22.04.1 LTS with Python 3.10.8. 

# Additional Information
 
- Followed the provided steps to reproduce the issue. 
- After applying the changes from this pull request, re-ran the  pygeoapi openapi generate  step. 
- Verified that the openAPI file was successfully generated without any errors. 

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute bugfix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
