### PR TITLE
Add fsspec as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Babel
 click
 filelock
 Flask
+fsspec
 importlib_metadata
 jinja2
 jsonschema


### PR DESCRIPTION
# Overview
Add `fsspec` to `requirements.txt` which is needed by `XarrayProvider`

# Related Issue / Discussion
PR https://github.com/geopython/pygeoapi/pull/1235

# Additional Information
No additional information.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
