### PR TITLE
Fixed openapi fixture usage in tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,13 +94,13 @@ def api_(config, openapi):
 
 
 @pytest.fixture()
-def enclosure_api(config_enclosure):
+def enclosure_api(config_enclosure, openapi):
     """ Returns an API instance with a collection with enclosure links. """
     return API(config_enclosure, openapi)
 
 
 @pytest.fixture()
-def rules_api(config_with_rules):
+def rules_api(config_with_rules, openapi):
     """ Returns an API instance with URL prefix and strict slashes policy.
     The API version is extracted from the current version here.
     """
@@ -108,7 +108,7 @@ def rules_api(config_with_rules):
 
 
 @pytest.fixture()
-def api_hidden_resources(config_hidden_resources):
+def api_hidden_resources(config_hidden_resources, openapi):
     return API(config_hidden_resources, openapi)
 
 

--- a/tests/test_api_ogr_provider.py
+++ b/tests/test_api_ogr_provider.py
@@ -56,7 +56,7 @@ def openapi():
 
 
 @pytest.fixture()
-def api_(config):
+def api_(config, openapi):
     return API(config, openapi)
 
 


### PR DESCRIPTION
# Overview

This PR fixes a bug in some test fixtures that are using an `openapi` object without declaring it as a parameter.

# Related Issue / Discussion

- fixes #1428 

# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
