### PR TITLE
Support jsonld for items with null geometry

### DIFF
--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -211,8 +211,6 @@ def geojson2jsonld(cls, data: dict, dataset: str,
         data.update(data.pop('properties'))
 
         # Include multiple geometry encodings
-        # if data.get('geometry') is not null:
-
         if (data.get('geometry') is not None):
             data['type'] = 'schema:Place'
             jsonldify_geometry(data)

--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -216,7 +216,8 @@ def geojson2jsonld(cls, data: dict, dataset: str,
         if (data.get('geometry') is not None):
             data['type'] = 'schema:Place'
             jsonldify_geometry(data)
-            data['@id'] = identifier
+
+        data['@id'] = identifier
 
     else:
         # Collection of jsonld

--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -211,9 +211,12 @@ def geojson2jsonld(cls, data: dict, dataset: str,
         data.update(data.pop('properties'))
 
         # Include multiple geometry encodings
-        data['type'] = 'schema:Place'
-        jsonldify_geometry(data)
-        data['@id'] = identifier
+        # if data.get('geometry') is not null:
+
+        if (data.get('geometry') is not None):
+            data['type'] = 'schema:Place'
+            jsonldify_geometry(data)
+            data['@id'] = identifier
 
     else:
         # Collection of jsonld


### PR DESCRIPTION
# Overview

Some items, like records, may have no geometry . This is throwing an error on the jsonld representation, because it always expect a geometry. This fix will avoid geometry operations over items that have a null geometry.

# Related Issue / Discussion

https://github.com/geopython/pygeoapi/issues/1422

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
