### PR TITLE
Replaced mutable default parameters with None

### DIFF
--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -153,7 +153,8 @@ class CSVProvider(BaseProvider):
                 feature['properties'] = OrderedDict()
 
                 if self.properties or select_properties:
-                    for p in set(self.properties) | set(select_properties or []):
+                    select_properties = set(select_properties or [])
+                    for p in set(self.properties) | select_properties:
                         try:
                             feature['properties'][p] = get_typed_value(row[p])
                         except KeyError as err:

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -153,7 +153,7 @@ class CSVProvider(BaseProvider):
                 feature['properties'] = OrderedDict()
 
                 if self.properties or select_properties:
-                    for p in set(self.properties) | set(select_properties):
+                    for p in set(self.properties) | set(select_properties or []):
                         try:
                             feature['properties'][p] = get_typed_value(row[p])
                         except KeyError as err:

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -90,8 +90,8 @@ class CSVProvider(BaseProvider):
             return fields
 
     def _load(self, offset=0, limit=10, resulttype='results',
-              identifier=None, bbox=[], datetime_=None, properties=[],
-              select_properties=[], skip_geometry=False, q=None):
+              identifier=None, bbox=None, datetime_=None, properties=None,
+              select_properties=None, skip_geometry=False, q=None):
         """
         Load CSV data
 
@@ -185,8 +185,8 @@ class CSVProvider(BaseProvider):
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None, **kwargs):
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None, **kwargs):
         """
         CSV query
 

--- a/pygeoapi/provider/csw_facade.py
+++ b/pygeoapi/provider/csw_facade.py
@@ -92,8 +92,8 @@ class CSWFacadeProvider(BaseProvider):
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None, **kwargs):
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None, **kwargs):
         """
         CSW GetRecords query
 
@@ -139,7 +139,7 @@ class CSWFacadeProvider(BaseProvider):
                 constraints.append(fes.PropertyIsEqualTo(date_property,
                                                          datetime_))
 
-        for p in properties:
+        for p in properties or []:
             LOGGER.debug(f'Processing property {p} parameter')
             if p[0] not in list(self.record_mappings.keys()):
                 msg = f'Invalid property: {p[0]}'

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -132,8 +132,8 @@ class ElasticsearchProvider(BaseProvider):
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None,
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None,
               filterq=None, **kwargs):
         """
         query Elasticsearch index
@@ -153,7 +153,7 @@ class ElasticsearchProvider(BaseProvider):
         :returns: dict of 0..n GeoJSON features
         """
 
-        self.select_properties = select_properties
+        self.select_properties = select_properties or []
 
         query = {'track_total_hits': True, 'query': {'bool': {'filter': []}}}
         filter_ = []
@@ -547,8 +547,8 @@ class ElasticsearchCatalogueProvider(ElasticsearchProvider):
         return fields
 
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None,
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None,
               filterq=None, **kwargs):
 
         records = super().query(

--- a/pygeoapi/provider/erddap.py
+++ b/pygeoapi/provider/erddap.py
@@ -81,8 +81,8 @@ class TabledapProvider(BaseProvider):
         return properties
 
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None,
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None,
               filterq=None, **kwargs):
 
         query_params = []

--- a/pygeoapi/provider/esri.py
+++ b/pygeoapi/provider/esri.py
@@ -108,8 +108,8 @@ class ESRIServiceProvider(BaseProvider):
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None, **kwargs):
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None, **kwargs):
         """
         ESRI query
 
@@ -136,7 +136,7 @@ class ESRIServiceProvider(BaseProvider):
             'where': self._make_where(properties, datetime_)
             }
 
-        if bbox != []:
+        if len(bbox or []) == 4:
             xmin, ymin, xmax, ymax = bbox
             params['inSR'] = '4326'
             params['geometryType'] = 'esriGeometryEnvelope'
@@ -233,7 +233,7 @@ class ESRIServiceProvider(BaseProvider):
 
         :returns: ESRI query `order` clause
         """
-        if sortby == []:
+        if not sortby:
             return None
 
         __ = {'+': 'ASC', '-': 'DESC'}
@@ -241,7 +241,7 @@ class ESRIServiceProvider(BaseProvider):
 
         return ','.join(ret)
 
-    def _make_fields(self, select_properties=[]):
+    def _make_fields(self, select_properties=None):
         """
         Make ESRI out fields clause
 
@@ -249,17 +249,18 @@ class ESRIServiceProvider(BaseProvider):
 
         :returns: ESRI query `outFields` clause
         """
-        if self.properties == [] and select_properties == []:
+        select_properties = select_properties or []
+        if not self.properties and not select_properties:
             return '*'
 
-        if self.properties != [] and select_properties != []:
+        if self.properties and select_properties:
             outFields = set(self.properties) & set(select_properties)
         else:
             outFields = set(self.properties) | set(select_properties)
 
         return ','.join(outFields)
 
-    def _make_where(self, properties=[], datetime_=None):
+    def _make_where(self, properties=None, datetime_=None):
         """
         Make ESRI filter from query properties
 
@@ -269,12 +270,12 @@ class ESRIServiceProvider(BaseProvider):
         :returns: ESRI query `where` clause
         """
 
-        if properties == [] and datetime_ is None:
+        if not properties and datetime_ is None:
             return '1 = 1'
 
         p = []
 
-        if properties != []:
+        if properties:
 
             for (k, v) in properties:
                 if 'String' in self.fields[k]['type']:

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -95,7 +95,7 @@ class GeoJSONProvider(BaseProvider):
             LOGGER.warning(f'File {self.data} does not exist.')
         return fields
 
-    def _load(self, skip_geometry=None, properties=[], select_properties=[]):
+    def _load(self, skip_geometry=None, properties=None, select_properties=None):
         """Load and validate the source GeoJSON file
         at self.data
 
@@ -133,8 +133,8 @@ class GeoJSONProvider(BaseProvider):
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None, **kwargs):
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None, **kwargs):
         """
         query the provider
 

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -95,7 +95,12 @@ class GeoJSONProvider(BaseProvider):
             LOGGER.warning(f'File {self.data} does not exist.')
         return fields
 
-    def _load(self, skip_geometry=None, properties=None, select_properties=None):
+    def _load(
+            self,
+            skip_geometry=None,
+            properties=None,
+            select_properties=None
+    ):
         """Load and validate the source GeoJSON file
         at self.data
 

--- a/pygeoapi/provider/mapscript_.py
+++ b/pygeoapi/provider/mapscript_.py
@@ -115,7 +115,7 @@ class MapScriptProvider(BaseProvider):
             LOGGER.warning(err)
             raise ProviderConnectionError('Cannot connect to map service')
 
-    def query(self, style=None, bbox=[], width=500, height=300, crs='CRS84',
+    def query(self, style=None, bbox=None, width=500, height=300, crs='CRS84',
               datetime_=None, format_='png', transparent=True, **kwargs):
         """
         Generate map
@@ -147,7 +147,7 @@ class MapScriptProvider(BaseProvider):
                 prj_src = mapscript.projectionObj(self._layer.getProjection())
                 prj_dst = mapscript.projectionObj(prj_dst_text)
 
-                rect = mapscript.rectObj(*bbox)
+                rect = mapscript.rectObj(*(bbox or []))
                 _ = rect.project(prj_src, prj_dst)
 
                 map_bbox = [rect.minx, rect.miny, rect.maxx, rect.maxy]

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -299,8 +299,8 @@ class OGRProvider(BaseProvider):
         return fields
 
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None,
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None,
               crs_transform_spec=None, **kwargs):
         """
         Query OGR source

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -55,7 +55,7 @@ class DatabaseConnection:
     The class returns a connection object.
     """
 
-    def __init__(self, conn_dic, table, properties=[], context="query"):
+    def __init__(self, conn_dic, table, properties=None, context="query"):
         """
         OracleProvider Class constructor
 
@@ -86,7 +86,7 @@ class DatabaseConnection:
         self.columns = (
             None  # Comma sepparated string with column names (for SQL query)
         )
-        self.properties = [item.lower() for item in properties]
+        self.properties = [item.lower() for item in properties or []]
         self.fields = {}  # Dict of columns. Key is col name, value is type
         self.conn = None
 
@@ -532,10 +532,10 @@ class OracleProvider(BaseProvider):
         resulttype="results",
         bbox=None,
         datetime_=None,
-        properties=[],
-        sortby=[],
+        properties=None,
+        sortby=None,
         skip_geometry=False,
-        select_properties=[],
+        select_properties=None,
         crs_transform_spec=None,
         q=None,
         language=None,
@@ -560,6 +560,8 @@ class OracleProvider(BaseProvider):
         :returns: GeoJSON FeaturesCollection
         """
 
+        properties = properties or []
+        select_properties = select_properties or []
         # Check mandatory filter properties
         property_dict = dict(properties)
         if self.mandatory_properties:
@@ -621,7 +623,7 @@ class OracleProvider(BaseProvider):
             #   or the configured columns from the Yaml file.
             props = (
                 db.columns
-                if select_properties == []
+                if not select_properties
                 else ", ".join([p for p in select_properties])
             )
 

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -112,8 +112,8 @@ class PostgreSQLProvider(BaseProvider):
         self.fields = self.get_fields()
 
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None,
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None,
               filterq=None, crs_transform_spec=None, **kwargs):
         """
         Query Postgis for all the content.
@@ -140,7 +140,7 @@ class PostgreSQLProvider(BaseProvider):
         property_filters = self._get_property_filters(properties)
         cql_filters = self._get_cql_filters(filterq)
         bbox_filter = self._get_bbox_filter(bbox)
-        order_by_clauses = self._get_order_by_clauses(sortby, self.table_model)
+        order_by_clauses = self._get_order_by_clauses(sortby or [], self.table_model)
         selected_properties = self._select_properties_clause(select_properties,
                                                              skip_geometry)
 

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -140,7 +140,8 @@ class PostgreSQLProvider(BaseProvider):
         property_filters = self._get_property_filters(properties)
         cql_filters = self._get_cql_filters(filterq)
         bbox_filter = self._get_bbox_filter(bbox)
-        order_by_clauses = self._get_order_by_clauses(sortby or [], self.table_model)
+        order_by_clauses = self._get_order_by_clauses(
+            sortby or [], self.table_model)
         selected_properties = self._select_properties_clause(select_properties,
                                                              skip_geometry)
 

--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -175,7 +175,7 @@ class RasterioProvider(BaseProvider):
         """
 
         bands = properties or []
-        subsets = dict(subsets) if subsets is not None else {}
+        subsets = subsets or {}
         LOGGER.debug(f'Bands: {bands}, subsets: {subsets}')
 
         args = {

--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -161,7 +161,7 @@ class RasterioProvider(BaseProvider):
 
         return rangetype
 
-    def query(self, properties=[], subsets={}, bbox=None, bbox_crs=4326,
+    def query(self, properties=None, subsets=None, bbox=None, bbox_crs=4326,
               datetime_=None, format_='json', **kwargs):
         """
         Extract data from collection collection
@@ -174,7 +174,8 @@ class RasterioProvider(BaseProvider):
         :returns: coverage data as dict of CoverageJSON or native format
         """
 
-        bands = properties
+        bands = properties or []
+        subsets = dict(subsets) if subsets is not None else {}
         LOGGER.debug(f'Bands: {bands}, subsets: {subsets}')
 
         args = {

--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -233,7 +233,8 @@ class SensorThingsProvider(BaseProvider):
         }
 
         if properties or bbox or datetime_:
-            params['$filter'] = self._make_filter(properties or [], bbox, datetime_)
+            params['$filter'] = self._make_filter(
+                properties or [], bbox, datetime_)
 
         if sortby:
             params['$orderby'] = self._make_orderby(sortby or [])
@@ -272,7 +273,12 @@ class SensorThingsProvider(BaseProvider):
 
         return fc
 
-    def _make_feature(self, entity, select_properties=None, skip_geometry=False):
+    def _make_feature(
+            self,
+            entity,
+            select_properties=None,
+            skip_geometry=False
+    ):
         """
         Private function: Create feature from entity
 

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -104,7 +104,7 @@ class SQLiteGPKGProvider(BaseProvider):
 
         return self.fields
 
-    def __get_where_clauses(self, properties=[], bbox=[]):
+    def __get_where_clauses(self, properties=None, bbox=None):
         """
         Generarates WHERE conditions to be implemented in query.
         Private method mainly associated with query method.
@@ -278,8 +278,8 @@ class SQLiteGPKGProvider(BaseProvider):
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None, **kwargs):
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None, **kwargs):
         """
         Query SQLite/GPKG for all the content.
         e,g: http://localhost:5000/collections/countries/items?

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -98,8 +98,8 @@ class TinyDBCatalogueProvider(BaseProvider):
         return fields
 
     def query(self, offset=0, limit=10, resulttype='results',
-              bbox=[], datetime_=None, properties=[], sortby=[],
-              select_properties=[], skip_geometry=False, q=None, **kwargs):
+              bbox=None, datetime_=None, properties=None, sortby=None,
+              select_properties=None, skip_geometry=False, q=None, **kwargs):
         """
         query TinyDB document store
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -201,7 +201,7 @@ class XarrayProvider(BaseProvider):
 
         return rangetype
 
-    def query(self, properties=[], subsets={}, bbox=[], bbox_crs=4326,
+    def query(self, properties=None, subsets=None, bbox=None, bbox_crs=4326,
               datetime_=None, format_='json', **kwargs):
         """
          Extract data from collection collection
@@ -215,6 +215,8 @@ class XarrayProvider(BaseProvider):
 
         :returns: coverage data as dict of CoverageJSON or native format
         """
+        properties = properties if properties is not None else []
+        subsets = subsets if subsets is not None else {}
 
         if not properties and not subsets and format_ != 'json':
             LOGGER.debug('No parameters specified, returning native data')


### PR DESCRIPTION
# Overview
This PR replaces the usage of mutable default method parameters with `None` and makes the necessary adjustments in the method body in order to cope with the change.

Most of the times this simply means ensuring that a value is a list if not provided in order to not break iteration.

Also made some comparisons implicit by doing:

```python
if not a:
    # do something
```

instead of 

```python
if a == []:
    # do something
```

This is regarded as the more pythonic way of checking for the existence of contents of some sequence, as mentioned in [pep8](https://peps.python.org/pep-0008/#programming-recommendations):


> For sequences, (strings, lists, tuples), use the fact that empty sequences are false:
> ```python
> # Correct:
> if not seq:
> if seq:
>
> # Wrong:
> if len(seq):
>if not len(seq):
> ```

# Related issue / discussion

- fixes #1474


# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
