### PR TITLE
Included exception info in the logs, if available

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -49,6 +49,7 @@ from gzip import compress
 from http import HTTPStatus
 import logging
 import re
+import sys
 from typing import Any, Tuple, Union, Optional
 
 from dateutil.parser import parse as dateparse
@@ -1388,7 +1389,11 @@ class API:
         :returns: tuple of headers, status, and message
         """
 
-        LOGGER.error(description)
+        exception_info = sys.exc_info()
+        LOGGER.error(
+            description,
+            exc_info=exception_info if exception_info[0] is not None else None
+        )
         exception = {
             'code': code,
             'type': code,

--- a/pygeoapi/api/coverages.py
+++ b/pygeoapi/api/coverages.py
@@ -97,7 +97,6 @@ def get_collection_coverage(
             HTTPStatus.NOT_FOUND, headers, format_,
             'InvalidParameterValue', msg)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -161,14 +160,12 @@ def get_collection_coverage(
             subsets = validate_subset(request.params['subset'] or '')
         except (AttributeError, ValueError) as err:
             msg = f'Invalid subset: {err}'
-            LOGGER.error(msg)
             return api.get_exception(
                     HTTPStatus.BAD_REQUEST, headers, format_,
                     'InvalidParameterValue', msg)
 
         if not set(subsets.keys()).issubset(p.axes):
             msg = 'Invalid axis name'
-            LOGGER.error(msg)
             return api.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, format_,
                 'InvalidParameterValue', msg)
@@ -180,7 +177,6 @@ def get_collection_coverage(
     try:
         data = p.query(**query_args)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)

--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -149,7 +149,6 @@ def get_collection_edr_query(api: API, request: APIRequest,
         p = load_plugin('provider', get_provider_by_type(
             collections[dataset]['providers'], 'edr'))
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -191,7 +190,6 @@ def get_collection_edr_query(api: API, request: APIRequest,
     try:
         data = p.query(**query_args)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -135,7 +135,6 @@ def get_collection_queryables(api: API, request: Union[APIRequest, Any],
             p = load_plugin('provider', get_provider_by_type(
                 api.config['resources'][dataset]['providers'], 'record'))
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -316,7 +315,6 @@ def get_collection_items(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'NoApplicableCode', msg)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -443,8 +441,7 @@ def get_collection_items(
                 storage_crs_uri=provider_def.get('storage_crs'),
                 geometry_column_name=provider_def.get('geom_field'),
             )
-        except Exception as err:
-            LOGGER.error(err)
+        except Exception:
             msg = f'Bad CQL string : {cql_text}'
             return api.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
@@ -491,7 +488,6 @@ def get_collection_items(
                           crs_transform_spec=crs_transform_spec,
                           q=q, language=prv_locale, filterq=filter_)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -596,8 +592,7 @@ def get_collection_items(
                                         'feature')
                 }
             )
-        except FormatterSerializationError as err:
-            LOGGER.error(err)
+        except FormatterSerializationError:
             msg = 'Error serializing output'
             return api.get_exception(
                 HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
@@ -857,8 +852,7 @@ def post_collection_items(
         # Parse bytes data, if applicable
         data = request.data.decode()
         LOGGER.debug(data)
-    except UnicodeDecodeError as err:
-        LOGGER.error(err)
+    except UnicodeDecodeError:
         msg = 'Unicode error in data'
         return api.get_exception(
             HTTPStatus.BAD_REQUEST, headers, request.format,
@@ -875,8 +869,7 @@ def post_collection_items(
                 storage_crs_uri=provider_def.get('storage_crs'),
                 geometry_column_name=provider_def.get('geom_field')
             )
-        except Exception as err:
-            LOGGER.error(err)
+        except Exception:
             msg = f'Bad CQL string : {data}'
             return api.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
@@ -885,8 +878,7 @@ def post_collection_items(
         LOGGER.debug('processing Elasticsearch CQL_JSON data')
         try:
             filter_ = CQLModel.parse_raw(data)
-        except Exception as err:
-            LOGGER.error(err)
+        except Exception:
             msg = f'Bad CQL string : {data}'
             return api.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
@@ -902,7 +894,6 @@ def post_collection_items(
                           q=q,
                           filterq=filter_)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -935,7 +926,6 @@ def manage_collection_item(
 
     if dataset not in collections.keys():
         msg = 'Collection not found'
-        LOGGER.error(msg)
         return api.get_exception(
             HTTPStatus.NOT_FOUND, headers, request.format, 'NotFound', msg)
 
@@ -951,7 +941,6 @@ def manage_collection_item(
             p = load_plugin('provider', provider_def)
         except ProviderTypeError:
             msg = 'Invalid provider type'
-            LOGGER.error(msg)
             return api.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'InvalidParameterValue', msg)
@@ -967,14 +956,12 @@ def manage_collection_item(
 
     if not p.editable:
         msg = 'Collection is not editable'
-        LOGGER.error(msg)
         return api.get_exception(
             HTTPStatus.BAD_REQUEST, headers, request.format,
             'InvalidParameterValue', msg)
 
     if action in ['create', 'update'] and not request.data:
         msg = 'No data found'
-        LOGGER.error(msg)
         return api.get_exception(
             HTTPStatus.BAD_REQUEST, headers, request.format,
             'InvalidParameterValue', msg)
@@ -989,7 +976,6 @@ def manage_collection_item(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'InvalidParameterValue', msg)
         except ProviderGenericError as err:
-            LOGGER.error(err)
             return api.get_exception(
                 err.http_status_code, headers, request.format,
                 err.ogc_exception_code, err.message)
@@ -1008,7 +994,6 @@ def manage_collection_item(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'InvalidParameterValue', msg)
         except ProviderGenericError as err:
-            LOGGER.error(err)
             return api.get_exception(
                 err.http_status_code, headers, request.format,
                 err.ogc_exception_code, err.message)
@@ -1020,7 +1005,6 @@ def manage_collection_item(
         try:
             _ = p.delete(identifier)
         except ProviderGenericError as err:
-            LOGGER.error(err)
             return api.get_exception(
                 err.http_status_code, headers, request.format,
                 err.ogc_exception_code, err.message)
@@ -1073,7 +1057,6 @@ def get_collection_item(api: API, request: APIRequest,
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'InvalidParameterValue', msg)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -1106,7 +1089,6 @@ def get_collection_item(api: API, request: APIRequest,
             crs_transform_spec=crs_transform_spec,
         )
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)

--- a/pygeoapi/api/maps.py
+++ b/pygeoapi/api/maps.py
@@ -96,7 +96,6 @@ def get_collection_map(api: API, request: APIRequest,
         return headers, HTTPStatus.NOT_FOUND, to_json(
             exception, api.pretty_print)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -160,7 +159,6 @@ def get_collection_map(api: API, request: APIRequest,
     try:
         data = p.query(**query_args)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -214,7 +212,6 @@ def get_collection_map_legend(api: API, request: APIRequest,
         return headers, HTTPStatus.NOT_FOUND, to_json(
             exception, api.pretty_print)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -223,7 +220,6 @@ def get_collection_map_legend(api: API, request: APIRequest,
     try:
         data = p.get_legend(style, request.params.get('f', 'png'))
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)

--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -364,9 +364,8 @@ def execute_process(api: API, request: APIRequest,
 
     try:
         data = json.loads(data)
-    except (json.decoder.JSONDecodeError, TypeError) as err:
+    except (json.decoder.JSONDecodeError, TypeError):
         # Input does not appear to be valid JSON
-        LOGGER.error(err)
         msg = 'invalid request data'
         return api.get_exception(
             HTTPStatus.BAD_REQUEST, headers, request.format,
@@ -407,7 +406,6 @@ def execute_process(api: API, request: APIRequest,
         headers.update(additional_headers or {})
         headers['Location'] = f'{api.base_url}/jobs/{job_id}'
     except ProcessorExecuteError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers,
             request.format, err.ogc_exception_code, err.message)

--- a/pygeoapi/api/stac.py
+++ b/pygeoapi/api/stac.py
@@ -144,8 +144,7 @@ def get_stac_path(api: API, request: APIRequest,
     try:
         p = load_plugin('provider', get_provider_by_type(
             stac_collections[dataset]['providers'], 'stac'))
-    except ProviderConnectionError as err:
-        LOGGER.error(err)
+    except ProviderConnectionError:
         msg = 'connection error (check logs)'
         return api.get_exception(
             HTTPStatus.INTERNAL_SERVER_ERROR, headers,
@@ -168,13 +167,11 @@ def get_stac_path(api: API, request: APIRequest,
             path,
             path.replace(dataset, '', 1)
         )
-    except ProviderNotFoundError as err:
-        LOGGER.error(err)
+    except ProviderNotFoundError:
         msg = 'resource not found'
         return api.get_exception(HTTPStatus.NOT_FOUND, headers,
                                  request.format, 'NotFound', msg)
-    except Exception as err:
-        LOGGER.error(err)
+    except Exception:
         msg = 'data query error'
         return api.get_exception(
             HTTPStatus.INTERNAL_SERVER_ERROR, headers,
@@ -204,7 +201,6 @@ def get_stac_path(api: API, request: APIRequest,
                     )
                 else:
                     msg = f'Unknown STAC type {content.type}'
-                    LOGGER.error(msg)
                     return api.get_exception(
                         HTTPStatus.INTERNAL_SERVER_ERROR,
                         headers,

--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -103,7 +103,6 @@ def get_collection_tiles(api: API, request: APIRequest,
             HTTPStatus.BAD_REQUEST, headers, request.format,
             'InvalidParameterValue', msg)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -252,7 +251,6 @@ def get_collection_tiles_data(
             HTTPStatus.BAD_REQUEST, headers, format_,
             'InvalidParameterValue', msg)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
@@ -295,7 +293,6 @@ def get_collection_tiles_metadata(
             HTTPStatus.BAD_REQUEST, headers, request.format,
             'InvalidParameterValue', msg)
     except ProviderGenericError as err:
-        LOGGER.error(err)
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)


### PR DESCRIPTION
# Overview

This PR modifies `API.get.exception()`'s already existing call to `LOGGER.error()` to include exception-related information, if available.

As a result of this modification, all calls to `LOGGER.error()` made just before a call to `API.get_exception()` also got removed, as the logging call that is inside the method is now able to show info related to exceptions.

# Related Issue / Discussion
- fixes #1442 


# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
