### PR TITLE
remove ajax call to fetch jsonld representation

### DIFF
--- a/pygeoapi/templates/_base.html
+++ b/pygeoapi/templates/_base.html
@@ -102,22 +102,5 @@
         style="height:24px;vertical-align: middle;" /></a> {{ version }}</footer>
     {% block extrafoot %}
     {% endblock %}
-    <script>
-      // Requests and embeds JSON-LD representation of current page
-      var xhr = new XMLHttpRequest();
-      var path = window.location.protocol + "//" + window.location.host + window.location.pathname + "?f=jsonld";
-      xhr.open('GET', path);
-      xhr.onload = function() {
-        if (xhr.status === 200) {
-          var head = document.getElementsByTagName('head')[0];
-          var jsonld_datablock = document.createElement('script');
-          jsonld_datablock.type = "application/ld+json";
-          //remove full context path, because search engines don't expect it here, pyld requires it.
-          jsonld_datablock.textContent = xhr.responseText.replace('docs/jsonldcontext.jsonld','');
-          head.appendChild(jsonld_datablock);
-        }
-      };
-      xhr.send();
-    </script>
   </body>
 </html>


### PR DESCRIPTION

# Overview

the jsonld reference is duplicated, this is the non functional one

# Related Issue / Discussion

see discussion in to https://github.com/geopython/pygeoapi/pull/916

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
