### PR TITLE
Added credentials for mongo-express web UI on the docker example

### DIFF
--- a/docker/examples/mongo/docker-compose.yml
+++ b/docker/examples/mongo/docker-compose.yml
@@ -67,6 +67,9 @@ services:
     image: mongo-express
     restart: always
     container_name: mongo_express
+    environment:
+     ME_CONFIG_BASICAUTH_USERNAME: admin #admin username
+     ME_CONFIG_BASICAUTH_PASSWORD: admin #admin password
     links:
       - mongo
     depends_on:


### PR DESCRIPTION
# Overview
[The mongo-express container does not pass any credentials](https://github.com/geopython/pygeoapi/blob/master/docker/examples/mongo/docker-compose.yml#L66) and authentication is enabled. As a result we cannot log into the web UI.

This PR adds a default username and password.

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
