### PR TITLE
Refactor code base to make it work with pydantic v2

### DIFF
--- a/pygeoapi/models/config.py
+++ b/pygeoapi/models/config.py
@@ -34,7 +34,7 @@ from pydantic import BaseModel, Field
 
 class APIRules(BaseModel):
     """ Pydantic model for API design rules that must be adhered to. """
-    api_version: str = Field(regex=r'^\d+\.\d+\..+$',
+    api_version: str = Field(pattern=r'^\d+\.\d+\..+$',
                              description="Semantic API version number.")
     url_prefix: str = Field(
         "",
@@ -60,11 +60,11 @@ class APIRules(BaseModel):
         """ Returns a new APIRules instance for the current API version
         and configured rules. """
         obj = {
-            k: v for k, v in rules_config.items() if k in APIRules.__fields__
+            k: v for k, v in rules_config.items() if k in APIRules.model_fields
         }
         # Validation will fail if required `api_version` is missing
         # or if `api_version` is not a semantic version number
-        return APIRules.parse_obj(obj)
+        return APIRules.model_validate(obj)
 
     @property
     def response_headers(self) -> dict:

--- a/pygeoapi/models/cql.py
+++ b/pygeoapi/models/cql.py
@@ -33,14 +33,14 @@
 # =================================================================
 
 from datetime import date, datetime
-from enum import Enum
 from typing import Any, List, Optional, Union
+from typing_extensions import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
-class CQLModel(BaseModel):
-    __root__: 'Union[\n        ComparisonPredicate,\n        SpatialPredicate,\n        TemporalPredicate,\n        AndExpression\n    ]'
+class CQLModel(RootModel):
+    root: 'Union[\n        ComparisonPredicate,\n        SpatialPredicate,\n        TemporalPredicate,\n        AndExpression\n    ]'
 
 
 class AndExpression(BaseModel):
@@ -59,140 +59,116 @@ class PropertyRef(BaseModel):
     property: 'Optional[str]' = None
 
 
-class ScalarLiteral(BaseModel):
-    __root__: 'Union[str, float, bool]'
+class ScalarLiteral(RootModel):
+    root: 'Union[str, float, bool]'
 
 
-class Bbox(BaseModel):
-    __root__: 'List[float]'
+class Bbox(RootModel):
+    root: 'List[float]'
 
 
-class LineStringType(Enum):
-    LineString = 'LineString'
-
-
-class LinestringCoordinate(BaseModel):
-    __root__: 'List[Any]'
+class LinestringCoordinate(RootModel):
+    root: 'List[Any]'
 
 
 class Linestring(BaseModel):
-    type: 'LineStringType'
+    type: Literal['LineString']
     coordinates: 'List[LinestringCoordinate]' = Field(...)
     bbox: 'Optional[List[float]]' = Field(None)
 
 
-class MultiLineStringType(Enum):
-    MultiLineString = 'MultiLineString'
-
-
-class MultilineStringCoordinate(BaseModel):
-    __root__: 'List[Any]'
+class MultilineStringCoordinate(RootModel):
+    root: 'List[Any]'
 
 
 class Multilinestring(BaseModel):
-    type: 'MultiLineStringType'
+    type: Literal['MultiLineString']
     coordinates: 'List[List[MultilineStringCoordinate]]'
     bbox: 'Optional[List[float]]' = Field(None)
 
 
-class MultiPointType(Enum):
-    MultiPoint = 'MultiPoint'
-
-
 class Multipoint(BaseModel):
-    type: 'MultiPointType'
+    type: Literal['MultiPoint']
     coordinates: 'List[List[float]]'
     bbox: 'Optional[List[float]]' = Field(None)
 
 
-class MultiPolygonType(Enum):
-    MultiPolygon = 'MultiPolygon'
-
-
-class MultipolygonCoordinateItem(BaseModel):
-    __root__: 'List[Any]'
+class MultipolygonCoordinateItem(RootModel):
+    root: 'List[Any]'
 
 
 class Multipolygon(BaseModel):
-    type: 'MultiPolygonType'
+    type: Literal['MultiPolygon']
     coordinates: 'List[List[List[MultipolygonCoordinateItem]]]'
     bbox: 'Optional[List[float]]' = Field(None)
 
 
-class PointType(Enum):
-    Point = 'Point'
-
-
 class Point(BaseModel):
-    type: 'PointType'
+    type: Literal['Point']
     coordinates: 'List[float]' = Field(...)
     bbox: 'Optional[List[float]]' = Field(None)
 
 
-class PolygonType(Enum):
-    Polygon = 'Polygon'
-
-
-class PolygonCoordinatesItem(BaseModel):
-    __root__: 'List[Any]'
+class PolygonCoordinatesItem(RootModel):
+    root: 'List[Any]'
 
 
 class Polygon(BaseModel):
-    type: 'PolygonType'
+    type: Literal['Polygon']
     coordinates: 'List[List[PolygonCoordinatesItem]]'
     bbox: 'Optional[List[float]]' = Field(None)
 
 
-class TimeString(BaseModel):
-    __root__: 'Union[date, datetime]'
+class TimeString(RootModel):
+    root: 'Union[date, datetime]'
 
 
 class EnvelopeLiteral(BaseModel):
     bbox: 'Bbox'
 
 
-class GeometryLiteral(BaseModel):
-    __root__: 'Union[\n        Point, Linestring, Polygon, Multipoint, Multilinestring, Multipolygon\n    ]'
+class GeometryLiteral(RootModel):
+    root: 'Union[\n        Point, Linestring, Polygon, Multipoint, Multilinestring, Multipolygon\n    ]'
 
 
 class TypedTimeString(BaseModel):
     datetime: 'TimeString'
 
 
-class PeriodString(BaseModel):
-    __root__: 'List[Union[TimeString, str]]' = Field(...)
+class PeriodString(RootModel):
+    root: 'List[Union[TimeString, str]]' = Field(...)
 
 
-class SpatialLiteral(BaseModel):
-    __root__: 'Union[GeometryLiteral, EnvelopeLiteral]'
+class SpatialLiteral(RootModel):
+    root: 'Union[GeometryLiteral, EnvelopeLiteral]'
 
 
-class TemporalLiteral(BaseModel):
-    __root__: 'Union[TimeString, PeriodString]'
+class TemporalLiteral(RootModel):
+    root: 'Union[TimeString, PeriodString]'
 
 
 class TypedPeriodString(BaseModel):
     datetime: 'PeriodString'
 
 
-class TypedTemporalLiteral(BaseModel):
-    __root__: 'Union[TypedTimeString, TypedPeriodString]'
+class TypedTemporalLiteral(RootModel):
+    root: 'Union[TypedTimeString, TypedPeriodString]'
 
 
-class ArrayPredicate(BaseModel):
-    __root__: 'Union[\n        AequalsExpression,\n        AcontainsExpression,\n        AcontainedByExpression,\n        AoverlapsExpression,\n    ]'
+class ArrayPredicate(RootModel):
+    root: 'Union[\n        AequalsExpression,\n        AcontainsExpression,\n        AcontainedByExpression,\n        AoverlapsExpression,\n    ]'
 
 
-class ComparisonPredicate(BaseModel):
-    __root__: 'Union[\n        BinaryComparisonPredicate,\n        IsLikePredicate,\n        IsBetweenPredicate,\n        IsInListPredicate,\n        IsNullPredicate,\n    ]'
+class ComparisonPredicate(RootModel):
+    root: 'Union[\n        BinaryComparisonPredicate,\n        IsLikePredicate,\n        IsBetweenPredicate,\n        IsInListPredicate,\n        IsNullPredicate,\n    ]'
 
 
-class SpatialPredicate(BaseModel):
-    __root__: 'Union[\n        IntersectsExpression,\n        EqualsExpression,\n        DisjointExpression,\n        TouchesExpression,\n        WithinExpression,\n        OverlapsExpression,\n        CrossesExpression,\n        ContainsExpression,\n    ]'
+class SpatialPredicate(RootModel):
+    root: 'Union[\n        IntersectsExpression,\n        EqualsExpression,\n        DisjointExpression,\n        TouchesExpression,\n        WithinExpression,\n        OverlapsExpression,\n        CrossesExpression,\n        ContainsExpression,\n    ]'
 
 
-class TemporalPredicate(BaseModel):
-    __root__: 'Union[\n        BeforeExpression,\n        AfterExpression,\n        MeetsExpression,\n        MetbyExpression,\n        ToverlapsExpression,\n        OverlappedbyExpression,\n        BeginsExpression,\n        BegunbyExpression,\n        DuringExpression,\n        TcontainsExpression,\n        EndsExpression,\n        EndedbyExpression,\n        TequalsExpression,\n        AnyinteractsExpression,\n    ]'
+class TemporalPredicate(RootModel):
+    root: 'Union[\n        BeforeExpression,\n        AfterExpression,\n        MeetsExpression,\n        MetbyExpression,\n        ToverlapsExpression,\n        OverlappedbyExpression,\n        BeginsExpression,\n        BegunbyExpression,\n        DuringExpression,\n        TcontainsExpression,\n        EndsExpression,\n        EndedbyExpression,\n        TequalsExpression,\n        AnyinteractsExpression,\n    ]'
 
 
 class AcontainedByExpression(BaseModel):
@@ -231,8 +207,8 @@ class BegunbyExpression(BaseModel):
     begunby: 'TemporalOperands'
 
 
-class BinaryComparisonPredicate(BaseModel):
-    __root__: 'Union[\n        EqExpression, LtExpression, GtExpression, LteExpression, GteExpression\n    ]'
+class BinaryComparisonPredicate(RootModel):
+    root: 'Union[\n        EqExpression, LtExpression, GtExpression, LteExpression, GteExpression\n    ]'
 
 
 class ContainsExpression(BaseModel):
@@ -269,8 +245,8 @@ class IntersectsExpression(BaseModel):
 
 class Between(BaseModel):
     value: 'ValueExpression'
-    lower: 'ScalarExpression' = Field(None)
-    upper: 'ScalarExpression' = Field(None)
+    lower: 'Optional[ScalarExpression]' = Field(None)
+    upper: 'Optional[ScalarExpression]' = Field(None)
 
 
 class IsBetweenPredicate(BaseModel):
@@ -335,8 +311,8 @@ class WithinExpression(BaseModel):
     within: 'SpatialOperands'
 
 
-class ArrayExpression(BaseModel):
-    __root__: 'List[Union[PropertyRef, FunctionRef, ArrayLiteral]]' = Field(
+class ArrayExpression(RootModel):
+    root: 'List[Union[PropertyRef, FunctionRef, ArrayLiteral]]' = Field(
         ...  # , max_items=2, min_items=2
     )
 
@@ -361,53 +337,55 @@ class LteExpression(BaseModel):
     lte: 'ScalarOperands'
 
 
-class ScalarExpression(BaseModel):
-    __root__: 'Union[ScalarLiteral, PropertyRef,\n                    FunctionRef, ArithmeticExpression]'
+class ScalarExpression(RootModel):
+    root: 'Union[ScalarLiteral, PropertyRef,\n                    FunctionRef, ArithmeticExpression]'
 
 
-class ScalarOperands(BaseModel):
-    __root__: 'List[ScalarExpression]' = Field(...)
+class ScalarOperands(RootModel):
+    root: 'List[ScalarExpression]' = Field(...)
 
 
-class SpatialOperands(BaseModel):
-    __root__: 'List[GeomExpression]' = Field(...)
+class SpatialOperands(RootModel):
+    root: 'List[GeomExpression]' = Field(...)
 
 
-class TemporalOperands(BaseModel):
-    __root__: 'List[TemporalExpression]' = Field(...)
+class TemporalOperands(RootModel):
+    root: 'List[TemporalExpression]' = Field(...)
     # , max_items=2, min_items=2)
 
 
-class ValueExpression(BaseModel):
-    __root__: 'Union[ScalarExpression, SpatialLiteral, TypedTemporalLiteral]'
+class ValueExpression(RootModel):
+    root: 'Union[ScalarExpression, SpatialLiteral, TypedTemporalLiteral]'
 
 
-class ArithmeticExpression(BaseModel):
-    __root__: 'Union[AddExpression, SubExpression, MulExpression, DivExpression]'
+class ArithmeticExpression(RootModel):
+    root: 'Union[AddExpression, SubExpression, MulExpression, DivExpression]'
 
 
-class ArrayLiteral(BaseModel):
-    __root__: 'List[\n        Union[\n            ScalarLiteral,\n            SpatialLiteral,\n            TypedTemporalLiteral,\n            PropertyRef,\n            FunctionRef,\n            ArithmeticExpression,\n            ArrayLiteral,\n        ]\n    ]'
+class ArrayLiteral(RootModel):
+    root: 'List[\n        Union[\n            ScalarLiteral,\n            SpatialLiteral,\n            TypedTemporalLiteral,\n            PropertyRef,\n            FunctionRef,\n            ArithmeticExpression,\n            ArrayLiteral,\n        ]\n    ]'
 
 
 class FunctionRef(BaseModel):
     function: 'Function'
 
 
-class GeomExpression(BaseModel):
-    __root__: 'Union[SpatialLiteral, PropertyRef, FunctionRef]'
+class GeomExpression(RootModel):
+    root: 'Union[SpatialLiteral, PropertyRef, FunctionRef]'
 
 
-class TemporalExpression(BaseModel):
-    __root__: 'Union[TemporalLiteral, PropertyRef, FunctionRef]'
+class TemporalExpression(RootModel):
+    root: 'Union[TemporalLiteral, PropertyRef, FunctionRef]'
 
 
+# here
 class AddExpression(BaseModel):
-    _: 'ArithmeticOperands' = Field(..., alias='+')
+    add_: 'ArithmeticOperands' = Field(..., alias='+')
 
 
+# here
 class DivExpression(BaseModel):
-    _: 'Optional[ArithmeticOperands]' = Field(None, alias='/')
+    div_: 'Optional[ArithmeticOperands]' = Field(None, alias='/')
 
 
 class Function(BaseModel):
@@ -415,76 +393,78 @@ class Function(BaseModel):
     arguments: 'Optional[\n        List[\n            Union[\n                ScalarLiteral,\n                SpatialLiteral,\n                TypedTemporalLiteral,\n                PropertyRef,\n                FunctionRef,\n                ArithmeticExpression,\n                ArrayLiteral,\n            ]\n        ]\n    ]' = None
 
 
+# here
 class MulExpression(BaseModel):
-    _: 'ArithmeticOperands' = Field(..., alias='*')
+    mul_: 'ArithmeticOperands' = Field(..., alias='*')
 
 
+# here
 class SubExpression(BaseModel):
-    _: 'ArithmeticOperands' = Field(..., alias='-')
+    sub_: 'ArithmeticOperands' = Field(..., alias='-')
 
 
-class ArithmeticOperands(BaseModel):
-    __root__: 'List[\n        Union[ArithmeticExpression, PropertyRef, FunctionRef, float]\n    ]' = Field(...)
+class ArithmeticOperands(RootModel):
+    root: 'List[\n        Union[ArithmeticExpression, PropertyRef, FunctionRef, float]\n    ]' = Field(...)
 
 
-CQLModel.update_forward_refs()
-AndExpression.update_forward_refs()
-ArrayPredicate.update_forward_refs()
-ComparisonPredicate.update_forward_refs()
-SpatialPredicate.update_forward_refs()
-TemporalPredicate.update_forward_refs()
-AcontainedByExpression.update_forward_refs()
-AcontainsExpression.update_forward_refs()
-AequalsExpression.update_forward_refs()
-AfterExpression.update_forward_refs()
-AnyinteractsExpression.update_forward_refs()
-AoverlapsExpression.update_forward_refs()
-BeforeExpression.update_forward_refs()
-BeginsExpression.update_forward_refs()
-BegunbyExpression.update_forward_refs()
-BinaryComparisonPredicate.update_forward_refs()
-ContainsExpression.update_forward_refs()
-CrossesExpression.update_forward_refs()
-DisjointExpression.update_forward_refs()
-DuringExpression.update_forward_refs()
-EndedbyExpression.update_forward_refs()
-EndsExpression.update_forward_refs()
-EqualsExpression.update_forward_refs()
-IntersectsExpression.update_forward_refs()
-Between.update_forward_refs()
-In.update_forward_refs()
-IsBetweenPredicate.update_forward_refs()
-IsLikePredicate.update_forward_refs()
-IsNullPredicate.update_forward_refs()
-ValueExpression.update_forward_refs()
-MeetsExpression.update_forward_refs()
-MetbyExpression.update_forward_refs()
-OverlappedbyExpression.update_forward_refs()
-OverlapsExpression.update_forward_refs()
-TcontainsExpression.update_forward_refs()
-TequalsExpression.update_forward_refs()
-TouchesExpression.update_forward_refs()
-ToverlapsExpression.update_forward_refs()
-WithinExpression.update_forward_refs()
-ArrayExpression.update_forward_refs()
-EqExpression.update_forward_refs()
-GtExpression.update_forward_refs()
-GteExpression.update_forward_refs()
-LtExpression.update_forward_refs()
-LteExpression.update_forward_refs()
-ScalarExpression.update_forward_refs()
-ScalarOperands.update_forward_refs()
-SpatialOperands.update_forward_refs()
-TemporalOperands.update_forward_refs()
-ArithmeticExpression.update_forward_refs()
-ArrayLiteral.update_forward_refs()
-ScalarLiteral.update_forward_refs()
-PropertyRef.update_forward_refs()
-FunctionRef.update_forward_refs()
-AddExpression.update_forward_refs()
-DivExpression.update_forward_refs()
-MulExpression.update_forward_refs()
-SubExpression.update_forward_refs()
+CQLModel.model_rebuild()
+AndExpression.model_rebuild()
+ArrayPredicate.model_rebuild()
+ComparisonPredicate.model_rebuild()
+SpatialPredicate.model_rebuild()
+TemporalPredicate.model_rebuild()
+AcontainedByExpression.model_rebuild()
+AcontainsExpression.model_rebuild()
+AequalsExpression.model_rebuild()
+AfterExpression.model_rebuild()
+AnyinteractsExpression.model_rebuild()
+AoverlapsExpression.model_rebuild()
+BeforeExpression.model_rebuild()
+BeginsExpression.model_rebuild()
+BegunbyExpression.model_rebuild()
+BinaryComparisonPredicate.model_rebuild()
+ContainsExpression.model_rebuild()
+CrossesExpression.model_rebuild()
+DisjointExpression.model_rebuild()
+DuringExpression.model_rebuild()
+EndedbyExpression.model_rebuild()
+EndsExpression.model_rebuild()
+EqualsExpression.model_rebuild()
+IntersectsExpression.model_rebuild()
+Between.model_rebuild()
+In.model_rebuild()
+IsBetweenPredicate.model_rebuild()
+IsLikePredicate.model_rebuild()
+IsNullPredicate.model_rebuild()
+ValueExpression.model_rebuild()
+MeetsExpression.model_rebuild()
+MetbyExpression.model_rebuild()
+OverlappedbyExpression.model_rebuild()
+OverlapsExpression.model_rebuild()
+TcontainsExpression.model_rebuild()
+TequalsExpression.model_rebuild()
+TouchesExpression.model_rebuild()
+ToverlapsExpression.model_rebuild()
+WithinExpression.model_rebuild()
+ArrayExpression.model_rebuild()
+EqExpression.model_rebuild()
+GtExpression.model_rebuild()
+GteExpression.model_rebuild()
+LtExpression.model_rebuild()
+LteExpression.model_rebuild()
+ScalarExpression.model_rebuild()
+ScalarOperands.model_rebuild()
+SpatialOperands.model_rebuild()
+TemporalOperands.model_rebuild()
+ArithmeticExpression.model_rebuild()
+ArrayLiteral.model_rebuild()
+ScalarLiteral.model_rebuild()
+PropertyRef.model_rebuild()
+FunctionRef.model_rebuild()
+AddExpression.model_rebuild()
+DivExpression.model_rebuild()
+MulExpression.model_rebuild()
+SubExpression.model_rebuild()
 
 
 def get_next_node(obj):
@@ -499,25 +479,25 @@ def get_next_node(obj):
         next_node = obj.not_
         logical_op = 'not'
     elif obj.__repr_name__() == 'ComparisonPredicate':
-        next_node = obj.__root__
+        next_node = obj.root
     elif obj.__repr_name__() == 'SpatialPredicate':
-        next_node = obj.__root__
+        next_node = obj.root
     elif obj.__repr_name__() == 'TemporalPredicate':
-        next_node = obj.__root__
+        next_node = obj.root
     elif obj.__repr_name__() == 'IsBetweenPredicate':
         next_node = obj.between
     elif obj.__repr_name__() == 'Between':
         next_node = obj.value
     elif obj.__repr_name__() == 'ValueExpression':
-        next_node = obj.__root__ or obj.lower or obj.upper
+        next_node = obj.root or obj.lower or obj.upper
     elif obj.__repr_name__() == 'ScalarExpression':
-        next_node = obj.__root__
+        next_node = obj.root
     elif obj.__repr_name__() == 'ScalarLiteral':
-        next_node = obj.__root__
+        next_node = obj.root
     elif obj.__repr_name__() == 'PropertyRef':
         next_node = obj.property
     elif obj.__repr_name__() == 'BinaryComparisonPredicate':
-        next_node = obj.__root__
+        next_node = obj.root
     elif obj.__repr_name__() == 'EqExpression':
         next_node = obj.eq
         logical_op = 'eq'

--- a/pygeoapi/models/openapi.py
+++ b/pygeoapi/models/openapi.py
@@ -31,7 +31,7 @@
 
 from enum import Enum
 
-from pydantic import BaseModel
+from pydantic import RootModel
 
 
 class SupportedFormats(Enum):
@@ -39,5 +39,5 @@ class SupportedFormats(Enum):
     YAML = "yaml"
 
 
-class OAPIFormat(BaseModel):
-    __root__: SupportedFormats = SupportedFormats.YAML
+class OAPIFormat(RootModel):
+    root: SupportedFormats = SupportedFormats.YAML

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -294,7 +294,7 @@ class ElasticsearchProvider(BaseProvider):
         try:
             LOGGER.debug('querying Elasticsearch')
             if filterq:
-                LOGGER.debug(f'adding cql object: {filterq.json()}')
+                LOGGER.debug(f'adding cql object: {filterq.model_dump_json()}')
                 query = update_query(input_query=query, cql=filterq)
             LOGGER.debug(json.dumps(query, indent=4))
 
@@ -645,16 +645,16 @@ class ESQueryBuilder:
 def _build_query(q, cql):
 
     # this would be handled by the AST with the traverse of CQL model
-    op, node = get_next_node(cql.__root__)
+    op, node = get_next_node(cql.root)
     q.operation = op
     if isinstance(node, list):
         query_list = []
         for elem in node:
             op, next_node = get_next_node(elem)
             if not getattr(next_node, 'between', 0) == 0:
-                property = next_node.between.value.__root__.__root__.property
-                lower = next_node.between.lower.__root__.__root__
-                upper = next_node.between.upper.__root__.__root__
+                property = next_node.between.value.root.root.property
+                lower = next_node.between.lower.root.root
+                upper = next_node.between.upper.root.root
                 query_list.append(Q(
                     {
                         'range':
@@ -665,24 +665,24 @@ def _build_query(q, cql):
                             }
                     }
                 ))
-            if not getattr(next_node, '__root__', 0) == 0:
-                scalars = tuple(next_node.__root__.eq.__root__)
-                property = scalars[0].__root__.property
-                value = scalars[1].__root__.__root__
+            if not getattr(next_node, 'root', 0) == 0:
+                scalars = tuple(next_node.root.eq.root)
+                property = scalars[0].root.property
+                value = scalars[1].root.root
                 query_list.append(Q(
                     {'match': {f'{property}': f'{value}'}}
                 ))
         q.must(query_list)
     elif not getattr(node, 'between', 0) == 0:
-        property = node.between.value.__root__.__root__.property
+        property = node.between.value.root.root.property
         lower = None
         if not getattr(node.between.lower,
-                       '__root__', 0) == 0:
-            lower = node.between.lower.__root__.__root__
+                       'root', 0) == 0:
+            lower = node.between.lower.root.root
         upper = None
         if not getattr(node.between.upper,
-                       '__root__', 0) == 0:
-            upper = node.between.upper.__root__.__root__
+                       'root', 0) == 0:
+            upper = node.between.upper.root.root
         query = Q(
             {
                 'range':
@@ -694,26 +694,26 @@ def _build_query(q, cql):
             }
         )
         q.must(query)
-    elif not getattr(node, '__root__', 0) == 0:
+    elif not getattr(node, 'root', 0) == 0:
         next_op, next_node = get_next_node(node)
         if not getattr(next_node, 'eq', 0) == 0:
-            scalars = tuple(next_node.eq.__root__)
-            property = scalars[0].__root__.property
-            value = scalars[1].__root__.__root__
+            scalars = tuple(next_node.eq.root)
+            property = scalars[0].root.property
+            value = scalars[1].root.root
             query = Q(
                 {'match': {f'{property}': f'{value}'}}
             )
             q.must(query)
     elif not getattr(node, 'intersects', 0) == 0:
-        property = node.intersects.__root__[0].__root__.property
+        property = node.intersects.root[0].root.property
         if property == 'geometry':
-            geom_type = node.intersects.__root__[
-                1].__root__.__root__.__root__.type
-            if geom_type.value == 'Polygon':
-                coordinates = node.intersects.__root__[
-                    1].__root__.__root__.__root__.coordinates
+            geom_type = node.intersects.root[
+                1].root.root.root.type
+            if geom_type == 'Polygon':
+                coordinates = node.intersects.root[
+                    1].root.root.root.coordinates
                 coords_list = [
-                    poly_coords.__root__ for poly_coords in coordinates[0]
+                    poly_coords.root for poly_coords in coordinates[0]
                 ]
                 filter_ = Q(
                     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,5 @@ requests
 shapely<2.0
 SQLAlchemy<2.0.0
 tinydb
+typing-extensions
 unicodecsv

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Flask
 importlib_metadata
 jinja2
 jsonschema
-pydantic<2.0
+pydantic
 pygeofilter
 pygeoif
 pyproj

--- a/tests/test_elasticsearch__provider.py
+++ b/tests/test_elasticsearch__provider.py
@@ -78,7 +78,7 @@ def between():
             "upper": 100000
         }
     }
-    return CQLModel.parse_obj(between_)
+    return CQLModel.model_validate(between_)
 
 
 @pytest.fixture()
@@ -89,7 +89,7 @@ def between_upper():
             "upper": 100000
         }
     }
-    return CQLModel.parse_obj(between_)
+    return CQLModel.model_validate(between_)
 
 
 @pytest.fixture()
@@ -100,7 +100,7 @@ def between_lower():
             "lower": 10000
         }
     }
-    return CQLModel.parse_obj(between_)
+    return CQLModel.model_validate(between_)
 
 
 @pytest.fixture()
@@ -111,7 +111,7 @@ def eq():
             "Admin-0 capital"
         ]
     }
-    return CQLModel.parse_obj(eq_)
+    return CQLModel.model_validate(eq_)
 
 
 @pytest.fixture()
@@ -135,7 +135,7 @@ def _and(eq, between):
             }
         ]
     }
-    return CQLModel.parse_obj(and_)
+    return CQLModel.model_validate(and_)
 
 
 @pytest.fixture()
@@ -155,7 +155,7 @@ def intersects():
             ]
         }
     ]}
-    return CQLModel.parse_obj(intersects)
+    return CQLModel.model_validate(intersects)
 
 
 def test_query(config):


### PR DESCRIPTION
# Overview
This PR refactor the code using pydantic to make it work with pydantic V2. Originally implemented in PR https://github.com/geopython/pygeoapi/pull/1349, but moved the pydantic related changes to this new PR.

# Related Issue / Discussion
https://github.com/geopython/pygeoapi/pull/1349

# Additional Information
This PR add `typing-extensions` to `requirements.txt` to allow for the use of the `Literal` type. If the python version is update in CI to version 3.8 or above, the `Literal` can be directly imported from the `typing` standard library and `typing-extensions` will not be needed.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
