### PR TITLE
GeoJSON schemas generation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,6 +136,7 @@ jobs:
         pytest tests/test_util.py
         pytest tests/test_xarray_netcdf_provider.py
         pytest tests/test_xarray_zarr_provider.py
+        pytest tests/test_models_geojson.py
     - name: build docs 🏗️
       run: cd docs && make html
     - name: failed tests 🚩

--- a/pygeoapi/models/geojson.py
+++ b/pygeoapi/models/geojson.py
@@ -29,11 +29,12 @@
 
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import (
     ConfigDict, create_model, conint, conlist, field_validator,
 )
+from typing_extensions import Literal
 
 from pygeoapi.models.validators import (
     geometry_collection_linear_rings_closed,

--- a/pygeoapi/models/geojson.py
+++ b/pygeoapi/models/geojson.py
@@ -31,7 +31,9 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import create_model, conint, conlist, field_validator
+from pydantic import (
+    ConfigDict, create_model, conint, conlist, field_validator,
+)
 
 from pygeoapi.models.validators import (
     geometry_collection_linear_rings_closed,
@@ -157,9 +159,10 @@ def create_geojson_geometry_model(
         return create_model(
             f'GeoJSON{geom_type}',
             type=(Literal[geom_type], ...),
-            geometries=(Union[tuple(geom_type_models)], ...),
+            geometries=(List[Union[tuple(geom_type_models)]], ...),
             bbox=(bbox_type, Optional),
             __validators__=validators,
+            __config__=ConfigDict(extra='forbid'),
         )
     return create_model(
         f'GeoJSON{geom_type}',
@@ -167,6 +170,7 @@ def create_geojson_geometry_model(
         coordinates=(coordinates_type, ...),
         bbox=(bbox_type, Optional),
         __validators__=validators,
+        __config__=ConfigDict(extra='forbid'),
     )
 
 
@@ -257,7 +261,9 @@ def create_geojson_feature_model(
                 default = Optional
             property_fields_def[prop.name] = (data_type, default)
         properties_model = create_model(
-            'FeaturePropertiesSchema', **property_fields_def,
+            'FeaturePropertiesSchema',
+            __config__=ConfigDict(extra='forbid'),
+            **property_fields_def,
         )
         properties_field_def = (properties_model, ...)
     return create_model(
@@ -268,6 +274,7 @@ def create_geojson_feature_model(
         properties=properties_field_def,
         bbox=(bbox_type, Optional),
         __validators__=validators,
+        __config__=ConfigDict(extra='forbid'),
     )
 
 
@@ -334,4 +341,5 @@ def create_geojson_feature_collection_model(
         features=(List[feature_model], ...),
         bbox=(bbox_type, Optional),
         __validators__=validators,
+        __config__=ConfigDict(extra='forbid'),
     )

--- a/pygeoapi/models/geojson.py
+++ b/pygeoapi/models/geojson.py
@@ -1,0 +1,189 @@
+# =================================================================
+#
+# Authors: Mathieu Tachon <tachon.mathieu@protonmail.com>
+#
+# Copyright (c) 2023 Mathieu Tachon
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+
+from dataclasses import dataclass
+from typing import Any, List, Literal, Optional, Union
+
+from pydantic import create_model, conint, conlist, field_validator
+
+
+GeomType = Literal[
+    'Point',
+    'LineString',
+    'Polygon',
+    'MultiPoint',
+    'MultiLineString',
+    'MultiPolygon',
+    'GeometryCollection',
+]
+
+
+def linear_ring_closed(cls, coordinates):
+    for ring in coordinates:
+        assert ring[0] == ring[-1], (
+            'First and and last position of linear ring must be the same'
+        )
+    return coordinates
+
+
+def multiple_linear_rings_closed(cls, coordinates):
+    for poly in coordinates:
+        linear_ring_closed(cls, poly)
+    return coordinates
+
+
+def create_GeoJSONGeometry_model(geom_type: GeomType, n_dims: conint(gt=1)):
+    validators = dict()
+    bbox_type = conlist(
+        item_type=float,
+        min_length=2 * n_dims,
+        max_length=2 * n_dims,
+    )
+    pt_coords = conlist(item_type=float, min_length=n_dims, max_length=n_dims)
+    ls_coords = conlist(item_type=pt_coords, min_length=2)
+    poly_coords = conlist(
+        item_type=conlist(item_type=pt_coords, min_length=4),
+        min_length=1,
+    )
+    if geom_type == 'Point':
+        coordinates_type = pt_coords
+    elif geom_type == 'LineString':
+        coordinates_type = ls_coords
+    elif geom_type == 'Polygon':
+        validators['polygon_coords_validator'] = field_validator('coordinates')(linear_ring_closed)  # noqa
+        coordinates_type = poly_coords
+    elif geom_type == 'MultiPoint':
+        coordinates_type = conlist(item_type=pt_coords, min_length=1)
+    elif geom_type == 'MultiLineString':
+        coordinates_type = conlist(item_type=ls_coords, min_length=1)
+    elif geom_type == 'MultiPolygon':
+        validators['multipolygon_coords_validator'] = field_validator('coordinates')(multiple_linear_rings_closed)  # noqa
+        coordinates_type = conlist(item_type=poly_coords, min_length=1)
+    elif geom_type == 'GeometryCollection':
+        geom_type_models = list()
+        for gt in (
+            'Point',
+            'LineString',
+            'Polygon',
+            'MultiPoint',
+            'MultiLineString',
+            'MultiPolygon',
+        ):
+            geom_type_models.append(create_GeoJSONGeometry_model(gt, n_dims))
+        return create_model(
+            f'GeoJSON{geom_type}',
+            type=(Literal[geom_type], ...),
+            geometries=(Union[tuple(geom_type_models)], ...),
+            bbox=(bbox_type, Optional),
+        )
+    return create_model(
+        f'GeoJSON{geom_type}',
+        type=(Literal[geom_type], ...),
+        coordinates=(coordinates_type, ...),
+        bbox=(bbox_type, Optional),
+        __validators__=validators,
+    )
+
+
+# Records defining GeoJSON properties
+@dataclass
+class GeoJSONProperty:
+    name: str
+    dtype: Any  # must be JSON serializable
+    nullable: bool
+    required: bool
+
+
+def create_GeoJSONFeature_model(
+    properties: Optional[List[GeoJSONProperty]] = None,
+    geom_type: Optional[GeomType] = None,
+    geom_nullable: bool = True,
+    n_dims: conint(gt=1) = 2,
+):
+    bbox_type = conlist(
+        item_type=float,
+        min_length=2 * n_dims,
+        max_length=2 * n_dims,
+    )
+    if geom_type is None:
+        geom_field_def = (Optional[None], ...)
+    elif geom_nullable:
+        geojson_geom_model = create_GeoJSONGeometry_model(geom_type, n_dims)
+        geom_field_def = (Optional[geojson_geom_model], ...)
+    else:
+        geom_field_def = (create_GeoJSONGeometry_model(geom_type, n_dims), ...)
+    if properties is None:
+        properties_field_def = (Optional[None], ...)
+    else:
+        property_fields_def = dict()
+        for prop in properties:
+            if prop.nullable:
+                data_type = Optional[prop.dtype]
+            else:
+                data_type = prop.dtype
+            if prop.required:
+                default = ...
+            else:
+                default = Optional
+            property_fields_def[prop.name] = (data_type, default)
+        properties_model = create_model(
+            'FeaturePropertiesSchema', **property_fields_def,
+        )
+        properties_field_def = (properties_model, ...)
+    return create_model(
+        'GeoJSONFeature',
+        type=(Literal['Feature'], ...),
+        id=(Union[str, float], Optional),
+        geometry=geom_field_def,
+        properties=properties_field_def,
+        bbox=(bbox_type, Optional),
+    )
+
+
+def create_GeoJSONFeatureCollection_model(
+    properties: Optional[List[GeoJSONProperty]] = None,
+    geom_type: Optional[GeomType] = None,
+    geom_nullable: bool = True,
+    n_dims: conint(gt=1) = 2,
+):
+    bbox_type = conlist(
+        item_type=float,
+        min_length=2 * n_dims,
+        max_length=2 * n_dims,
+    )
+    feature_model = create_GeoJSONFeature_model(
+        properties, geom_type, geom_nullable, n_dims,
+    )
+    return create_model(
+        'GeoJSONFeatureCollection',
+        type=(Literal['FeatureCollection'], ...),
+        features=(List[feature_model], ...),
+        bbox=(bbox_type, Optional),
+    )

--- a/pygeoapi/models/geojson.py
+++ b/pygeoapi/models/geojson.py
@@ -161,7 +161,7 @@ def create_geojson_geometry_model(
             f'GeoJSON{geom_type}',
             type=(Literal[geom_type], ...),
             geometries=(List[Union[tuple(geom_type_models)]], ...),
-            bbox=(bbox_type, Optional),
+            bbox=(bbox_type, None),
             __validators__=validators,
             __config__=ConfigDict(extra='forbid'),
         )
@@ -169,7 +169,7 @@ def create_geojson_geometry_model(
         f'GeoJSON{geom_type}',
         type=(Literal[geom_type], ...),
         coordinates=(coordinates_type, ...),
-        bbox=(bbox_type, Optional),
+        bbox=(bbox_type, None),
         __validators__=validators,
         __config__=ConfigDict(extra='forbid'),
     )
@@ -239,7 +239,7 @@ def create_geojson_feature_model(
         validators['geometry_validator'] = field_validator('geometry')(feature_linear_rings_closed)  # noqa
     bbox_type = get_bbox_type(n_dims)
     if geom_type is None:
-        geom_field_def = (Optional[None], ...)
+        geom_field_def = (Literal[None], ...)
     elif geom_nullable:
         geojson_geom_model = create_geojson_geometry_model(geom_type, n_dims)
         geom_field_def = (Optional[geojson_geom_model], ...)
@@ -248,7 +248,7 @@ def create_geojson_feature_model(
             create_geojson_geometry_model(geom_type, n_dims), ...,
         )
     if properties is None:
-        properties_field_def = (Optional[None], ...)
+        properties_field_def = (Literal[None], ...)
     else:
         property_fields_def = dict()
         for prop in properties:
@@ -259,7 +259,7 @@ def create_geojson_feature_model(
             if prop.required:
                 default = ...
             else:
-                default = Optional
+                default = None
             property_fields_def[prop.name] = (data_type, default)
         properties_model = create_model(
             'FeaturePropertiesSchema',
@@ -270,10 +270,10 @@ def create_geojson_feature_model(
     return create_model(
         'GeoJSONFeature',
         type=(Literal['Feature'], ...),
-        id=(Union[str, float], Optional),
+        id=(Union[str, float], None),
         geometry=geom_field_def,
         properties=properties_field_def,
-        bbox=(bbox_type, Optional),
+        bbox=(bbox_type, None),
         __validators__=validators,
         __config__=ConfigDict(extra='forbid'),
     )
@@ -340,7 +340,7 @@ def create_geojson_feature_collection_model(
         'GeoJSONFeatureCollection',
         type=(Literal['FeatureCollection'], ...),
         features=(List[feature_model], ...),
-        bbox=(bbox_type, Optional),
+        bbox=(bbox_type, None),
         __validators__=validators,
         __config__=ConfigDict(extra='forbid'),
     )

--- a/pygeoapi/models/geojson.py
+++ b/pygeoapi/models/geojson.py
@@ -29,9 +29,18 @@
 
 
 from dataclasses import dataclass
-from typing import Any, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import create_model, conint, conlist, field_validator
+
+from pygeoapi.models.validators import (
+    geometry_collection_linear_rings_closed,
+    feature_linear_rings_closed,
+    feature_collection_linear_rings_closed,
+    format_model_field_validators,
+    multipolygon_linear_rings_closed,
+    polygon_linear_rings_closed,
+)
 
 
 # Types for GeoJSON Features' geometry
@@ -46,25 +55,25 @@ GeomType = Literal[
 ]
 
 
-def linear_ring_closed(cls, coordinates):
-    """Validator function that check whether a linear ring is closed or opened.
+def get_bbox_type(n_dims: conint(gt=1)):
+    """ Get data type for 'bbox' field.
+
+    :param n_dims: number of coordinate dimensions. Must be larger than 1.
+    :type n_dims: int
+
+    :returns: data type of the 'bbox'
+    :rtype: `typing._AnnotatedAlias`
     """
-    for ring in coordinates:
-        assert ring[0] == ring[-1], (
-            'First and and last position of linear ring must be the same'
-        )
-    return coordinates
+    return conlist(
+        item_type=float, min_length=2 * n_dims, max_length=2 * n_dims,
+    )
 
 
-def multiple_linear_rings_closed(cls, coordinates):
-    """Validator function that checks for closed/opened linear rings.
-    """
-    for poly in coordinates:
-        linear_ring_closed(cls, poly)
-    return coordinates
-
-
-def create_GeoJSONGeometry_model(geom_type: GeomType, n_dims: conint(gt=1)):
+def create_geojson_geometry_model(
+    geom_type: GeomType,
+    n_dims: conint(gt=1),
+    field_validators: Optional[Dict[str, Union[callable, None]]] = None,
+):
     """ Create a pydantic model for a GeoJSON Geometry.
 
     Generic function that creates dynamically a pydantic model for a GeoJSON
@@ -73,18 +82,35 @@ def create_GeoJSONGeometry_model(geom_type: GeomType, n_dims: conint(gt=1)):
     :param geom_type: type of GeoJSON geometry.
     :type geom_type: `GeomType`
     :param n_dims: number of dimensions of the GeoJSON Geometry's
-    coordinates. Must be larger than 1.
+        coordinates. Must be larger than 1.
     :type n_dims: int
+    :param field_validators: field validator functions. If this parameter is
+        passed a value different from `None`, it must be a `dict` which keys
+        are the field names of a GeoJSON Geometry to validate
+        (e.g. 'coordinates'), and which values are the validator functions for
+        the corresponding fields. The validator function must have a <Signature
+        (cls, field_value)> signature, and return the validated field value.
+    :type field_validators: `dict`
 
     :returns: pydantic model of GeoJSON Geometry
     :rtype: subclass of `pydantic.BaseModel`
+
+    .. note::
+        - If ``field_validators`` is not specified or set to `None`, the
+          geometry model for 'Polygon' and 'MultiPolygon' geometry types will
+          have default validators which ensure that linear rings in the
+          'coordinates' field are closed, as per the `GeoJSON Specification
+          (RFC 7946) <https://datatracker.ietf.org/doc/html/rfc7946>`_. The
+          same default validation will be applied to 'Polygon' and
+          'MultiPolygon' geometries inside a 'GeometryCollection'. If a
+          validator function is specified for a given field, it will override
+          the corresponding default validator function.
+        - The value of a key-value pair of the ``field_validators`` `dict` can
+          be set to `None` instead of a `callable` if one wants to deactivate
+          one of the default validators.
     """
-    validators = dict()
-    bbox_type = conlist(
-        item_type=float,
-        min_length=2 * n_dims,
-        max_length=2 * n_dims,
-    )
+    validators = format_model_field_validators(field_validators)
+    bbox_type = get_bbox_type(n_dims)
     pt_coords = conlist(item_type=float, min_length=n_dims, max_length=n_dims)
     ls_coords = conlist(item_type=pt_coords, min_length=2)
     poly_coords = conlist(
@@ -96,16 +122,20 @@ def create_GeoJSONGeometry_model(geom_type: GeomType, n_dims: conint(gt=1)):
     elif geom_type == 'LineString':
         coordinates_type = ls_coords
     elif geom_type == 'Polygon':
-        validators['polygon_coords_validator'] = field_validator('coordinates')(linear_ring_closed)  # noqa
+        if 'coordinates_validator' not in validators.keys():
+            validators['coordinates_validator'] = field_validator('coordinates')(polygon_linear_rings_closed)  # noqa
         coordinates_type = poly_coords
     elif geom_type == 'MultiPoint':
         coordinates_type = conlist(item_type=pt_coords, min_length=1)
     elif geom_type == 'MultiLineString':
         coordinates_type = conlist(item_type=ls_coords, min_length=1)
     elif geom_type == 'MultiPolygon':
-        validators['multipolygon_coords_validator'] = field_validator('coordinates')(multiple_linear_rings_closed)  # noqa
+        if 'coordinates_validator' not in validators.keys():
+            validators['coordinates_validator'] = field_validator('coordinates')(multipolygon_linear_rings_closed)  # noqa
         coordinates_type = conlist(item_type=poly_coords, min_length=1)
     elif geom_type == 'GeometryCollection':
+        if 'geometries_validator' not in validators.keys():
+            validators['geometries_validator'] = field_validator('geometries')(geometry_collection_linear_rings_closed)  # noqa
         geom_type_models = list()
         for gt in (
             'Point',
@@ -115,12 +145,21 @@ def create_GeoJSONGeometry_model(geom_type: GeomType, n_dims: conint(gt=1)):
             'MultiLineString',
             'MultiPolygon',
         ):
-            geom_type_models.append(create_GeoJSONGeometry_model(gt, n_dims))
+            geom_type_models.append(
+                create_geojson_geometry_model(
+                    gt,
+                    n_dims,
+                    # Deactivate default validator function for 'coordinates'
+                    # field of internal geometries
+                    field_validators={'coordinates': None},
+                )
+            )
         return create_model(
             f'GeoJSON{geom_type}',
             type=(Literal[geom_type], ...),
             geometries=(Union[tuple(geom_type_models)], ...),
             bbox=(bbox_type, Optional),
+            __validators__=validators,
         )
     return create_model(
         f'GeoJSON{geom_type}',
@@ -140,11 +179,12 @@ class GeoJSONProperty:
     required: bool
 
 
-def create_GeoJSONFeature_model(
+def create_geojson_feature_model(
     properties: Optional[List[GeoJSONProperty]] = None,
     geom_type: Optional[GeomType] = None,
     geom_nullable: bool = True,
     n_dims: conint(gt=1) = 2,
+    field_validators: Optional[Dict[str, Union[callable, None]]] = None,
 ):
     """ Create a pydantic model for a GeoJSON Feature.
 
@@ -162,28 +202,46 @@ def create_GeoJSONFeature_model(
     :param n_dims: number of dimensions of the coordinates of the feature's
         geometry. Must be larger than 1.
     :type n_dims: int, default: 2
+    :param field_validators: field validator functions. If this parameter is
+        passed a value different from `None`, it must be a `dict` which keys
+        are the field names of a GeoJSON Feature to validate
+        (e.g. 'geometry'), and which values are the validator functions for
+        the corresponding fields. The validator function must have a <Signature
+        (cls, field_value)> signature, and return the validated field value.
+    :type field_validators: `dict`
 
     :returns: pydantic model of GeoJSON Feature
     :rtype: subclass of `pydantic.BaseModel`
 
     .. note::
-        If ``properties`` and/or ``geom_type`` are not given/set to `None`, a
-        GeoJSON Feature object will only validate against the returned GeoJSON
-        Feature model if its 'properties' and/or 'geometry' members are set to
-        'null', respectively.
+        - If ``properties`` and/or ``geom_type`` are not given/set to `None`, a
+          GeoJSON Feature object will only validate against the returned
+          GeoJSON Feature model if its 'properties' and/or 'geometry' members
+          are set to 'null', respectively.
+        - If ``field_validators`` is not specified or set to `None`, the
+          'geometry' field has a default validator, which ensure that 'Polygon'
+          and 'MultiPolygon' geometries have closed linear rings, as per the
+          `GeoJSON Specification (RFC 7946)
+          <https://datatracker.ietf.org/doc/html/rfc7946>`_. If a validator
+          function is specified for the 'geometry' field, it will override the
+          corresponding default validator function.
+        - The value of the 'geometry' field validator can be set to `None`
+          instead of a `callable` if one wants to deactivate the default
+          validator.
     """
-    bbox_type = conlist(
-        item_type=float,
-        min_length=2 * n_dims,
-        max_length=2 * n_dims,
-    )
+    validators = format_model_field_validators(field_validators)
+    if 'geometry_validator' not in validators.keys():
+        validators['geometry_validator'] = field_validator('geometry')(feature_linear_rings_closed)  # noqa
+    bbox_type = get_bbox_type(n_dims)
     if geom_type is None:
         geom_field_def = (Optional[None], ...)
     elif geom_nullable:
-        geojson_geom_model = create_GeoJSONGeometry_model(geom_type, n_dims)
+        geojson_geom_model = create_geojson_geometry_model(geom_type, n_dims)
         geom_field_def = (Optional[geojson_geom_model], ...)
     else:
-        geom_field_def = (create_GeoJSONGeometry_model(geom_type, n_dims), ...)
+        geom_field_def = (
+            create_geojson_geometry_model(geom_type, n_dims), ...,
+        )
     if properties is None:
         properties_field_def = (Optional[None], ...)
     else:
@@ -209,14 +267,16 @@ def create_GeoJSONFeature_model(
         geometry=geom_field_def,
         properties=properties_field_def,
         bbox=(bbox_type, Optional),
+        __validators__=validators,
     )
 
 
-def create_GeoJSONFeatureCollection_model(
+def create_geojson_feature_collection_model(
     properties: Optional[List[GeoJSONProperty]] = None,
     geom_type: Optional[GeomType] = None,
     geom_nullable: bool = True,
     n_dims: conint(gt=1) = 2,
+    field_validators: Optional[Dict[str, Union[callable, None]]] = None,
 ):
     """ Create a pydantic model for a GeoJSON FeatureCollection.
 
@@ -234,22 +294,38 @@ def create_GeoJSONFeatureCollection_model(
     :param n_dims: number of dimensions of the coordinates of the features'
         geometry. Must be larger than 1.
     :type n_dims: int, default: 2
+    :param field_validators: field validator functions. If this parameter is
+        passed a value different from `None`, it must be a `dict` which keys
+        are the field names of a GeoJSON FeatureCollection to validate
+        (e.g. 'features'), and which values are the validator functions for
+        the corresponding fields. The validator function must have a <Signature
+        (cls, field_value)> signature, and return the validated field value.
+    :type field_validators: `dict`
 
     :returns: pydantic model of GeoJSON FeatureCollection
     :rtype: subclass of `pydantic.BaseModel`
 
     .. note::
-        If ``properties`` and/or ``geom_type`` are not given/set to `None`, a
-        GeoJSON FeatureCollection object will only validate against the
-        returned GeoJSON FeatureCollection model if all Features have their
-        'properties' and/or 'geometry' members set to 'null', respectively.
+        - If ``properties`` and/or ``geom_type`` are not given/set to `None`, a
+          GeoJSON FeatureCollection object will only validate against the
+          returned GeoJSON FeatureCollection model if all Features have their
+          'properties' and/or 'geometry' members set to 'null', respectively.
+        - If ``field_validators`` is not specified or set to `None`, the
+          'features' field has a default validator, which ensure that 'Polygon'
+          and 'MultiPolygon' geometries have closed linear rings, as per the
+          `GeoJSON Specification (RFC 7946)
+          <https://datatracker.ietf.org/doc/html/rfc7946>`_. If a validator
+          function is specified for the 'features' field, it will override the
+          corresponding default validator function.
+        - The value of the 'features' field validator can be set to `None`
+          instead of a `callable` if one wants to deactivate the default
+          validator.
     """
-    bbox_type = conlist(
-        item_type=float,
-        min_length=2 * n_dims,
-        max_length=2 * n_dims,
-    )
-    feature_model = create_GeoJSONFeature_model(
+    validators = format_model_field_validators(field_validators)
+    if 'features_validator' not in validators.keys():
+        validators['features_validator'] = field_validator('features')(feature_collection_linear_rings_closed)  # noqa
+    bbox_type = get_bbox_type(n_dims)
+    feature_model = create_geojson_feature_model(
         properties, geom_type, geom_nullable, n_dims,
     )
     return create_model(
@@ -257,4 +333,5 @@ def create_GeoJSONFeatureCollection_model(
         type=(Literal['FeatureCollection'], ...),
         features=(List[feature_model], ...),
         bbox=(bbox_type, Optional),
+        __validators__=validators,
     )

--- a/pygeoapi/models/geojson.py
+++ b/pygeoapi/models/geojson.py
@@ -34,6 +34,7 @@ from typing import Any, List, Literal, Optional, Union
 from pydantic import create_model, conint, conlist, field_validator
 
 
+# Types for GeoJSON Features' geometry
 GeomType = Literal[
     'Point',
     'LineString',
@@ -46,6 +47,8 @@ GeomType = Literal[
 
 
 def linear_ring_closed(cls, coordinates):
+    """Validator function that check whether a linear ring is closed or opened.
+    """
     for ring in coordinates:
         assert ring[0] == ring[-1], (
             'First and and last position of linear ring must be the same'
@@ -54,12 +57,28 @@ def linear_ring_closed(cls, coordinates):
 
 
 def multiple_linear_rings_closed(cls, coordinates):
+    """Validator function that checks for closed/opened linear rings.
+    """
     for poly in coordinates:
         linear_ring_closed(cls, poly)
     return coordinates
 
 
 def create_GeoJSONGeometry_model(geom_type: GeomType, n_dims: conint(gt=1)):
+    """ Create a pydantic model for a GeoJSON Geometry.
+
+    Generic function that creates dynamically a pydantic model for a GeoJSON
+    Geometry, based on a geometry type and a N number of coordinate dimensions.
+
+    :param geom_type: type of GeoJSON geometry.
+    :type geom_type: `GeomType`
+    :param n_dims: number of dimensions of the GeoJSON Geometry's
+    coordinates. Must be larger than 1.
+    :type n_dims: int
+
+    :returns: pydantic model of GeoJSON Geometry
+    :rtype: subclass of `pydantic.BaseModel`
+    """
     validators = dict()
     bbox_type = conlist(
         item_type=float,
@@ -127,6 +146,32 @@ def create_GeoJSONFeature_model(
     geom_nullable: bool = True,
     n_dims: conint(gt=1) = 2,
 ):
+    """ Create a pydantic model for a GeoJSON Feature.
+
+    Generic function that creates dynamically a pydantic model for a GeoJSON
+    Feature, based on a list of properties, a geometry type and a N number of
+    coordinate dimensions.
+
+    :param properties: list of feature's properties.
+    :type properties: list of `GeoJSONProperty` objects, optional
+    :param geom_type: type of GeoJSON geometry.
+    :type geom_type: `GeomType`, optional
+    :param geom_nullable: whether the geometry of the GeoJSON Feature can be
+        set to 'null'.
+    :type geom_nullable: bool, default: True
+    :param n_dims: number of dimensions of the coordinates of the feature's
+        geometry. Must be larger than 1.
+    :type n_dims: int, default: 2
+
+    :returns: pydantic model of GeoJSON Feature
+    :rtype: subclass of `pydantic.BaseModel`
+
+    .. note::
+        If ``properties`` and/or ``geom_type`` are not given/set to `None`, a
+        GeoJSON Feature object will only validate against the returned GeoJSON
+        Feature model if its 'properties' and/or 'geometry' members are set to
+        'null', respectively.
+    """
     bbox_type = conlist(
         item_type=float,
         min_length=2 * n_dims,
@@ -173,6 +218,32 @@ def create_GeoJSONFeatureCollection_model(
     geom_nullable: bool = True,
     n_dims: conint(gt=1) = 2,
 ):
+    """ Create a pydantic model for a GeoJSON FeatureCollection.
+
+    Generic function that creates dynamically a pydantic model for a GeoJSON
+    FeatureCollection, based on a list of properties, a geometry type and a N
+    number of coordinate dimensions.
+
+    :param properties: list of features' properties.
+    :type properties: list of `GeoJSONProperty` objects, optional
+    :param geom_type: type of GeoJSON geometry.
+    :type geom_type: `GeomType`, optional
+    :param geom_nullable: whether the geometry of the GeoJSON Features can be
+        set to 'null'.
+    :type geom_nullable: bool, default: True
+    :param n_dims: number of dimensions of the coordinates of the features'
+        geometry. Must be larger than 1.
+    :type n_dims: int, default: 2
+
+    :returns: pydantic model of GeoJSON FeatureCollection
+    :rtype: subclass of `pydantic.BaseModel`
+
+    .. note::
+        If ``properties`` and/or ``geom_type`` are not given/set to `None`, a
+        GeoJSON FeatureCollection object will only validate against the
+        returned GeoJSON FeatureCollection model if all Features have their
+        'properties' and/or 'geometry' members set to 'null', respectively.
+    """
     bbox_type = conlist(
         item_type=float,
         min_length=2 * n_dims,

--- a/pygeoapi/models/validators.py
+++ b/pygeoapi/models/validators.py
@@ -1,0 +1,123 @@
+# =================================================================
+#
+# Authors: Mathieu Tachon <tachon.mathieu@protonmail.com>
+#
+# Copyright (c) 2023 Mathieu Tachon
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+
+from typing import Dict, Optional, Union
+
+from pydantic import field_validator
+
+
+def format_model_field_validators(
+    field_validators: Optional[Dict[str, Union[callable, None]]] = None,
+):
+    """ Format the field validators for the pydantic models to create.
+
+    :param field_validators: field validator functions mapping. If this
+        parameter is passed a value different from `None`, it must be a `dict`
+        which keys are the field names of a given pydantic model to validate,
+        and which values are the validator functions for the corresponding
+        fields. The validator function must have a <Signature (cls,
+        field_value)> signature, and return the validated field value.
+    :type field_validators: `dict`
+
+    :returns: formatted field validators to pass to the __validators__
+        parameter of the :func:`pydantic.create_model` function.
+    :rtype: `dict`
+    """
+    validators = dict()
+    if field_validators is not None:
+        for f, v in field_validators.items():
+            if v is None:
+                # Always valid field and return unchanged
+                validators[f'{f}_validator'] = field_validator(f)(
+                    lambda cls, field_val: field_val
+                )
+            else:
+                validators[f'{f}_validator'] = field_validator(f)(v)
+    return validators
+
+
+def polygon_linear_rings_closed(cls, coordinates):
+    """Validator function that checks for closed/opened linear rings in a
+    polygon.
+    """
+    for ring in coordinates:
+        assert ring[0] == ring[-1], (
+            'First and and last position of linear ring must be the same'
+        )
+    return coordinates
+
+
+def multipolygon_linear_rings_closed(cls, coordinates):
+    """Validator function that checks for closed/opened linear rings in a
+    multipolygon.
+    """
+    for poly in coordinates:
+        polygon_linear_rings_closed(cls, poly)
+    return coordinates
+
+
+def geometry_collection_linear_rings_closed(cls, geometries):
+    """Validator function that checks for closed/opened linear rings in a
+    geometry collection.
+    """
+    for geom in geometries:
+        if geom.type == 'Polygon':
+            _ = polygon_linear_rings_closed(geom, geom.coordinates)
+        elif geom.type == 'MultiPolygon':
+            _ = multipolygon_linear_rings_closed(geom, geom.coordinates)
+    return geometries
+
+
+def feature_linear_rings_closed(cls, geometry):
+    """Validator function that checks for closed/opened linear rings in a
+    feature's geometry.
+    """
+    if geometry:  # Make sure that 'geometry' != 'null'/None
+        if geometry.type == 'Polygon':
+            _ = polygon_linear_rings_closed(geometry, geometry.coordinates)
+        elif geometry.type == 'MultiPolygon':
+            _ = multipolygon_linear_rings_closed(
+                geometry, geometry.coordinates,
+            )
+        elif geometry.type == 'GeometryCollection':
+            _ = geometry_collection_linear_rings_closed(
+                geometry, geometry.geometries,
+            )
+    return geometry
+
+
+def feature_collection_linear_rings_closed(cls, features):
+    """Validator function that checks for closed/opened linear rings in the
+    features' geometry of a feature collection.
+    """
+    if features:
+        for feature in features:
+            _ = feature_linear_rings_closed(feature, feature.geometry)
+    return features

--- a/pygeoapi/models/validators.py
+++ b/pygeoapi/models/validators.py
@@ -117,7 +117,6 @@ def feature_collection_linear_rings_closed(cls, features):
     """Validator function that checks for closed/opened linear rings in the
     features' geometry of a feature collection.
     """
-    if features:
-        for feature in features:
-            _ = feature_linear_rings_closed(feature, feature.geometry)
+    for feature in features:
+        _ = feature_linear_rings_closed(feature, feature.geometry)
     return features

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -47,7 +47,8 @@ from pygeoapi import l10n
 from pygeoapi.models.openapi import OAPIFormat
 from pygeoapi.plugin import load_plugin
 from pygeoapi.process.manager.base import get_manager
-from pygeoapi.provider.base import ProviderTypeError, SchemaType
+from pygeoapi.provider.base import ProviderTypeError
+from pygeoapi.schemas import SchemaType
 from pygeoapi.util import (filter_dict_by_key_value, get_provider_by_type,
                            filter_providers_by_type, to_json, yaml_load,
                            get_api_rules, get_base_url)

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -29,16 +29,11 @@
 
 import json
 import logging
-from enum import Enum
+
+from pygeoapi.schemas import SchemaType
+
 
 LOGGER = logging.getLogger(__name__)
-
-
-class SchemaType(Enum):
-    item = 'item'
-    create = 'create'
-    update = 'update'
-    replace = 'replace'
 
 
 class BaseProvider:

--- a/pygeoapi/schemas.py
+++ b/pygeoapi/schemas.py
@@ -63,10 +63,10 @@ def get_GeoJSONFeature_schema(
     :type geom_type: `GeomType`, optional
     :param geom_nullable: whether the geometry of the GeoJSON Feature can be
         set to 'null'.
-    :type geom_nullable: bool
+    :type geom_nullable: bool, default: True
     :param n_dims: number of dimensions of the coordinates of the feature's
-        geometry.
-    :type n_dims: int
+        geometry. Must be larger than 1.
+    :type n_dims: int, default: 2
 
     :returns: JSON schema of GeoJSON Feature.
     :rtype: dict
@@ -97,10 +97,10 @@ def get_GeoJSONFeatureCollection_schema(
     :type geom_type: `GeomType`, optional
     :param geom_nullable: whether the geometry of the GeoJSON Features can be
         set to 'null'.
-    :type geom_nullable: bool
+    :type geom_nullable: bool, default: True
     :param n_dims: number of dimensions of the coordinates of the features'
-        geometry.
-    :type n_dims: int
+        geometry. Must be larger than 1.
+    :type n_dims: int, default: 2
 
     :returns: JSON schema of GeoJSON FeatureCollection.
     :rtype: dict

--- a/pygeoapi/schemas.py
+++ b/pygeoapi/schemas.py
@@ -1,0 +1,117 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Mathieu Tachon <tachon.mathieu@protonmail.com>
+#
+# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2023 Mathieu Tachon
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import conint
+
+from pygeoapi.models.geojson import (
+    create_GeoJSONFeature_model, create_GeoJSONFeatureCollection_model,
+    GeoJSONProperty, GeomType,
+)
+
+
+# Enum of data schema types depending on request action
+class SchemaType(Enum):
+    item = 'item'
+    create = 'create'
+    update = 'update'
+    replace = 'replace'
+
+
+def get_GeoJSONFeature_schema(
+    properties: Optional[List[GeoJSONProperty]] = None,
+    geom_type: Optional[GeomType] = None,
+    geom_nullable: bool = True,
+    n_dims: conint(gt=1) = 2,
+) -> dict:
+    """Get JSON schema of GeoJSON Feature.
+
+    :param properties: list of feature's properties.
+    :type properties: list of `GeoJSONProperty` objects, optional
+    :param geom_type: type of GeoJSON geometry.
+    :type geom_type: `GeomType`, optional
+    :param geom_nullable: whether the geometry of the GeoJSON Feature can be
+        set to 'null'.
+    :type geom_nullable: bool
+    :param n_dims: number of dimensions of the coordinates of the feature's
+        geometry.
+    :type n_dims: int
+
+    :returns: JSON schema of GeoJSON Feature.
+    :rtype: dict
+
+    .. note::
+        If ``properties`` and/or ``geom_type`` are not given/set to `None`, a
+        GeoJSON Feature will only validate against the returned JSON schema if
+        its 'properties' and/or 'geometry' members are set to 'null',
+        respectively.
+    """
+    geojson_feature_model = create_GeoJSONFeature_model(
+        properties, geom_type, geom_nullable, n_dims,
+    )
+    return geojson_feature_model.model_json_schema()
+
+
+def get_GeoJSONFeatureCollection_schema(
+    properties: Optional[List[GeoJSONProperty]] = None,
+    geom_type: Optional[GeomType] = None,
+    geom_nullable: bool = True,
+    n_dims: conint(gt=1) = 2,
+) -> dict:
+    """Get JSON schema of GeoJSON FeatureCollection.
+
+    :param properties: list of features' properties.
+    :type properties: list of `GeoJSONProperty` objects, optional
+    :param geom_type: type of GeoJSON geometry.
+    :type geom_type: `GeomType`, optional
+    :param geom_nullable: whether the geometry of the GeoJSON Features can be
+        set to 'null'.
+    :type geom_nullable: bool
+    :param n_dims: number of dimensions of the coordinates of the features'
+        geometry.
+    :type n_dims: int
+
+    :returns: JSON schema of GeoJSON FeatureCollection.
+    :rtype: dict
+
+    .. note::
+        If ``properties`` and/or ``geom_type`` are not given/set to `None`, the
+        GeoJSON Features will only validate against the returned JSON schema if
+        their 'properties' and/or 'geometry' members are set to 'null',
+        respectively.
+    """
+    geojson_feature_collection_model = create_GeoJSONFeatureCollection_model(
+        properties, geom_type, geom_nullable, n_dims,
+    )
+    return geojson_feature_collection_model.model_json_schema()

--- a/pygeoapi/schemas.py
+++ b/pygeoapi/schemas.py
@@ -36,7 +36,7 @@ from typing import List, Optional
 from pydantic import conint
 
 from pygeoapi.models.geojson import (
-    create_GeoJSONFeature_model, create_GeoJSONFeatureCollection_model,
+    create_geojson_feature_model, create_geojson_feature_collection_model,
     GeoJSONProperty, GeomType,
 )
 
@@ -49,7 +49,7 @@ class SchemaType(Enum):
     replace = 'replace'
 
 
-def get_GeoJSONFeature_schema(
+def get_geojson_feature_schema(
     properties: Optional[List[GeoJSONProperty]] = None,
     geom_type: Optional[GeomType] = None,
     geom_nullable: bool = True,
@@ -77,13 +77,13 @@ def get_GeoJSONFeature_schema(
         its 'properties' and/or 'geometry' members are set to 'null',
         respectively.
     """
-    geojson_feature_model = create_GeoJSONFeature_model(
+    geojson_feature_model = create_geojson_feature_model(
         properties, geom_type, geom_nullable, n_dims,
     )
     return geojson_feature_model.model_json_schema()
 
 
-def get_GeoJSONFeatureCollection_schema(
+def get_geojson_feature_collection_schema(
     properties: Optional[List[GeoJSONProperty]] = None,
     geom_type: Optional[GeomType] = None,
     geom_nullable: bool = True,
@@ -111,7 +111,7 @@ def get_GeoJSONFeatureCollection_schema(
         their 'properties' and/or 'geometry' members are set to 'null',
         respectively.
     """
-    geojson_feature_collection_model = create_GeoJSONFeatureCollection_model(
+    geojson_feature_collection_model = create_geojson_feature_collection_model(
         properties, geom_type, geom_nullable, n_dims,
     )
     return geojson_feature_collection_model.model_json_schema()

--- a/tests/test_models_geojson.py
+++ b/tests/test_models_geojson.py
@@ -28,12 +28,18 @@
 # =================================================================
 
 
+import datetime as dt
 import itertools
 
 from pydantic import ValidationError
 import pytest
 
-from pygeoapi.models.geojson import create_geojson_geometry_model
+from pygeoapi.models.geojson import (
+    create_geojson_geometry_model,
+    # create_geojson_feature_model,
+    # create_geojson_feature_collection_model,
+    GeoJSONProperty,
+)
 
 
 @pytest.fixture
@@ -554,6 +560,102 @@ def test_create_geojson_geometry_model(
          ],
         }
     )
+
+
+@pytest.fixture
+def geojson_properties() -> list:
+    """Returns list of `GeoJSONProperty` to create the pydantic models"""
+    return [
+        GeoJSONProperty(
+            name='city', dtype=str, nullable=False, required=True,
+        ),
+        GeoJSONProperty(
+            name='population', dtype=int, nullable=False, required=False,
+        ),
+        GeoJSONProperty(
+            name='area', dtype=float, nullable=True, required=True,
+        ),
+        GeoJSONProperty(
+            name='db_datetime', dtype=dt.datetime, nullable=True, required=False,  # noqa
+        ),
+    ]
+
+
+@pytest.fixture
+def valid_features():
+    """Returns list of valid features"""
+    return [
+        {
+         'type': 'Feature',
+         'geometry': {'type': 'Point', 'coordinates': [48.856667, 2.352222]},
+         'properties': {
+             'city': 'Paris',
+             'population': 2_102_650,
+             'area': 2_853.5,
+             'db_datetime': dt.datetime(2023, 9, 19),
+         },
+        },
+        {
+         'type': 'Feature',
+         'geometry': {'type': 'Point', 'coordinates': [40.712778, -74.006111]},
+         'properties': {
+             'city': 'New York',
+             'population': 8_804_190,
+             'area': 1_223.59,
+             'db_datetime': dt.datetime(2023, 9, 10),
+         },
+        },
+        {
+         'type': 'Feature',
+         'geometry': {'type': 'Point', 'coordinates': [45.508889, -73.554167]},
+         'properties': {
+             'city': 'Montreal',
+             'population': 1_762_949,
+             'area': 431.50,
+             'db_datetime': dt.datetime(2023, 9, 10),
+         },
+        },
+        {
+         'type': 'Feature',
+         'geometry': {'type': 'Point', 'coordinates': [41.893333, 12.482778]},
+         'properties': {
+             'city': 'Rome',
+             'population': 4_342_212,
+             'area': 1_285,
+             'db_datetime': dt.datetime(2023, 9, 10),
+         },
+        },
+        {
+         'type': 'Feature',
+         'geometry': {'type': 'Point', 'coordinates': [52.372778, 4.893611]},
+         'properties': {
+             'city': 'Amsterdam',
+             'population': 1_459_402,
+             'area': 219.32,
+             'db_datetime': dt.datetime(2023, 9, 11),
+         },
+        },
+        {
+         'type': 'Feature',
+         'geometry': {'type': 'Point', 'coordinates': [37.984167, 23.728056]},
+         'properties': {
+             'city': 'Athens',
+             'population': 3_059_764,
+             'area': 412,
+             'db_datetime': dt.datetime(2023, 9, 12),
+         },
+        },
+        {
+         'type': 'Feature',
+         'geometry': {'type': 'Point', 'coordinates': [38.725278, -9.15]},
+         'properties': {
+             'city': 'Lisbon',
+             'population': 548_703,
+             'area': 100.05,
+             'db_datetime': dt.datetime(2023, 9, 13),
+         },
+        },
+    ]
 
 
 def test_create_geojson_feature_model():

--- a/tests/test_models_geojson.py
+++ b/tests/test_models_geojson.py
@@ -591,7 +591,7 @@ def valid_features():
          'properties': {
              'city': 'Paris',
              'population': 2_102_650,
-             'area': 2_853.5,
+             'area': None,
              'db_datetime': dt.datetime(2023, 9, 19),
          },
         },
@@ -600,7 +600,6 @@ def valid_features():
          'geometry': {'type': 'Point', 'coordinates': [40.712778, -74.006111]},
          'properties': {
              'city': 'New York',
-             'population': 8_804_190,
              'area': 1_223.59,
              'db_datetime': dt.datetime(2023, 9, 10),
          },
@@ -630,8 +629,7 @@ def valid_features():
          'geometry': {'type': 'Point', 'coordinates': [52.372778, 4.893611]},
          'properties': {
              'city': 'Amsterdam',
-             'population': 1_459_402,
-             'area': 219.32,
+             'area': None,
              'db_datetime': dt.datetime(2023, 9, 11),
          },
         },
@@ -642,7 +640,6 @@ def valid_features():
              'city': 'Athens',
              'population': 3_059_764,
              'area': 412,
-             'db_datetime': dt.datetime(2023, 9, 12),
          },
         },
         {
@@ -652,7 +649,7 @@ def valid_features():
              'city': 'Lisbon',
              'population': 548_703,
              'area': 100.05,
-             'db_datetime': dt.datetime(2023, 9, 13),
+             'db_datetime': None,
          },
         },
     ]

--- a/tests/test_models_geojson.py
+++ b/tests/test_models_geojson.py
@@ -1,0 +1,564 @@
+# =================================================================
+#
+# Authors: Mathieu Tachon <tachon.mathieu@protonmail.com>
+#
+# Copyright (c) 2023 Mathieu Tachon
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+
+import itertools
+
+from pydantic import ValidationError
+import pytest
+
+from pygeoapi.models.geojson import create_geojson_geometry_model
+
+
+@pytest.fixture
+def invalid_bboxes() -> list:
+    """Returns list of invalid bboxes"""
+    return [
+        [0, 1.0],
+        'wrong_type',
+    ]
+
+
+@pytest.fixture
+def invalid_points(invalid_bboxes) -> list:
+    """Returns list of invalid GeoJSON Points"""
+    invalid_points = [
+        {
+         'type': 'wrong_type',
+         'coordinates': [0.0, 0.0],
+        },
+        {
+         'type': 'Point',
+         'coordinates': [0.0, 0.0],
+         'wrong_field': 'blabla',
+        },
+        {
+         'type': 'Point',
+         # must be at least two dimensional
+         'coordinates': [0],
+        },
+        {
+         'type': 'Point',
+         'coordinates': [0.0, 0.0],
+         # mismatch between number of dimensions for the 'coordinates' and
+         # the'bbox' fields
+         'bbox': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        },
+    ]
+    invalid_points.extend(
+        {'type': 'Point', 'coordinates': [0.0, 0.0], 'bbox': bbox}
+        for bbox in invalid_bboxes
+    )
+
+    invalid_points.append(
+        {
+         'type': 'Point',
+         'coordinates': [0.0, 0.0],
+         'bbox': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        }
+    )
+    return invalid_points
+
+
+@pytest.fixture
+def invalid_linestrings(invalid_bboxes) -> list:
+    """Returns list of invalid GeoJSON LineStrings"""
+    invalid_linestrings = [
+        {
+         'type': 'wrong_type',
+         'coordinates': [[0.0, 0.0], [1.0, 1.0]],
+        },
+        {
+         'type': 'LineString',
+         'coordinates': [[0.0, 0.0], [1.0, 1.0]],
+         'wrong_field': 'blabla',
+        },
+        {
+         'type': 'LineString',
+         # must be at least two dimensional
+         'coordinates': [[0], [1]],
+        },
+        {
+         'type': 'LineString',
+         'coordinates': [[0.0, 0.0], [1.0, 1.0]],
+         # mismatch between number of dimensions for the 'coordinates' and
+         # the'bbox' fields
+         'bbox': [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        },
+    ]
+    invalid_linestrings.extend(
+        {
+         'type': 'LineString',
+         'coordinates': [[0.0, 0.0], [1.0, 1.0]],
+         'bbox': bbox,
+        }
+        for bbox in invalid_bboxes
+    )
+    return invalid_linestrings
+
+
+@pytest.fixture
+def invalid_polygons(invalid_bboxes) -> list:
+    """Returns list of invalid GeoJSON Polygons"""
+    invalid_polygons = [
+        {
+         'type': 'wrong_type',
+         'coordinates': [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]],
+        },
+        {
+         'type': 'Polygon',
+         'coordinates': [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]],
+         'wrong_field': 'blabla',
+        },
+        {
+         'type': 'Polygon',
+         # must be at least two dimensional
+         'coordinates': [[[0.0], [1.0], [2.0], [0.0]]],
+        },
+        {
+         'type': 'Polygon',
+         'coordinates': [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]],
+         # mismatch between number of dimensions for the 'coordinates' and
+         # the'bbox' fields
+         'bbox': [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        },
+        {
+         'type': 'Polygon',
+         # must be an array of at least four positions
+         'coordinates': [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]],
+        },
+    ]
+    invalid_polygons.extend(
+        {
+         'type': 'Polygon',
+         'coordinates': [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]],
+         'bbox': bbox,
+        }
+        for bbox in invalid_bboxes
+    )
+    invalid_polygons.append(
+        {
+         'type': 'Polygon',
+         # must have closed rings
+         'coordinates': [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.5, 1.0]]],
+        }
+    )
+    return invalid_polygons
+
+
+@pytest.fixture
+def invalid_multipoints(invalid_bboxes) -> list:
+    """Returns list of invalid GeoJSON MultiPoints"""
+    invalid_multipoints = [
+        {
+         'type': 'wrong_type',
+         'coordinates': [[0.0, 0.0]],
+        },
+        {
+         'type': 'MultiPoint',
+         'coordinates': [[0.0, 0.0]],
+         'wrong_field': 'blabla',
+        },
+        {
+         'type': 'MultiPoint',
+         'coordinates': [[0.0, 0.0]],
+         # mismatch between number of dimensions for the 'coordinates' and
+         # the'bbox' fields
+         'bbox': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        },
+        {
+         'type': 'MultiPoint',
+         # must be at least two dimensional
+         'coordinates': [[0]],
+        },
+    ]
+    invalid_multipoints.extend(
+        {
+         'type': 'MultiPoint',
+         'coordinates': [[0.0, 0.0], [1.0, 1.0]],
+         'bbox': bbox,
+        }
+        for bbox in invalid_bboxes
+    )
+    return invalid_multipoints
+
+
+@pytest.fixture
+def invalid_multilinestrings(invalid_bboxes) -> list:
+    """Returns list of invalid GeoJSON MultiLineStrings"""
+    invalid_multilinestrings = [
+        {
+         'type': 'wrong_type',
+         'coordinates': [[[0.0, 0.0], [1.0, 1.0]]],
+        },
+        {
+         'type': 'MultiLineString',
+         'coordinates': [[[0.0, 0.0], [1.0, 1.0]]],
+         'wrong_field': 'blabla',
+        },
+        {
+         'type': 'MultiLineString',
+         # must be at least two dimensional
+         'coordinates': [[[0], [1]]],
+        },
+        {
+         'type': 'MultiLineString',
+         'coordinates': [[[0.0, 0.0], [1.0, 1.0]]],
+         # mismatch between number of dimensions for the 'coordinates' and
+         # the'bbox' fields
+         'bbox': [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        },
+    ]
+    invalid_multilinestrings.extend(
+        {
+         'type': 'MultiLineString',
+         'coordinates': [[[0.0, 0.0], [1.0, 1.0]]],
+         'bbox': bbox,
+        }
+        for bbox in invalid_bboxes
+    )
+    return invalid_multilinestrings
+
+
+@pytest.fixture
+def invalid_multipolygons(invalid_polygons, invalid_bboxes) -> list:
+    """Returns list of invalid GeoJSON MultiPolygons"""
+    invalid_multipolygons = [
+        {
+         'type': 'wrong_type',
+         'coordinates': [[[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]]],
+        },
+        {
+         'type': 'MultiPolygon',
+         'coordinates': [[[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]]],
+         'wrong_field': 'blabla',
+        },
+        {
+         'type': 'MultiPolygon',
+         # must be at least two dimensional
+         'coordinates': [[[[0.0], [1.0], [2.0], [0.0]]]],
+        },
+        {
+         'type': 'MultiPolygon',
+         'coordinates': [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]],
+         # mismatch between number of dimensions for the 'coordinates' and
+         # the'bbox' fields
+         'bbox': [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        },
+    ]
+    invalid_multipolygons.extend(
+        {
+         'type': 'MultiPolygon',
+         'coordinates': [[[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]]],
+         'bbox': bbox,
+        }
+        for bbox in invalid_bboxes
+    )
+    return invalid_multipolygons
+
+
+@pytest.fixture
+def invalid_geometrycollections(
+    invalid_points,
+    invalid_linestrings,
+    invalid_polygons,
+    invalid_multipoints,
+    invalid_multilinestrings,
+    invalid_multipolygons,
+    invalid_bboxes,
+) -> list:
+    """Returns list of invalid GeoJSON GeometryCollections"""
+    invalid_geometrycollections = [
+        {
+         'type': 'wrong_type',
+         'geometries': [
+             {
+              'type': 'Point',
+              'coordinates': [0.0, 0.0],
+             }
+         ],
+        },
+        {
+         'type': 'GeometryCollection',
+         'geometries': [
+             {
+              'type': 'Point',
+              'coordinates': [0.0, 0.0],
+             }
+         ],
+         'wrong_field': 'blabla',
+        },
+        {
+         'type': 'GeometryCollection',
+         'geometries': [
+             {
+              'type': 'Point',
+              'coordinates': [0.0, 0.0],
+             }
+         ],
+         # mismatch between number of dimensions for the 'coordinates' of the
+         # GeoJSON Point and the'bbox' fields
+         'bbox': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        },
+    ]
+    invalid_geometrycollections.extend(
+        {
+         'type': 'GeometryCollection',
+         'geometries': [invalid_geom],
+        }
+        for invalid_geom in itertools.chain(
+            invalid_points,
+            invalid_linestrings,
+            invalid_polygons,
+            invalid_multipoints,
+            invalid_multilinestrings,
+            invalid_multipolygons,
+        )
+    )
+    invalid_geometrycollections.extend(
+        {
+         'type': 'GeometryCollection',
+         'geometries': [
+             {
+              'type': 'Point',
+              'coordinates': [0.0, 0.0],
+             }
+         ],
+         'bbox': bbox,
+        }
+        for bbox in invalid_bboxes
+    )
+    return invalid_geometrycollections
+
+
+def test_create_geojson_geometry_model(
+    invalid_points,
+    invalid_linestrings,
+    invalid_polygons,
+    invalid_multipoints,
+    invalid_multilinestrings,
+    invalid_multipolygons,
+    invalid_geometrycollections,
+):
+    """Test that pydantic models validate valid GeoJSON geometries and raises
+    ValidationError for invalid GeoJSON geometries.
+    """
+    PointModel2D = create_geojson_geometry_model('Point', 2)
+
+    valid_point = PointModel2D.model_validate(
+        {'type': 'Point', 'coordinates': [0.0, 0.0]}
+    )
+
+    for point in invalid_points:
+        with pytest.raises(ValidationError):
+            PointModel2D.model_validate(point)
+
+    PointModel3D = create_geojson_geometry_model('Point', 3)
+
+    valid_point3d = PointModel3D.model_validate(
+        {
+         'type': 'Point',
+         'coordinates': [0.0, 0.0, 0.0],
+         'bbox': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        }
+    )
+
+    LineStringModel2D = create_geojson_geometry_model('LineString', 2)
+
+    valid_linestring = LineStringModel2D.model_validate(
+        {'type': 'LineString', 'coordinates': [[0.0, 0.0], [1.0, 1.0]]}
+    )
+
+    for linestring in invalid_linestrings:
+        with pytest.raises(ValidationError):
+            LineStringModel2D.model_validate(linestring)
+
+    LineStringModel3D = create_geojson_geometry_model('LineString', 3)
+
+    valid_linestring3d = LineStringModel3D.model_validate(
+        {
+         'type': 'LineString',
+         'coordinates': [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+         'bbox': [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        }
+    )
+
+    PolygonModel2D = create_geojson_geometry_model('Polygon', 2)
+
+    valid_polygon = PolygonModel2D.model_validate(
+        {
+         'type': 'Polygon',
+         'coordinates': [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]],
+        }
+    )
+
+    for polygon in invalid_polygons:
+        with pytest.raises(ValidationError):
+            PolygonModel2D.model_validate(polygon)
+
+    PolygonModel3D = create_geojson_geometry_model('Polygon', 3)
+
+    valid_polygon3d = PolygonModel3D.model_validate(
+        {
+         'type': 'Polygon',
+         'coordinates': [
+             [
+              [0.0, 0.0, 0.0],
+              [1.0, 0.0, 0.5],
+              [1.0, 1.0, 1.0],
+              [0.0, 0.0, 0.0],
+             ]
+         ],
+         'bbox': [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        }
+    )
+
+    MultiPointModel2D = create_geojson_geometry_model('MultiPoint', 2)
+
+    valid_multipoint = MultiPointModel2D.model_validate(
+        {'type': 'MultiPoint', 'coordinates': [[0.0, 0.0]]}
+    )
+
+    for multipoint in invalid_multipoints:
+        with pytest.raises(ValidationError):
+            MultiPointModel2D.model_validate(multipoint)
+
+    MultiPointModel3D = create_geojson_geometry_model('MultiPoint', 3)
+
+    valid_multipoint3d = MultiPointModel3D.model_validate(
+        {
+         'type': 'MultiPoint',
+         'coordinates': [[0.0, 0.0, 0.0]],
+         'bbox': [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        }
+    )
+
+    MultiLineStringModel2D = create_geojson_geometry_model(
+        'MultiLineString', 2,
+    )
+
+    valid_multilinestring = MultiLineStringModel2D.model_validate(
+        {'type': 'MultiLineString', 'coordinates': [[[0.0, 0.0], [1.0, 1.0]]]}
+    )
+
+    for multilinestring in invalid_multilinestrings:
+        with pytest.raises(ValidationError):
+            MultiLineStringModel2D.model_validate(multilinestring)
+
+    MultiLineStringModel3D = create_geojson_geometry_model(
+        'MultiLineString', 3,
+    )
+
+    valid_multilinestring3d = MultiLineStringModel3D.model_validate(
+        {
+         'type': 'MultiLineString',
+         'coordinates': [[[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]],
+         'bbox': [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        }
+    )
+
+    MultiPolygonModel2D = create_geojson_geometry_model('MultiPolygon', 2)
+
+    valid_multipolygon = MultiPolygonModel2D.model_validate(
+        {
+         'type': 'MultiPolygon',
+         'coordinates': [[[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]]],
+        }
+    )
+
+    for multipolygon in invalid_multipolygons:
+        with pytest.raises(ValidationError):
+            MultiPolygonModel2D.model_validate(multipolygon)
+
+    MultiPolygonModel3D = create_geojson_geometry_model('MultiPolygon', 3)
+
+    valid_multipolygon3d = MultiPolygonModel3D.model_validate(
+        {
+         'type': 'MultiPolygon',
+         'coordinates': [
+             [
+              [
+               [0.0, 0.0, 0.0],
+               [1.0, 0.0, 0.5],
+               [1.0, 1.0, 1.0],
+               [0.0, 0.0, 0.0],
+              ],
+             ]
+         ],
+         'bbox': [0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        }
+    )
+
+    GeometryCollectionModel2D = create_geojson_geometry_model(
+        'GeometryCollection', 2,
+    )
+
+    _ = GeometryCollectionModel2D.model_validate(
+        {
+         'type': 'GeometryCollection',
+         'geometries': [
+             valid_point.model_dump(exclude_unset=True),
+             valid_linestring.model_dump(exclude_unset=True),
+             valid_polygon.model_dump(exclude_unset=True),
+             valid_multipoint.model_dump(exclude_unset=True),
+             valid_multilinestring.model_dump(exclude_unset=True),
+             valid_multipolygon.model_dump(exclude_unset=True),
+         ],
+        }
+    )
+
+    for geometrycollection in invalid_geometrycollections:
+        with pytest.raises(ValidationError):
+            GeometryCollectionModel2D.model_validate(geometrycollection)
+
+    GeometryCollectionModel3D = create_geojson_geometry_model(
+        'GeometryCollection', 3,
+    )
+
+    _ = GeometryCollectionModel3D.model_validate(
+        {
+         'type': 'GeometryCollection',
+         'geometries': [
+             valid_point3d.model_dump(exclude_unset=True),
+             valid_linestring3d.model_dump(exclude_unset=True),
+             valid_polygon3d.model_dump(exclude_unset=True),
+             valid_multipoint3d.model_dump(exclude_unset=True),
+             valid_multilinestring3d.model_dump(exclude_unset=True),
+             valid_multipolygon3d.model_dump(exclude_unset=True),
+         ],
+        }
+    )
+
+
+def test_create_geojson_feature_model():
+    pass
+
+
+def test_create_geojson_feature_collection_model():
+    pass


### PR DESCRIPTION
# Overview
This PR builds upon PR https://github.com/geopython/pygeoapi/pull/1022 , and intends to *provide a standard way*/*facilitate* the schema generation for providers, which publish GeoJSON data. It makes use of pydantic models, that can be used to generate the corresponding JSON schemas. Pydantic models can also help with validating incoming data (for transactions), beyond what JSON schemas allows for (e.g closed linear rings(s) for a valid `GeoJSON Polygon`, invalid geometry checks...) with custom validator functions.

Several helper functions are implemented, which can be used in the `get_schema()` method of providers:

`pygeoapi/models/geojson.py`:

- `create_geojson_geometry_model()`: creates a pydantic model for a *GeoJSON Geometry*
- `create_geojson_feature_model()`: creates a pydantic model for a *GeoJSON Feature*
- `create_geojson_feature_collection_model()`: creates a pydantic model for a *GeoJSON FeatureCollection*

**_NOTE:_** These helper functions return pydantic models which have default validator functions. These validator functions (defined in `pygeoapi/models/validators.py`) check that all GeoJSON geometries of type `Polygon` have closed linear rings in a GeoJSON `Geometry`/`Feature`/`FeatureCollection`. The validator functions are called when the `model_validate()` method of the output pydantic models are called, and can be overwritten with the `field_validators` parameter of the `create_geojson_geometry_model()`, `create_geojson_feature_model()` and `create_geojson_feature_collection_model()` functions.

`pygeoapi/schemas.py`:

- `get_geojson_feature_schema()`: creates the JSON schema for *GeoJSON Feature*
- `get_geojson_feature_collection_schema()`: creates the JSON schema for *GeoJSON FeatureCollection*

**_NOTE:_** These are shorthand function to directly create JSON schemas generated from pydantic models. They create the appropriate pydantic models by calling one of the functions from `pygeoapi/models/geojson.py`, and call their `model_json_schema()` method. In the schema generation process, default values are removed for `bbox` and `id` properties.

The following code shows how vector data providers can implement their `get_schema()` method:

```python

import datetime as dt

from pygeoapi.models.geojson import GeoJSONProperty
from pygeoapi.schemas import get_geojson_feature_schema


class MyProvider(BaseProvider):
    ...
    def get_schema():
        # Getting the fields here
        ...

        # Defining a list of GeoJSONProperty for the data published by the provider,
        # based on the field names and types obtained above
        # Note the use of the 'nullable' and 'required' parameters
        # The argument passed to 'dtype' must be a type supported by pydantic and JSON serializable
        geojson_properties = [
            GeoJSONProperty(
                name='city', dtype=str, nullable=False, required=True,
            ),
            GeoJSONProperty(
                name='population', dtype=int, nullable=False, required=False,
            ),
            GeoJSONProperty(
                name='area', dtype=float, nullable=True, required=True,
            ),
            GeoJSONProperty(
                name='db_datetime', dtype=dt.datetime, nullable=True, required=False,
            ),
        ]

        # Generate the JSON schema
        json_schema = get_geojson_feature_schema(
            properties=geojson_properties,
            geom_type='Point',
            # True/False affects how features will validate against the schema,
            # whether 'geometry' can be set to 'null' or not
            geom_nullable=False,
            n_dims=2,  # number of dimensions for 'bbox' and 'coordinates' fields
        )

        return {'application/geo+json', json_schema}
```
Ideally, the `get_fields()` method of providers could be extended so that it returns the list of GeoJSONProperty directly, or a custom `get_geojson_properties()` method could be used instead. Either should take care of the `nullable` and `required` parameters.

This PR also opens up for defining a `get_data_model(type_: Literal['Feature', 'FeatureCollection'])` abstract method in the `BaseProvider`, which can be implemented in providers. The `get_data_model()` would call one of the `create_geojson_feature_model()` or `create_geojson_feature_collection_model()` functions and return the appropriate pydantic models. For supporting feature transactions, the `model_validate()` method of the pydantic models can be called directly in `pygeoapi.api.manage_collection_item()` to validate/invalidate incoming data. The validation with pydantic models is more flexible and powerful than that of JSON schemas, as mentioned above.

# Related Issue / Discussion
- https://github.com/geopython/pygeoapi/pull/1022

# Additional Information
- The implementation uses Pydantic 2 syntax. Migration to pydantic v2 was implemented in https://github.com/geopython/pygeoapi/pull/1353.
- Using `geojson-pydantic` was considered. It does not seem to play well with pydantic v2 right now. In addition, dumping the JSON schema of a `geojson_pydantic.Feature` instance results in a valid JSON schema for a GeoJSON Feature in general, which cannot be used if we, for example, want to constrain a specific geometry type (e.g. `Point`), and let the end-users know which geometry type is expected through the OpenAPI document. If this changes and that we are willing to add another dependency to pygeoapi, we may refactor the code to use `geojson-pydantic`.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
