### PR TITLE
Removed datamodel-code-generator from dev requirements

### DIFF
--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -23,39 +23,6 @@ To run all tests, simply run ``pytest`` in the repository.  To run a specific te
 run ``pytest tests/test_api.py``, for example.
 
 
-CQL extension lifecycle
------------------------
-
-Limitations
-^^^^^^^^^^^
-
-This workflow is valid only for the `CQL-JSON` format.
-
-Schema
-^^^^^^
-
-The Common Query Language (CQL) is the part 3 of the standard OGC API - Features. This extension has its specification available at 
-`OGC API - Features - Part 3: Filtering and the Common Query Language (CQL) <https://portal.ogc.org/files/96288>`_ and the schema exists in development at
-`cql.json <https://portal.ogc.org/files/96288#cql-json-schema>`_.
-
-Model generation
-^^^^^^^^^^^^^^^^
-
-pygeoapi uses a class-based Python model interface to translate the schema into Python objects defined by `pydantic <https://docs.pydantic.dev/>`_ models.
-The model is generated with the pre-processing of the schema through the utility ``datamodel-codegen``:
-
-.. code-block:: bash
-
-   # Generate from local downloaded json schema file
-   datamodel-codegen  --input ~/Download/cql-schema.json --input-file-type jsonschema --output ./pygeoapi/models/cql_update.py --class-name CQLModel
-
-How to merge
-^^^^^^^^^^^^
-
-Once the new pydantic models have been generated then the content of the Python file ``cql_update.py`` can be used to replace the old classes within the ``cql.py`` file.
-Update everything above the function ``get_next_node`` and then verify if the tests for the CQL are still passing, for example ``test_post_cql_json_between_query`` 
-in ``tests/test_elasticsearch__provider.py``.
-
 Working with Spatialite on OSX
 ------------------------------
 

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -23,6 +23,43 @@ To run all tests, simply run ``pytest`` in the repository.  To run a specific te
 run ``pytest tests/test_api.py``, for example.
 
 
+CQL extension lifecycle
+-----------------------
+
+Limitations
+^^^^^^^^^^^
+
+This workflow is valid only for the `CQL-JSON` format.
+
+Schema
+^^^^^^
+
+The Common Query Language (CQL) is the part 3 of the standard OGC API - Features. This extension has its specification available at
+`OGC API - Features - Part 3: Filtering and the Common Query Language (CQL) <https://portal.ogc.org/files/96288>`_ and the schema exists in development at
+`cql.json <https://portal.ogc.org/files/96288#cql-json-schema>`_.
+
+Model generation
+^^^^^^^^^^^^^^^^
+
+pygeoapi uses a class-based Python model interface to translate the schema into Python objects defined by `pydantic <https://docs.pydantic.dev/>`_ models.
+The model is generated with the pre-processing of the schema through the utility ``datamodel-codegen``, which is part
+of the `datamodel-code-generator <https://koxudaxi.github.io/datamodel-code-generator/>`_ package:
+
+
+.. code-block:: bash
+
+   # Generate from local downloaded json schema file
+   datamodel-codegen  --input ~/Download/cql-schema.json --input-file-type jsonschema --output ./pygeoapi/models/cql_update.py --class-name CQLModel
+
+Note that datamodel-code-generator must be explicitly installed, as it is not a pygeoapi runtime dependency
+
+How to merge
+^^^^^^^^^^^^
+
+Once the new pydantic models have been generated then the content of the Python file ``cql_update.py`` can be used to replace the old classes within the ``cql.py`` file.
+Update everything above the function ``get_next_node`` and then verify if the tests for the CQL are still passing, for example ``test_post_cql_json_between_query``
+in ``tests/test_elasticsearch__provider.py``.
+
 Working with Spatialite on OSX
 ------------------------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,6 @@
 # Flask-based CORS setup
 flask_cors
 
-# Generate pydantic models from json schema
-datamodel-code-generator
-
 # testing
 pytest
 pytest-cov


### PR DESCRIPTION
This PR removes `datamodel-code-generator` from dev requirements, following the discussion from #1367 

# Related Issue / Discussion
- #1367



# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
