### PR TITLE
Get bbox query parameter interactively

### DIFF
--- a/pygeoapi/templates/collections/collection.html
+++ b/pygeoapi/templates/collections/collection.html
@@ -8,8 +8,8 @@
 {% endblock %}
 
 {% block extrahead %}
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
-    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
+    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
 {% endblock %}
 
 {% block body %}
@@ -128,5 +128,71 @@
 
     map.addLayer(bbox_layer);
     map.fitBounds(bbox_layer.getBounds(), {maxZoom: 10});
+
+    // Allow to get bbox query parameter of a rectangular area specified by
+    // dragging the mouse while pressing the Ctrl key
+    var firstCorner;
+    var secondCorner;
+    var currentBoundingBox;
+    var boundingBox;
+    var drawingBoundingBox = false;
+
+    map.on('mousedown', setFirstCorner);
+    map.on('mouseup', setSecondCorner);
+    map.on('mousemove', drawCurrentBoundingBox);
+    map.on('click', boundingBoxInfo);
+
+    function boundingBoxInfo(e) {
+        if (map.hasLayer(boundingBox)) {
+            var bboxCoords = boundingBox.getBounds().toBBoxString();
+            L.popup({maxWidth:"auto"})
+            .setLatLng(boundingBox.getBounds().getCenter())
+            .setContent(`?bbox=${bboxCoords}`)
+            .addTo(map);
+        }
+    }
+
+    function setFirstCorner(e) {
+        if (e.originalEvent.ctrlKey) {
+            if (map.hasLayer(boundingBox)) {
+                map.removeLayer(boundingBox);
+            }
+            map.dragging.disable();
+            firstCorner = e.latlng;
+            drawingBoundingBox = true;
+        } else if (map.hasLayer(boundingBox) && !boundingBox.getBounds().contains(e.latlng)) {
+        map.removeLayer(boundingBox);
+        }
+    }
+
+    function setSecondCorner(e) {
+        if (map.hasLayer(currentBoundingBox)) {
+             map.removeLayer(currentBoundingBox);
+        }
+        if (e.originalEvent.ctrlKey) {
+            if (drawingBoundingBox) {
+                drawingBoundingBox = false;
+                secondCorner = e.latlng;
+                var bounds = [firstCorner, secondCorner];
+                boundingBox = L.rectangle(bounds, {color:"#ff7800", weight:1});
+                boundingBox.addTo(map);
+                var bboxCoords = boundingBox.getBounds().toBBoxString();
+            }
+        }
+        drawingBoundingBox = false;
+        map.dragging.enable();
+    }
+
+    function drawCurrentBoundingBox(e) {
+        if (drawingBoundingBox) {
+            if (map.hasLayer(currentBoundingBox)) {
+                map.removeLayer(currentBoundingBox);
+            }
+            secondCorner = e.latlng;
+            var bounds = [firstCorner, secondCorner];
+            currentBoundingBox = L.rectangle(bounds, {dashArray:"4 1", weight:0.4});
+            currentBoundingBox.addTo(map);
+        }
+    }
     </script>
 {% endblock %}

--- a/pygeoapi/templates/collections/collection.html
+++ b/pygeoapi/templates/collections/collection.html
@@ -176,7 +176,6 @@
                 var bounds = [firstCorner, secondCorner];
                 boundingBox = L.rectangle(bounds, {color:"#ff7800", weight:1});
                 boundingBox.addTo(map);
-                var bboxCoords = boundingBox.getBounds().toBBoxString();
             }
         }
         drawingBoundingBox = false;

--- a/pygeoapi/templates/collections/collection.html
+++ b/pygeoapi/templates/collections/collection.html
@@ -8,8 +8,8 @@
 {% endblock %}
 
 {% block extrahead %}
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css"/>
-    <script src="https://unpkg.com/leaflet@1.7.1/dist/leaflet.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
+    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
 {% endblock %}
 
 {% block body %}

--- a/pygeoapi/templates/collections/collection.html
+++ b/pygeoapi/templates/collections/collection.html
@@ -147,7 +147,7 @@
             var bboxCoords = boundingBox.getBounds().toBBoxString();
             L.popup({maxWidth:"auto"})
             .setLatLng(boundingBox.getBounds().getCenter())
-            .setContent(`?bbox=${bboxCoords}`)
+            .setContent(`bbox=${bboxCoords}`)
             .addTo(map);
         }
     }


### PR DESCRIPTION
# Overview

This PR implements a way for end-users to get interactively the `bbox` query parameter from a collection's HTML page. In order to get `bbox` coordinates, end-users can click and drag the mouse over a rectangular area of interest, while pressing the the `Ctrl` key. A popup appears with the `bbox` query parameter corresponding to the rectangular area drawn on the map. The popup's text can then be copied and pasted directly in the query URL.

# Additional Information

Several provider types may support an additional `bbox-crs` query parameter that specify which coordinate reference system the bbox's coordinates are in. In the [part 2 of the OGC API Features standard](https://docs.ogc.org/is/18-058r1/18-058r1.html#_parameter_bbox_crs), it says that "*If the bbox-crs parameter is not specified then the coordinate values of the bbox parameter SHALL be assumed to be in the default CRS specified in [OGC API - Feature - Part 1: Core](https://docs.ogc.org/is/18-058r1/18-058r1.html#OAFeat-1); that is http://www.opengis.net/def/crs/OGC/1.3/CRS84...*". It is likely that other OGC API standards will use the same assumption. This implementation allows to get interactively the `bbox` query parameter directly in the default CRS. The `bbox` can therefore be used without specifying any `bbox-crs`.
  
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
