### PR TITLE
Include requirements-admin.txt to Quickstart

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -27,6 +27,7 @@ For developers and the truly impatient
    cd pygeoapi
    pip3 install --upgrade pip
    pip3 install -r requirements.txt
+   pip3 install -r requirements-admin.txt
    python3 setup.py install
    cp pygeoapi-config.yml example-config.yml
    vi example-config.yml  # edit as required


### PR DESCRIPTION
# Overview
Adds installing admin requirements to the install in 5 minutes section.

# Related issue / discussion
Closes https://github.com/geopython/pygeoapi/issues/1469
# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
