### PR TITLE
Ensure OAProc id parity with resource name

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3294,6 +3294,7 @@ class API:
                 p = self.manager.get_processor(key)
                 p2 = l10n.translate_struct(deepcopy(p.metadata),
                                            request.locale)
+                p2['id'] = key
 
                 if process is None:
                     p2.pop('inputs')


### PR DESCRIPTION
# Overview
Ensure configured resource name is the same as the process id

# Related Issue / Discussion
Closes https://github.com/geopython/pygeoapi/issues/1345

# Additional Information
![image](https://github.com/geopython/pygeoapi/assets/40066515/782e20f8-71fa-4986-8ac4-c7bcdcd16160)
![image](https://github.com/geopython/pygeoapi/assets/40066515/9d138049-22cc-4e73-b525-5dfcc88a5223)

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
