### PR TITLE
Use same format handling in collection coverage as elsewhere

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -107,6 +107,7 @@ F_JSONLD = 'jsonld'
 F_GZIP = 'gzip'
 F_PNG = 'png'
 F_MVT = 'mvt'
+F_NETCDF = 'NetCDF'
 
 #: Formats allowed for ?f= requests (order matters for complex MIME types)
 FORMAT_TYPES = OrderedDict((
@@ -114,7 +115,8 @@ FORMAT_TYPES = OrderedDict((
     (F_JSONLD, 'application/ld+json'),
     (F_JSON, 'application/json'),
     (F_PNG, 'image/png'),
-    (F_MVT, 'application/vnd.mapbox-vector-tile')
+    (F_MVT, 'application/vnd.mapbox-vector-tile'),
+    (F_NETCDF, 'application/x-netcdf'),
 ))
 
 #: Locale used for system responses (e.g. exceptions)
@@ -2433,11 +2435,10 @@ class API:
         """
 
         query_args = {}
-        format_ = F_JSON
+        format_ = request.format or F_JSON
 
         # Force response content type and language (en-US only) headers
         headers = request.get_response_headers(SYSTEM_LOCALE,
-                                               FORMAT_TYPES[F_JSON],
                                                **self.api_headers)
 
         LOGGER.debug('Loading provider')
@@ -2499,10 +2500,7 @@ class API:
                 'InvalidParameterValue', msg)
 
         query_args['datetime_'] = datetime_
-
-        if 'f' in request.params:
-            # Format explicitly set using a query parameter
-            query_args['format_'] = format_ = request.format
+        query_args['format_'] = format_
 
         properties = request.params.get('properties')
         if properties:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1449,8 +1449,11 @@ def test_get_collection_coverage(config, api_):
     rsp_headers, code, response = api_.get_collection_coverage(
         req, 'gdps-temperature')
 
-    assert code == HTTPStatus.OK
-    assert rsp_headers['Content-Type'] == 'application/prs.coverage+json'
+    # NOTE: This test used to assert the code to be 200 OK,
+    #       but it requested HTML, which is not available,
+    #       so it should be 400 Bad Request
+    assert code == HTTPStatus.BAD_REQUEST
+    assert rsp_headers['Content-Type'] == 'text/html'
 
     req = mock_request({'subset': 'Lat(5:10),Long(5:10)'})
     rsp_headers, code, response = api_.get_collection_coverage(
@@ -1486,6 +1489,13 @@ def test_get_collection_coverage(config, api_):
 
     assert code == HTTPStatus.OK
     assert isinstance(response, bytes)
+
+    req = mock_request(HTTP_ACCEPT='application/x-netcdf')
+    rsp_headers, code, response = api_.get_collection_coverage(
+        req, 'cmip5')
+
+    assert code == HTTPStatus.OK
+    assert rsp_headers['Content-Type'] == 'application/x-netcdf'
 
     # req = mock_request({
     #     'subset': 'time("2006-07-01T06:00:00":"2007-07-01T06:00:00")'


### PR DESCRIPTION


# Overview

# Related Issue / Discussion

This now fixes the issue that the `Accept` header wasn't considered for format selection.

This adds netcdf as a known mime type in order to be able to test this, but also for actual clients to use.

Note that if we want to allow other mime types such as `application/x-grib2`, we also have to add them to `FORMAT_TYPES`.

Fixes #1390

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
