### PR TITLE
Fix placeholder typo

### DIFF
--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -219,7 +219,7 @@ class MVTProvider(BaseTileProvider):
                 session.get(base_url)
                 # There is a "." in the url path
                 if '.' in url.path:
-                    resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}.{f}{url_query}')  # noqa
+                    resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}.{format_}{url_query}')  # noqa
                 # There is no "." in the url )e.g. elasticsearch)
                 else:
                     resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}')  # noqa


### PR DESCRIPTION
# Overview
I'm using vector tiles with pg_tileserv, but I get this error:

```
  File "/pygeoapi/pygeoapi/provider/mvt.py", line 222, in get_tiles
    resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}.{f}{url_query}')  # noqa
NameError: name 'f' is not defined
```
It looks like a typo in the variable name for the URL placeholder, called **f** (variable not defined anywhere else) instead of **format_**, the extension for the tile. 

# Related Issue / Discussion
I didn't create an issue. It's a very simple error :innocent: 

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
