### PR TITLE
Fixing pydantic validation issue of tilejson metadata

### DIFF
--- a/pygeoapi/models/provider/mvt.py
+++ b/pygeoapi/models/provider/mvt.py
@@ -50,8 +50,3 @@ class MVTTilesJson(BaseModel):
     # attribution: Optional[str]
     description: Optional[str]
     vector_layers: Optional[List[VectorLayers]]
-
-
-
-
-

--- a/pygeoapi/models/provider/mvt.py
+++ b/pygeoapi/models/provider/mvt.py
@@ -47,6 +47,11 @@ class MVTTilesJson(BaseModel):
     maxzoom: Optional[int]
     bounds: Optional[str]
     center: Optional[str]
-    attribution: Optional[str]
+    # attribution: Optional[str]
     description: Optional[str]
     vector_layers: Optional[List[VectorLayers]]
+
+
+
+
+

--- a/pygeoapi/provider/mvt.py
+++ b/pygeoapi/provider/mvt.py
@@ -280,11 +280,11 @@ class MVTProvider(BaseTileProvider):
         content = {}
         if metadata_format == TilesMetadataFormat.TILEJSON:
             if 'metadata_json_content' in locals():
+                metadata_json_content["tiles"] = service_url
+                metadata_json_content["vector_layers"] = json.loads(
+                         metadata_json_content["json"])["vector_layers"]
                 content = MVTTilesJson(**metadata_json_content)
-                content.tiles = service_url
-                content.vector_layers = json.loads(
-                        metadata_json_content["json"])["vector_layers"]
-                return content.dict()
+                return content.model_dump()
             else:
                 msg = f'No tiles metadata json available: {self.service_metadata_url}'  # noqa
                 LOGGER.error(msg)


### PR DESCRIPTION
# Overview

The tileset metadata endpoint for tilejson metadata is no longer working.

# Related Issue / Discussion

https://github.com/geopython/pygeoapi/issues/1418

# Additional Information

When instantiating the model, pydantic requires all the fields to be present (even, if they are optional). As a workaround, we are adding the fields before instantiating the model, instead of after (as we were doing before).

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
