### PR TITLE
fix coords for non-cube query

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -1012,7 +1012,7 @@ def get_oas_30(cfg):
                 if eqe['qt'] == 'cube':
                     spatial_parameter = 'bbox'
                 else:
-                    spatial_parameter = f"{eqe['qt']}Coords.yaml"
+                    spatial_parameter = f"{eqe['qt']}Coords"
                 paths[eqe['path']] = {
                     'get': {
                         'summary': f"query {v['description']} by {eqe['qt']}",  # noqa


### PR DESCRIPTION
# Overview
This is a follow-up fix to #1404, which improperly designated the link to the Coords yaml file for non-cube queries.

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this bug fix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
