### PR TITLE
Check docker image CVEs in vulnerabilities workflow

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -27,16 +27,23 @@ jobs:
     - name: Checkout pygeoapi
       uses: actions/checkout@v4
     - name: Scan vulnerabilities with trivy
-      run: |
-        sudo apt-get install -y wget apt-transport-https gnupg lsb-release
-        wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
-        echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
-        sudo apt-get update
-        sudo apt-get install -y trivy
-        trivy --exit-code 1 fs --scanners vuln,misconfig,secret --severity HIGH,CRITICAL --ignore-unfixed .
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: fs
+        exit-code: 1
+        ignore-unfixed: true
+        severity: CRITICAL,HIGH
+        scanners: vuln,misconfig,secret
+        scan-ref: .
     - name: Build locally the image from Dockerfile
       run: |
         docker buildx build -t ${{ env.DOCKER_REPOSITORY }}:${{ github.sha }} --platform linux/amd64 --no-cache -f Dockerfile .
     - name: Scan locally built Docker image for vulnerabilities with trivy
-      run: |
-        trivy --exit-code 1 image --severity HIGH,CRITICAL ${{ env.DOCKER_REPOSITORY }}:${{ github.sha }} --ignore-unfixed
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: image
+        exit-code: 1
+        ignore-unfixed: true
+        severity: CRITICAL,HIGH
+        vuln-type: os,library
+        image-ref: '${{ env.DOCKER_REPOSITORY }}:${{ github.sha }}'

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -13,6 +13,9 @@ on:
     types:
       - released
 
+env:
+  DOCKER_REPOSITORY: geopython/pygeoapi
+
 jobs:
   clone:
     runs-on: ubuntu-22.04
@@ -38,3 +41,9 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y trivy
         trivy --exit-code 1 fs --scanners vuln,misconfig,secret --severity HIGH,CRITICAL --ignore-unfixed .
+    - name: Build an image from Dockerfile
+      run: |
+        docker build -t ${{ env.DOCKER_REPOSITORY }}:${{ github.sha }} .
+    - name: Scan locally built Docker image for vulnerabilities with trivy
+      run: |
+        trivy --exit-code 1 image --severity HIGH,CRITICAL ${{ env.DOCKER_REPOSITORY }}:${{ github.sha }} --ignore-unfixed

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -17,22 +17,15 @@ env:
   DOCKER_REPOSITORY: geopython/pygeoapi
 
 jobs:
-  clone:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.8
-          architecture: x64
-      - name: Checkout pygeoapi
-        uses: actions/checkout@master
 
   vulnerabilities:
-    needs: [clone]
     runs-on: ubuntu-22.04
-
+    defaults:
+      run:
+        working-directory: .
     steps:
+    - name: Checkout pygeoapi
+      uses: actions/checkout@v4
     - name: Scan vulnerabilities with trivy
       run: |
         sudo apt-get install -y wget apt-transport-https gnupg lsb-release
@@ -41,7 +34,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y trivy
         trivy --exit-code 1 fs --scanners vuln,misconfig,secret --severity HIGH,CRITICAL --ignore-unfixed .
-    - name: Build an image from Dockerfile
+    - name: Build locally the image from Dockerfile
       run: |
         docker buildx build -t ${{ env.DOCKER_REPOSITORY }}:${{ github.sha }} --platform linux/amd64 --no-cache -f Dockerfile .
     - name: Scan locally built Docker image for vulnerabilities with trivy

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -13,9 +13,6 @@ on:
     types:
       - released
 
-env:
-  DOCKER_REPOSITORY: geopython/pygeoapi
-
 jobs:
 
   vulnerabilities:
@@ -37,7 +34,7 @@ jobs:
         scan-ref: .
     - name: Build locally the image from Dockerfile
       run: |
-        docker buildx build -t ${{ env.DOCKER_REPOSITORY }}:${{ github.sha }} --platform linux/amd64 --no-cache -f Dockerfile .
+        docker buildx build -t ${{ github.repository }}:${{ github.sha }} --platform linux/amd64 --no-cache -f Dockerfile .
     - name: Scan locally built Docker image for vulnerabilities with trivy
       uses: aquasecurity/trivy-action@master
       with:
@@ -46,4 +43,4 @@ jobs:
         ignore-unfixed: true
         severity: CRITICAL,HIGH
         vuln-type: os,library
-        image-ref: '${{ env.DOCKER_REPOSITORY }}:${{ github.sha }}'
+        image-ref: '${{ github.repository }}:${{ github.sha }}'

--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -43,7 +43,7 @@ jobs:
         trivy --exit-code 1 fs --scanners vuln,misconfig,secret --severity HIGH,CRITICAL --ignore-unfixed .
     - name: Build an image from Dockerfile
       run: |
-        docker build -t ${{ env.DOCKER_REPOSITORY }}:${{ github.sha }} .
+        docker buildx build -t ${{ env.DOCKER_REPOSITORY }}:${{ github.sha }} --platform linux/amd64 --no-cache -f Dockerfile .
     - name: Scan locally built Docker image for vulnerabilities with trivy
       run: |
         trivy --exit-code 1 image --severity HIGH,CRITICAL ${{ env.DOCKER_REPOSITORY }}:${{ github.sha }} --ignore-unfixed


### PR DESCRIPTION
# Overview
Check CVEs in the Docker image via [trivy](https://aquasecurity.github.io/trivy). Limitations:
- Ignore unfixed CVEs

# Related issue / discussion
[#1479](https://github.com/geopython/pygeoapi/issues/1479)

# Additional information
None

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
