### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,7 +77,8 @@ ARG ADD_DEB_PACKAGES="\
     python3-zarr \
     python3-mapscript \
     python3-pytest \
-    python3-pyld"
+    python3-pyld \
+    python3-numpy"
 
 # ENV settings
 ENV TZ=${TZ} \


### PR DESCRIPTION
Added numpy in the ADD_DEB_PACKAGES

# Overview
numpy is added into the dockerfile as a first level dependency.
# Related Issue / Discussion
[https://github.com/geopython/pygeoapi/issues/1426#issue-2039505089](url)
# Additional Information
Since numpy was not a first level dependency it is being added as a first level dependency.
# Contributions and Licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [numpy is a first level dependency| numpy being implicitly installed] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
