### PR TITLE
Data return for STAC collections

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3810,9 +3810,29 @@ class API:
             if request.format == F_HTML:  # render
                 content['path'] = path
                 if 'assets' in content:  # item view
-                    content = render_j2_template(self.tpl_config,
-                                                 'stac/item.html',
-                                                 content, request.locale)
+                    if content['type'] == 'Collection':
+                        content = render_j2_template(
+                            self.tpl_config,
+                            'stac/collection_base.html',
+                            content,
+                            request.locale
+                        )
+                    elif content['type'] == 'Feature':
+                        content = render_j2_template(
+                            self.tpl_config,
+                            'stac/item.html',
+                            content,
+                            request.locale
+                        )
+                    else:
+                        msg = f'Unknown STAC type {content.type}'
+                        LOGGER.error(msg)
+                        return self.get_exception(
+                            HTTPStatus.INTERNAL_SERVER_ERROR,
+                            headers,
+                            request.format,
+                            'NoApplicableCode',
+                            msg)
                 else:
                     content = render_j2_template(self.tpl_config,
                                                  'stac/catalog.html',

--- a/pygeoapi/provider/hateoas.py
+++ b/pygeoapi/provider/hateoas.py
@@ -171,7 +171,11 @@ class HateoasProvider(BaseProvider):
 
             if len(link_href_list) == 0:
                 content = jsondata
-                content = _modify_content_for_display(content, baseurl, urlpath)
+                content = _modify_content_for_display(
+                    content,
+                    baseurl,
+                    urlpath
+                )
 
         elif resource_type == 'Assets':
             content = jsondata
@@ -191,7 +195,7 @@ def _modify_content_for_display(
         urlpath: str,
     ) -> dict:
     """
-    Helper function to fill out required information in content for HTML display
+    Helper function to fill in required information for HTML display.
 
     :param content: `dict` of JSON item
     :param baseurl: base URL of endpoint
@@ -201,14 +205,16 @@ def _modify_content_for_display(
     """
     content['assets']['default'] = {
         'href': os.path.join(baseurl, urlpath).replace('\\', '/'),
-    }   
+    }
     for key in content['assets']:
         content['assets'][key]['file:size'] = 0
         try:
             content['assets'][key]['created'] = content["properties"]["datetime"] # noqa
-        except:
-            pass
+        except Exception as err:
+            LOGGER.debug(err)
+            LOGGER.debug('no properties included in STAC')
     return content
+
 
 def _get_json_data(jsonpath):
     """

--- a/pygeoapi/provider/hateoas.py
+++ b/pygeoapi/provider/hateoas.py
@@ -169,15 +169,13 @@ class HateoasProvider(BaseProvider):
                         'entry:type': 'Item'
                     })
 
+            if len(link_href_list) == 0:
+                content = jsondata
+                content = _modify_content_for_display(content, baseurl, urlpath)
+
         elif resource_type == 'Assets':
             content = jsondata
-            content['assets']['default'] = {
-                'href': os.path.join(baseurl, urlpath).replace('\\', '/'),
-            }
-
-            for key in content['assets']:
-                content['assets'][key]['file:size'] = 0
-                content['assets'][key]['created'] = jsondata["properties"]["datetime"] # noqa
+            content = _modify_content_for_display(content, baseurl, urlpath)
 
         content['links'].extend(child_links)
 
@@ -186,6 +184,31 @@ class HateoasProvider(BaseProvider):
     def __repr__(self):
         return f'<HateoasProvider> {self.data}'
 
+
+def _modify_content_for_display(
+        content: dict,
+        baseurl: str,
+        urlpath: str,
+    ) -> dict:
+    """
+    Helper function to fill out required information in content for HTML display
+
+    :param content: `dict` of JSON item
+    :param baseurl: base URL of endpoint
+    :param urlpath: base path of URL
+
+    :returns: `dict` of JSON item
+    """
+    content['assets']['default'] = {
+        'href': os.path.join(baseurl, urlpath).replace('\\', '/'),
+    }   
+    for key in content['assets']:
+        content['assets'][key]['file:size'] = 0
+        try:
+            content['assets'][key]['created'] = content["properties"]["datetime"] # noqa
+        except:
+            pass
+    return content
 
 def _get_json_data(jsonpath):
     """

--- a/pygeoapi/provider/hateoas.py
+++ b/pygeoapi/provider/hateoas.py
@@ -192,8 +192,7 @@ class HateoasProvider(BaseProvider):
 def _modify_content_for_display(
         content: dict,
         baseurl: str,
-        urlpath: str,
-    ) -> dict:
+        urlpath: str) -> dict:
     """
     Helper function to fill in required information for HTML display.
 

--- a/pygeoapi/provider/hateoas.py
+++ b/pygeoapi/provider/hateoas.py
@@ -169,7 +169,7 @@ class HateoasProvider(BaseProvider):
                         'entry:type': 'Item'
                     })
 
-            if len(link_href_list) == 0:
+            if resource_type == "Collection" and len(link_href_list) == 0:
                 content = jsondata
                 content = _modify_content_for_display(
                     content,

--- a/pygeoapi/templates/stac/collection_base.html
+++ b/pygeoapi/templates/stac/collection_base.html
@@ -1,0 +1,114 @@
+{% extends "_base.html" %}
+{% block title %}{{ super() }} stac/{{ data['path'] }} {% endblock %}
+{% block crumbs %}{{ super() }}
+/ <a href="{{ config['server']['url'] }}/stac">{% trans %}SpatioTemporal Asset Catalog{% endtrans %}</a>
+{% for link in get_breadcrumbs(data['path']) %}
+/ <a class="crumbs-path" href="{{config['server']['url'] }}/stac/{{ link['href'] }}">{{ link['title'] }}</a>
+{% endfor %}
+{% endblock %}
+
+{% block extrahead %}
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
+    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+{% endblock %}
+
+{% block body %}
+    <section id="item">
+      <div class="row">
+        <div class="col-sm">
+          <h2>{% trans %}Collections{% endtrans %}: {{ data['id'] }}</h2>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-6 col-sm-12">
+          <div class="row">
+            <div class="col-sm-12">
+              <div id="items-map"></div>
+              <div id="assets">
+                <h4>{% trans %}Assets{% endtrans %}</h4>
+                <table class="table table-striped table-bordered">
+                  <thead>
+                    <tr>
+                      <th>{% trans %}URL{% endtrans %}</th>
+                      <th>{% trans %}Last Modified{% endtrans %}</th>
+                      <th>{% trans %}Size{% endtrans %}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                  {% for k, link in data['assets'].items() %}
+                  <tr>
+                    <td data-label="name">
+                      <a title="{{ link['href'] }}" href="{{ link['href'] }}">
+                      <span>{{ link['href'] | get_path_basename }}</span></a>
+                    </td>
+                    <td data-label="created">{{ link['created'] }}</td>
+                    <td data-label="size">{{ link['file:size'] | human_size }}</td>
+                  </tr>
+                  {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 col-sm-12">
+            <table class="table table-striped table-bordered">
+              <thead>
+              <tr>
+                <th>{% trans %}Property{% endtrans %}</th>
+                <th>{% trans %}Value{% endtrans %}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{% trans %}id{% endtrans %}</td>
+                <td>{{ data.id }}</td>
+              </tr>
+              <tr>
+                <td>{% trans %}description{% endtrans %}</td>
+                <td>{{ data.description }}</td>
+              </tr>
+              <tr>
+                <td>{% trans %}extent{% endtrans %}</td>
+                <td>{{ data.extent }}</td>
+              </tr>
+              {% if data['cube:dimensions'] %}
+              <tr>
+                <td>{% trans %}cube:dimensions{% endtrans %}</td>
+                <td>{{ data['cube:dimensions'] }}</td>
+              </tr>
+              {% endif %}
+              {% if data['cube:variables'] %}
+              <tr>
+                <td>{% trans %}cube:variables{% endtrans %}</td>
+                <td>{{ data['cube:variables'] }}</td>
+              </tr>
+              {% endif %}
+
+            </tbody>
+            </table>
+        </div>
+      </div>
+    </section>
+{% endblock %}
+
+{% block extrafoot %}
+    <script>
+    //var map = L.map('items-map').setView([{{ 45 }}, {{ -75 }}], 2);
+    var map = L.map('items-map').setView([{{ 0 }}, {{ 0 }}], 1);
+    map.addLayer(new L.TileLayer(
+        '{{ config['server']['map']['url'] }}', {
+            maxZoom: 18,
+            attribution: '{{ config['server']['map']['attribution'] | safe }}'
+        }
+    ));
+    var bbox_layer = L.polygon([
+        [{{ data['extent']['spatial']['bbox'][0][1] }}, {{ data['extent']['spatial']['bbox'][0][0] }}],
+        [{{ data['extent']['spatial']['bbox'][0][3] }}, {{ data['extent']['spatial']['bbox'][0][0] }}],
+        [{{ data['extent']['spatial']['bbox'][0][3] }}, {{ data['extent']['spatial']['bbox'][0][2] }}],
+        [{{ data['extent']['spatial']['bbox'][0][1] }}, {{ data['extent']['spatial']['bbox'][0][2] }}],
+    ]);
+    map.addLayer(bbox_layer);
+    map.fitBounds(bbox_layer.getBounds(), {maxZoom: 10});
+    </script>
+{% endblock %}


### PR DESCRIPTION
# Overview
In the `hateoas` provider, check to see if `collections` have any `items` within them. If they do not, then create a data rendering page that displays the contents of the `collection`, including a map of the extent and a table of properties.

# Related issue / discussion
This was raised in #1409.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

Note: there are no changes to the config file as a result of this update (the hateoas provider does not appear to be in the config file). Is there anything else that I need to check in the public demo?

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this feature to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
