### PR TITLE
Fixing pydantic validation issue of tilejson metadata

### DIFF
--- a/pygeoapi/models/provider/base.py
+++ b/pygeoapi/models/provider/base.py
@@ -3,8 +3,10 @@
 # =================================================================
 #
 # Authors: Antonio Cerciello <anto.nio.cerciello@gmail.com>
+#          Francesco Bartoli <xbartolone@gmail.com>
 #
 # Copyright (c) 2022 Antonio Cerciello
+# Copyright (c) 2023 Francesco Bartoli
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -113,103 +115,103 @@ class TileMatrixLimitsType(BaseModel):
 class TwoDBoundingBoxType(BaseModel):
     lowerLeft: List[float]
     upperRight: List[float]
-    crs: Optional[str]
+    crs: Optional[str] = None
 
 
 class LinkType(BaseModel):
     href: str
-    rel: Optional[str]
-    type_: Optional[str]
-    hreflang: Optional[str]
-    title: Optional[str]
-    length: Optional[int]
+    rel: Optional[str] = None
+    type_: Optional[str] = None
+    hreflang: Optional[str] = None
+    title: Optional[str] = None
+    length: Optional[int] = None
 
 
 class GeospatialDataType(BaseModel):
-    id: Optional[str]
+    id: Optional[str] = None
     title: Optional[str] = None
-    description: Optional[str]
-    keywords: Optional[List[str]]
+    description: Optional[str] = None
+    keywords: Optional[List[str]] = None
     dataType: DataTypeEnum = DataTypeEnum.VECTOR
-    geometryDimension: Optional[GeometryDimensionEnum]
-    maxTileMatrix: Optional[str]
-    minTileMatrix: Optional[str]
-    minScaleDenominator: Optional[float]
-    maxScaleDenominator: Optional[float]
-    minCellSize: Optional[float]
-    maxCellSize: Optional[float]
-    boundingBox: Optional[TwoDBoundingBoxType]
-    links: Optional[LinkType]
-    propertiesSchema: Optional[dict]
+    geometryDimension: Optional[GeometryDimensionEnum] = None
+    maxTileMatrix: Optional[str] = None
+    minTileMatrix: Optional[str] = None
+    minScaleDenominator: Optional[float] = None
+    maxScaleDenominator: Optional[float] = None
+    minCellSize: Optional[float] = None
+    maxCellSize: Optional[float] = None
+    boundingBox: Optional[TwoDBoundingBoxType] = None
+    links: Optional[LinkType] = None
+    propertiesSchema: Optional[dict] = None
 
 
 class StyleType(BaseModel):
-    id: Optional[str]
-    title: Optional[str]
-    description: Optional[str]
-    keywords: Optional[List[str]]
-    links: Optional[LinkType]
+    id: Optional[str] = None
+    title: Optional[str] = None
+    description: Optional[str] = None
+    keywords: Optional[List[str]] = None
+    links: Optional[LinkType] = None
 
 
 class TilePointType(BaseModel):
     crs: str
-    coordinates: Optional[List[float]]
-    scaleDenominator: Optional[float]
-    cellSize: Optional[float]
+    coordinates: Optional[List[float]] = None
+    scaleDenominator: Optional[float] = None
+    cellSize: Optional[float] = None
     # CodeType as adaptation of MD_Identifier class ISO 19115
     tileMatrix: str
-    cellSize: Optional[str]
+    cellSize: Optional[str] = None
 
 
 class TileSetMetadata(BaseModel):
     # A title for this tileset
-    title: Optional[str]
+    title: Optional[str] = None
     # Brief narrative description of this tile set
-    description: Optional[str]
+    description: Optional[str] = None
     # keywords about this tileset
-    keywords: Optional[List[str]]
+    keywords: Optional[List[str]] = None
     # Version of the Tile Set. Changes if the data behind the tiles
     # has been changed
-    version: Optional[str]
+    version: Optional[str] = None
     # Useful information to contact the authors or custodians for the Tile Set
-    pointOfContact: Optional[str]
+    pointOfContact: Optional[str] = None
     # Short reference to recognize the author or provider
-    attribution: Optional[str]
+    attribution: Optional[str] = None
     # License applicable to the tiles
-    license_: Optional[str]
+    license_: Optional[str] = None
     # Restrictions on the availability of the Tile Set that the user needs to
     # be aware of before using or redistributing the Tile Set
     accessConstraints: Optional[AccessConstraintsEnum] = AccessConstraintsEnum.UNCLASSIFIED
     # Media types available for the tiles
-    mediaTypes:  Optional[List[str]]
+    mediaTypes:  Optional[List[str]] = None
     # Type of data represented in the tileset
     dataType: DataTypeEnum = DataTypeEnum.VECTOR
     # Limits for the TileRow and TileCol values for each TileMatrix in the
     # tileMatrixSet. If missing, there are no limits other that the ones
     # imposed by the TileMatrixSet. If present the TileMatrices listed are
     # limited and the rest not available at all
-    tileMatrixSetLimits: Optional[TileMatrixLimitsType]
+    tileMatrixSetLimits: Optional[TileMatrixLimitsType] = None
     # Coordinate Reference System (CRS)
-    crs: Optional[str]
+    crs: Optional[str] = None
     # Epoch of the Coordinate Reference System (CRS)
-    epoch: Optional[int]
+    epoch: Optional[int] = None
     # Minimum bounding rectangle surrounding the tile matrix set, in the
     # supported CRS
-    boundingBox: Optional[TwoDBoundingBoxType]
+    boundingBox: Optional[TwoDBoundingBoxType] = None
     # When the Tile Set was first produced
-    created: Optional[datetime]
+    created: Optional[datetime] = None
     # Last Tile Set change/revision
-    updated: Optional[datetime]
-    layers: Optional[GeospatialDataType]
+    updated: Optional[datetime] = None
+    layers: Optional[GeospatialDataType] = None
     # Style involving all layers used to generate the tileset
-    style: Optional[StyleType]
+    style: Optional[StyleType] = None
     # Location of a tile that nicely represents the tileset.
     # Implementations may use this center value to set the default location
     # or to present a representative tile in a user interface
-    centerPoint: Optional[TilePointType]
+    centerPoint: Optional[TilePointType] = None
     # Tile matrix set definition
-    tileMatrixSet: Optional[str]
+    tileMatrixSet: Optional[str] = None
     # Reference to a Tile Matrix Set on an official source
-    tileMatrixSetURI: Optional[str]
+    tileMatrixSetURI: Optional[str] = None
     # Links to related resources.
-    links: Optional[List[LinkType]]
+    links: Optional[List[LinkType]] = None

--- a/pygeoapi/models/provider/mvt.py
+++ b/pygeoapi/models/provider/mvt.py
@@ -41,12 +41,12 @@ class VectorLayers(BaseModel):
 
 class MVTTilesJson(BaseModel):
     tilejson: str = "3.0.0"
-    name: Optional[str]
-    tiles: Optional[str]
-    minzoom: Optional[int]
-    maxzoom: Optional[int]
-    bounds: Optional[str]
-    center: Optional[str]
-    attribution: Optional[str]
-    description: Optional[str]
-    vector_layers: Optional[List[VectorLayers]]
+    name: Optional[str] = None
+    tiles: Optional[str]  = None
+    minzoom: Optional[int] = None
+    maxzoom: Optional[int] = None
+    bounds: Optional[str] = None
+    center: Optional[str] = None
+    attribution: Optional[str] = None
+    description: Optional[str] = None
+    vector_layers: Optional[List[VectorLayers]] = None

--- a/pygeoapi/models/provider/mvt.py
+++ b/pygeoapi/models/provider/mvt.py
@@ -42,7 +42,7 @@ class VectorLayers(BaseModel):
 class MVTTilesJson(BaseModel):
     tilejson: str = "3.0.0"
     name: Optional[str] = None
-    tiles: Optional[str]  = None
+    tiles: Optional[str] = None
     minzoom: Optional[int] = None
     maxzoom: Optional[int] = None
     bounds: Optional[str] = None


### PR DESCRIPTION
# Overview

The tileset metadata endpoint for tilejson metadata is no longer working.

# Related Issue / Discussion

https://github.com/geopython/pygeoapi/issues/1418

# Additional Information

This issue is related to the upgrade of the pydantic version: https://github.com/geopython/pygeoapi/pull/1353

According to [this](https://docs.pydantic.dev/latest/migration/), pydantic2 requires all the optional fields to be present, unless they have a default value of None. This PR adds defaults values to all the optional fields, so that we[ continue to instantiate the model, without having all the information](https://github.com/geopython/pygeoapi/blob/master/pygeoapi/provider/mvt.py#L283).

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
