### PR TITLE
Updated well-known tileMatrixSetURIs to normative references on the OGC definition server

### DIFF
--- a/pygeoapi/models/provider/base.py
+++ b/pygeoapi/models/provider/base.py
@@ -79,7 +79,8 @@ class TileMatrixSetEnumType(BaseModel):
 class TileMatrixSetEnum(Enum):
     WORLDCRS84QUAD = TileMatrixSetEnumType(
         tileMatrixSet="WorldCRS84Quad",
-        tileMatrixSetURI="http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json",  # noqa
+
+        tileMatrixSetURI="http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldCRS84Quad",  # noqa
         crs="http://www.opengis.net/def/crs/OGC/1.3/CRS84",
         tileMatrixSetDefinition=
             {
@@ -91,7 +92,7 @@ class TileMatrixSetEnum(Enum):
         )
     WEBMERCATORQUAD = TileMatrixSetEnumType(
         tileMatrixSet="WebMercatorQuad",
-        tileMatrixSetURI="http://schemas.opengis.net/tms/1.0/json/examples/WebMercatorQuad.json",  # noqa
+        tileMatrixSetURI="http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",  # noqa
         crs="http://www.opengis.net/def/crs/EPSG/0/3857",
         tileMatrixSetDefinition=
             {

--- a/pygeoapi/models/provider/base.py
+++ b/pygeoapi/models/provider/base.py
@@ -79,7 +79,6 @@ class TileMatrixSetEnumType(BaseModel):
 class TileMatrixSetEnum(Enum):
     WORLDCRS84QUAD = TileMatrixSetEnumType(
         tileMatrixSet="WorldCRS84Quad",
-
         tileMatrixSetURI="http://www.opengis.net/def/tilematrixset/OGC/1.0/WorldCRS84Quad",  # noqa
         crs="http://www.opengis.net/def/crs/OGC/1.3/CRS84",
         tileMatrixSetDefinition=


### PR DESCRIPTION
# Overview

This PR updates the tileMatrixSetURIs for the supported common TileMatrixSet Definitions.

# Related issue / discussion
https://github.com/geopython/pygeoapi/issues/1470

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
