### PR TITLE
safeguard missing properties during .../items queries using properties=

### DIFF
--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -463,9 +463,10 @@ class ElasticsearchProvider(BaseProvider):
         LOGGER.debug('Fetching id and geometry from GeoJSON document')
         feature_ = doc['_source']
 
-        if self.id_field in doc['_source']['properties']:
+        try:
             id_ = doc['_source']['properties'][self.id_field]
-        else:
+        except KeyError as err:
+            LOGGER.debug(f'Missing field: {err}')
             id_ = doc['_source'].get('id', doc['_id'])
 
         feature_['id'] = id_


### PR DESCRIPTION
# Overview
When users issue OAFeat `.../items` queries using `properties=`, when a given property does not exist, safeguard (try/except).
# Related Issue / Discussion
None
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
