### PR TITLE
Modified starlette test client initialization to not receive a base URL

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -162,15 +162,14 @@ def mock_starlette(config_file: str = 'pygeoapi-test-config.yml',
         reload(starlette_app)
 
         # Get server root path
-        base_url = starlette_app.CONFIG['server']['url'].rstrip('/')
-        root_path = urlsplit(base_url).path.rstrip('/') or ''
+        public_base_url = starlette_app.CONFIG['server']['url'].rstrip('/')
+        root_path = urlsplit(public_base_url).path.rstrip('/') or ''
 
         # Create and return test client
         # Note: setting the 'root_path' does NOT really work and
         # does not have the same effect as Flask's APPLICATION_ROOT
         client = StarletteClient(
             starlette_app.APP,
-            base_url,
             root_path=root_path,
             **kwargs
         )


### PR DESCRIPTION
# Overview
This PR fixes the failing of CI due to the [recent starlette release](https://github.com/encode/starlette/releases/tag/0.34.0) which modified how its TestClient merges URLs.

The fix is very small and consists in not using the `base_url` initialization parameter to the test client. See the related issue for more detail about the change

# Related Issue / Discussion
- fixes #1445 

# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
