### PR TITLE
Handle ProviderInvalidQueryError for every query()

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1653,6 +1653,12 @@ class API:
                               select_properties=select_properties,
                               crs_transform_spec=crs_transform_spec,
                               q=q, language=prv_locale, filterq=filter_)
+        except ProviderInvalidQueryError as err:
+            LOGGER.error(err)
+            msg = f'query error: {err}'
+            return self.get_exception(
+                HTTPStatus.BAD_REQUEST, headers, request.format,
+                'InvalidQuery', msg)
         except ProviderConnectionError as err:
             LOGGER.error(err)
             msg = 'connection error (check logs)'
@@ -2074,6 +2080,12 @@ class API:
                               skip_geometry=skip_geometry,
                               q=q,
                               filterq=filter_)
+        except ProviderInvalidQueryError as err:
+            LOGGER.error(err)
+            msg = f'query error: {err}'
+            return self.get_exception(
+                HTTPStatus.BAD_REQUEST, headers, request.format,
+                'InvalidQuery', msg)
         except ProviderConnectionError as err:
             LOGGER.error(err)
             msg = 'connection error (check logs)'
@@ -3853,6 +3865,11 @@ class API:
 
         try:
             data = p.query(**query_args)
+        except ProviderInvalidQueryError as err:
+            msg = f'query error: {err}'
+            return self.get_exception(
+                HTTPStatus.BAD_REQUEST, headers, request.format,
+                'InvalidQuery', msg)
         except ProviderNoDataError:
             msg = 'No data found'
             return self.get_exception(


### PR DESCRIPTION
This is necessary for a more consistent error handling, where providers can raise `ProviderInvalidQueryError` for any `query()` call and the API will correspondingly return a code in the 4xx range with an error message.

Currently for some functions such as `get_collection_items`, a `ProviderInvalidQueryError` will only be handled as `ProviderGenericError` (its superclass), which leads to a 500 error code and no specific error message.

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
