### PR TITLE
Simplify provider error handling

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2129,7 +2129,7 @@ class API:
                 msg = str(err)
                 return self.get_exception(
                     HTTPStatus.BAD_REQUEST, headers, request.format,
-                   'InvalidParameterValue', msg)
+                    'InvalidParameterValue', msg)
             except ProviderGenericError as err:
                 LOGGER.error(err)
                 return self.get_exception(

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1653,24 +1653,6 @@ class API:
                               select_properties=select_properties,
                               crs_transform_spec=crs_transform_spec,
                               q=q, language=prv_locale, filterq=filter_)
-        except ProviderInvalidQueryError as err:
-            LOGGER.error(err)
-            msg = f'query error: {err}'
-            return self.get_exception(
-                HTTPStatus.BAD_REQUEST, headers, request.format,
-                'InvalidQuery', msg)
-        except ProviderConnectionError as err:
-            LOGGER.error(err)
-            msg = 'connection error (check logs)'
-            return self.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
-                'NoApplicableCode', msg)
-        except ProviderQueryError as err:
-            LOGGER.error(err)
-            msg = 'query error (check logs)'
-            return self.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
-                'NoApplicableCode', msg)
         except ProviderGenericError as err:
             LOGGER.error(err)
             msg = 'generic error (check logs)'

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2305,28 +2305,11 @@ class API:
                 language=prv_locale,
                 crs_transform_spec=crs_transform_spec,
             )
-        except ProviderConnectionError as err:
-            LOGGER.error(err)
-            msg = 'connection error (check logs)'
-            return self.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
-                'NoApplicableCode', msg)
-        except ProviderItemNotFoundError:
-            msg = 'identifier not found'
-            return self.get_exception(HTTPStatus.NOT_FOUND, headers,
-                                      request.format, 'NotFound', msg)
-        except ProviderQueryError as err:
-            LOGGER.error(err)
-            msg = 'query error (check logs)'
-            return self.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
-                'NoApplicableCode', msg)
         except ProviderGenericError as err:
             LOGGER.error(err)
-            msg = 'generic error (check logs)'
             return self.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
-                'NoApplicableCode', msg)
+                err.http_status_code, headers, request.format,
+                err.ogc_exception_code, err.default_msg)
 
         if content is None:
             msg = 'identifier not found'

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1655,10 +1655,9 @@ class API:
                               q=q, language=prv_locale, filterq=filter_)
         except ProviderGenericError as err:
             LOGGER.error(err)
-            msg = 'generic error (check logs)'
             return self.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
-                'NoApplicableCode', msg)
+                err.http_status_code, headers, request.format,
+                err.ogc_exception_code, err.message)
 
         serialized_query_params = ''
         for k, v in request.params.items():
@@ -2291,7 +2290,7 @@ class API:
             LOGGER.error(err)
             return self.get_exception(
                 err.http_status_code, headers, request.format,
-                err.ogc_exception_code, err.default_msg)
+                err.ogc_exception_code, err.message)
 
         if content is None:
             msg = 'identifier not found'

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -291,12 +291,16 @@ class ProviderTypeError(ProviderGenericError):
 
 class ProviderInvalidQueryError(ProviderGenericError):
     """provider invalid query error"""
-    pass
+    ogc_exception_code = 'InvalidQuery'
+    http_status_code = HTTPStatus.BAD_REQUEST
+    default_msg = "query error"
+
+    # TODO: user facing message
 
 
 class ProviderQueryError(ProviderGenericError):
     """provider query error"""
-    pass
+    default_msg = 'query error (check logs)'
 
 
 class ProviderItemNotFoundError(ProviderGenericError):

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -297,7 +297,8 @@ class ProviderConnectionError(ProviderGenericError):
 
 class ProviderTypeError(ProviderGenericError):
     """provider type error"""
-    pass
+    default_msg = 'invalid provider type'
+    http_status_code = HTTPStatus.BAD_REQUEST
 
 
 class ProviderInvalidQueryError(ProviderGenericError):
@@ -321,7 +322,9 @@ class ProviderItemNotFoundError(ProviderGenericError):
 
 class ProviderNoDataError(ProviderGenericError):
     """provider no data error"""
-    pass
+    ogc_exception_code = 'InvalidParameterValue'
+    http_status_code = HTTPStatus.NO_CONTENT
+    default_msg = 'No data found'
 
 
 class ProviderNotFoundError(ProviderGenericError):
@@ -341,4 +344,10 @@ class ProviderInvalidDataError(ProviderGenericError):
 
 class ProviderRequestEntityTooLargeError(ProviderGenericError):
     """provider request entity too large error"""
-    pass
+    http_status_code = HTTPStatus.REQUEST_ENTITY_TOO_LARGE
+
+    def __init__(self, msg=None, *args, user_msg=None) -> None:
+        if msg and not user_msg:
+            # This error type shows the error by default
+            user_msg = msg
+        super().__init__(msg, *args, user_msg=user_msg)

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -278,6 +278,17 @@ class ProviderGenericError(Exception):
     http_status_code = HTTPStatus.INTERNAL_SERVER_ERROR
     default_msg = 'generic error (check logs)'
 
+    def __init__(self, msg=None, *args, user_msg=None) -> None:
+        # if only a user_msg is provided, use it as msg
+        if user_msg and not msg:
+            msg = user_msg
+        super().__init__(msg, *args)
+        self.user_msg = user_msg
+
+    @property
+    def message(self):
+        return self.user_msg if self.user_msg else self.default_msg
+
 
 class ProviderConnectionError(ProviderGenericError):
     """provider connection error"""
@@ -294,8 +305,6 @@ class ProviderInvalidQueryError(ProviderGenericError):
     ogc_exception_code = 'InvalidQuery'
     http_status_code = HTTPStatus.BAD_REQUEST
     default_msg = "query error"
-
-    # TODO: user facing message
 
 
 class ProviderQueryError(ProviderGenericError):

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -30,6 +30,7 @@
 import json
 import logging
 from enum import Enum
+from http import HTTPStatus
 
 LOGGER = logging.getLogger(__name__)
 
@@ -273,12 +274,14 @@ class BaseProvider:
 
 class ProviderGenericError(Exception):
     """provider generic error"""
-    pass
+    ogc_exception_code = 'NoApplicableCode'
+    http_status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    default_msg = 'generic error (check logs)'
 
 
 class ProviderConnectionError(ProviderGenericError):
     """provider connection error"""
-    pass
+    default_msg = 'connection error (check logs)'
 
 
 class ProviderTypeError(ProviderGenericError):
@@ -298,7 +301,9 @@ class ProviderQueryError(ProviderGenericError):
 
 class ProviderItemNotFoundError(ProviderGenericError):
     """provider item not found query error"""
-    pass
+    ogc_exception_code = 'NotFound'
+    http_status_code = HTTPStatus.NOT_FOUND
+    default_msg = 'identifier not found'
 
 
 class ProviderNoDataError(ProviderGenericError):

--- a/pygeoapi/provider/csw_facade.py
+++ b/pygeoapi/provider/csw_facade.py
@@ -144,7 +144,7 @@ class CSWFacadeProvider(BaseProvider):
             if p[0] not in list(self.record_mappings.keys()):
                 msg = f'Invalid property: {p[0]}'
                 LOGGER.error(msg)
-                raise ProviderInvalidQueryError(msg)
+                raise ProviderInvalidQueryError(user_msg=msg)
 
             prop = self.record_mappings[p[0]][0]
             constraints.append(fes.PropertyIsEqualTo(prop, p[1]))

--- a/pygeoapi/provider/tile.py
+++ b/pygeoapi/provider/tile.py
@@ -32,7 +32,8 @@
 import logging
 from http import HTTPStatus
 
-from pygeoapi.provider.base import ProviderGenericError, ProviderItemNotFoundError
+from pygeoapi.provider.base import (
+    ProviderGenericError, ProviderItemNotFoundError)
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/provider/tile.py
+++ b/pygeoapi/provider/tile.py
@@ -30,8 +30,9 @@
 # =================================================================
 
 import logging
+from http import HTTPStatus
 
-from pygeoapi.provider.base import ProviderGenericError
+from pygeoapi.provider.base import ProviderGenericError, ProviderItemNotFoundError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -125,14 +126,16 @@ class BaseTileProvider:
 
 class ProviderTileQueryError(ProviderGenericError):
     """provider tile query error"""
-    pass
+    default_msg = 'Tile not found'
 
 
-class ProviderTileNotFoundError(ProviderGenericError):
+class ProviderTileNotFoundError(ProviderItemNotFoundError):
     """provider tile not found error"""
-    pass
+    default_msg = 'Tile not found (check logs)'
 
 
 class ProviderTilesetIdNotFoundError(ProviderTileQueryError):
     """provider tileset matrix query error"""
-    pass
+    default_msg = 'Tileset id not found'
+    http_status_code = HTTPStatus.NOT_FOUND
+    ogc_exception_code = 'NotFound'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1380,7 +1380,7 @@ def test_get_coverage_domainset(config, api_):
     rsp_headers, code, response = api_.get_collection_coverage_domainset(
         req, 'obs')
 
-    assert code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert code == HTTPStatus.BAD_REQUEST
 
     rsp_headers, code, response = api_.get_collection_coverage_domainset(
         req, 'gdps-temperature')
@@ -1399,7 +1399,7 @@ def test_get_collection_coverage_rangetype(config, api_):
     rsp_headers, code, response = api_.get_collection_coverage_rangetype(
         req, 'obs')
 
-    assert code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert code == HTTPStatus.BAD_REQUEST
 
     rsp_headers, code, response = api_.get_collection_coverage_rangetype(
         req, 'gdps-temperature')


### PR DESCRIPTION
# Overview

Previously, the kinds of errors that could be raised in the provider depended on the concrete method and it was not always clear, which error was available where.

Now every method allows all kinds of errors, and even custom subclasses of `ProviderGenericError`.

To enable this, the default message, ogc status code and http status code is defined at the error class level. Custom subclasses can override this.

Now every error class allows provider developers to pass messages to the user using the `user_msg` parameter.

Note that previously, some errors lead to slightly different error codes, which are now unified. E.g. `ProviderTypeError` used to sometimes produce a 400 and sometimes a 500 code, now it's always 400 (since the user provide



# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
