### PR TITLE
add notes on using RFC1738 URLs for ES connections (#1413)

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -109,7 +109,17 @@ To publish an Elasticsearch index, the following are required in your index:
          id_field: geonameid
          time_field: datetimefield
 
-This provider has the support for the CQL queries as indicated in the table above.
+.. note::
+
+   For Elasticseach indexes that are password protect, a RFC1738 URL can be used as follows:
+
+   ``data: http://username:password@localhost:9200/ne_110m_populated_places_simple``
+
+   To further conceal authentication credentials, environment variables can be used:
+
+   ``data: http://${MY_USERNAME}:${MY_PASSWORD}@localhost:9200/ne_110m_populated_places_simple``
+
+The ES provider also has the support for the CQL queries as indicated in the table above.
 
 .. seealso::
   :ref:`cql` for more details on how to use Common Query Language (CQL) to filter the collection with specific queries.


### PR DESCRIPTION
# Overview
Adds a note about using RFC1738 URLs for ES instances that have access control applied.
# Related Issue / Discussion
#1413 
# Additional Information
None
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
