### PR TITLE
Fix pydantic version on requirements-django.txt

### DIFF
--- a/requirements-django.txt
+++ b/requirements-django.txt
@@ -1,2 +1,2 @@
 Django
-pydantic<2.0
+pydantic


### PR DESCRIPTION
# Overview

Fix pydantic version not aligned for django requirements

# Related Issue / Discussion

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
