### PR TITLE
Pin down mongo-express version on docker example

### DIFF
--- a/docker/examples/mongo/docker-compose.yml
+++ b/docker/examples/mongo/docker-compose.yml
@@ -64,7 +64,7 @@ services:
         MONGO_INITDB_DATABASE: pop_places
 
   mongo-express:
-    image: mongo-express
+    image: mongo-express:1.0.0
     restart: always
     container_name: mongo_express
     links:


### PR DESCRIPTION
# Overview
[The version of the mongo-express container is not pinned down](https://github.com/geopython/pygeoapi/blob/master/docker/examples/mongo/docker-compose.yml#L67), which may cause surprises.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
