### PR TITLE
add gunicorn reload trigger to Docker setup

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -100,6 +100,8 @@ case ${entry_cmd} in
 				--timeout ${WSGI_WORKER_TIMEOUT} \
 				--name=${CONTAINER_NAME} \
 				--bind ${CONTAINER_HOST}:${CONTAINER_PORT} \
+                                --reload \
+				--reload-extra-file ${PYGEOAPI_CONFIG} \
 				pygeoapi.flask_app:APP
 	  ;;
 	*)


### PR DESCRIPTION
# Overview
This PR adds gunicorn's reload functionality based on changes to a given file.  As a result, when pygeoapi configuration changes, gunicorn will restart its workers accordingly.
# Related Issue / Discussion
Partial solution for #1417 (we will introduce 
# Additional Information

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
