### PR TITLE
EDR /locations and /locations/{locId} endpoints

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3651,7 +3651,8 @@ class API:
     @pre_process
     def get_collection_edr_query(
             self, request: Union[APIRequest, Any],
-            dataset, instance, query_type) -> Tuple[dict, int, str]:
+            dataset, instance, query_type,
+            location_id=None) -> Tuple[dict, int, str]:
         """
         Queries collection EDR
 
@@ -3659,6 +3660,7 @@ class API:
         :param dataset: dataset name
         :param instance: instance name
         :param query_type: EDR query type
+        :param location_id: location id of a /location/<location_id> query
 
         :returns: tuple of headers, status code, content
         """
@@ -3694,11 +3696,11 @@ class API:
             parameternames = parameternames.split(',')
 
         bbox = None
-        if query_type == 'cube':
+        if query_type in ['cube', 'locations']:
             LOGGER.debug('Processing cube bbox')
             try:
                 bbox = validate_bbox(request.params.get('bbox'))
-                if not bbox:
+                if not bbox and query_type == 'cube':
                     raise ValueError('bbox parameter required by cube queries')
             except ValueError as err:
                 return self.get_exception(
@@ -3716,7 +3718,7 @@ class API:
                 return self.get_exception(
                     HTTPStatus.BAD_REQUEST, headers, request.format,
                     'InvalidParameterValue', msg)
-        elif query_type != 'cube':
+        elif query_type not in ['cube', 'locations']:
             msg = 'missing coords parameter'
             return self.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
@@ -3771,7 +3773,8 @@ class API:
             bbox=bbox,
             within=within,
             within_units=within_units,
-            limit=int(self.config['server']['limit'])
+            limit=int(self.config['server']['limit']),
+            location_id=location_id,
         )
 
         try:

--- a/pygeoapi/django_/urls.py
+++ b/pygeoapi/django_/urls.py
@@ -183,6 +183,16 @@ urlpatterns = [
         name='collection-edr-corridor',
     ),
     path(
+        'collections/<str:collection_id>/locations/<str:location_id>',
+        views.get_collection_edr_query,
+        name='collection-edr-corridor',
+    ),
+    path(
+        'collections/<str:collection_id>/locations',
+        views.get_collection_edr_query,
+        name='collection-edr-corridor',
+    ),
+    path(
         'collections/<str:collection_id>/instances/<str:instance_id>/position',
         views.get_collection_edr_query,
         name='collection-edr-instance-position',
@@ -211,6 +221,16 @@ urlpatterns = [
         'collections/<str:collection_id>/instances/<str:instance_id>/corridor',
         views.get_collection_edr_query,
         name='collection-edr-instance-corridor',
+    ),
+    path(
+        'collections/<str:collection_id>/instances/locations/<str:location_id>',  # noqa
+        views.get_collection_edr_query,
+        name='collection-edr-corridor',
+    ),
+    path(
+        'collections/<str:collection_id>/instances/locations',
+        views.get_collection_edr_query,
+        name='collection-edr-corridor',
     ),
     path(apply_slash_rule('processes/'), views.processes, name='processes'),
     path('processes/<str:process_id>', views.processes, name='process-detail'),

--- a/pygeoapi/django_/views.py
+++ b/pygeoapi/django_/views.py
@@ -433,7 +433,8 @@ def job_results_resource(request: HttpRequest, process_id: str, job_id: str,
 
 def get_collection_edr_query(
         request: HttpRequest, collection_id: str,
-        instance_id: Optional[str] = None
+        instance_id: Optional[str] = None,
+        location_id: Optional[str] = None
 ) -> HttpResponse:
     """
     OGC API - EDR endpoint
@@ -441,17 +442,22 @@ def get_collection_edr_query(
     :param request: Django HTTP Request
     :param collection_id: collection identifier
     :param instance_id: optional instance identifier. default is None
+    :param location_id: optional location identifier. default is None
 
     :returns: Django HTTP response
     """
 
-    query_type = request.path.split('/')[-1]
+    if location_id:
+        query_type = 'locations'
+    else:
+        query_type = request.path.split('/')[-1]
     response_ = _feed_response(
         request,
         'get_collection_edr_query',
         collection_id,
         instance_id,
-        query_type
+        query_type,
+        location_id
     )
     response = _to_django_response(*response_)
 

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -426,24 +426,35 @@ def get_job_result_resource(job_id, resource):
 @BLUEPRINT.route('/collections/<path:collection_id>/radius')
 @BLUEPRINT.route('/collections/<path:collection_id>/trajectory')
 @BLUEPRINT.route('/collections/<path:collection_id>/corridor')
+@BLUEPRINT.route('/collections/<path:collection_id>/locations/<location_id>')  # noqa
+@BLUEPRINT.route('/collections/<path:collection_id>/locations')  # noqa
 @BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>/position')  # noqa
 @BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>/area')  # noqa
 @BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>/cube')  # noqa
 @BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>/radius')  # noqa
 @BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>/trajectory')  # noqa
 @BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>/corridor')  # noqa
-def get_collection_edr_query(collection_id, instance_id=None):
+@BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>/locations/<location_id>')  # noqa
+@BLUEPRINT.route('/collections/<path:collection_id>/instances/<instance_id>/locations')  # noqa
+def get_collection_edr_query(collection_id, instance_id=None,
+                             location_id=None):
     """
     OGC EDR API endpoints
 
     :param collection_id: collection identifier
     :param instance_id: instance identifier
+    :param location_id: location id of a /locations/<location_id> query
 
     :returns: HTTP response
     """
-    query_type = request.path.split('/')[-1]
+    if location_id:
+        query_type = 'locations'
+    else:
+        query_type = request.path.split('/')[-1]
+
     return get_response(api_.get_collection_edr_query(request, collection_id,
-                                                      instance_id, query_type))
+                                                      instance_id, query_type,
+                                                      location_id))
 
 
 @BLUEPRINT.route('/stac')

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -985,7 +985,7 @@ def get_oas_30(cfg):
 
             edr_query_endpoints = []
 
-            for qt in ep.get_query_types():
+            for qt in [qt for qt in ep.get_query_types() if qt != 'locations']:
                 edr_query_endpoints.append({
                     'path': f'{collection_name_path}/{qt}',
                     'qt': qt,
@@ -1011,6 +1011,53 @@ def get_oas_30(cfg):
                         'operationId': eqe['op_id'],
                         'parameters': [
                             {'$ref': f"{OPENAPI_YAML['oaedr']}/parameters/{spatial_parameter}.yaml"},  # noqa
+                            {'$ref': f"{OPENAPI_YAML['oapif-1']}#/components/parameters/datetime"},  # noqa
+                            {'$ref': f"{OPENAPI_YAML['oaedr']}/parameters/parameter-name.yaml"},  # noqa
+                            {'$ref': f"{OPENAPI_YAML['oaedr']}/parameters/z.yaml"},  # noqa
+                            {'$ref': '#/components/parameters/f'}
+                        ],
+                        'responses': {
+                            '200': {
+                                'description': 'Response',
+                                'content': {
+                                    'application/prs.coverage+json': {
+                                        'schema': {
+                                            '$ref': f"{OPENAPI_YAML['oaedr']}/schemas/coverageJSON.yaml"  # noqa
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            if 'locations' in ep.get_query_types():
+                paths[f'{collection_name_path}/locations'] = {
+                    'get': {
+                        'summary': f"Get pre-defined locations of {v['description']}",  # noqa
+                        'description': v['description'],
+                        'tags': [k],
+                        'operationId': f'queryLOCATIONS{k.capitalize()}',
+                        'parameters': [
+                            {'$ref': f"{OPENAPI_YAML['oaedr']}/parameters/bbox.yaml"},  # noqa
+                            {'$ref': f"{OPENAPI_YAML['oapif-1']}#/components/parameters/datetime"},  # noqa
+                            {'$ref': '#/components/parameters/f'}
+                        ],
+                        'responses': {
+                            '200': {'$ref': f"{OPENAPI_YAML['oapif-1']}#/components/responses/Features"},  # noqa
+                            '400': {'$ref': f"{OPENAPI_YAML['oapif-1']}#/components/responses/InvalidParameter"},  # noqa
+                            '500': {'$ref': f"{OPENAPI_YAML['oapif-1']}#/components/responses/ServerError"}  # noqa
+                        }
+                    }
+                }
+                paths[f'{collection_name_path}/locations/{{locId}}'] = {
+                    'get': {
+                        'summary': f"query {v['description']} by location",  # noqa
+                        'description': v['description'],
+                        'tags': [k],
+                        'operationId': f'queryLOCATIONSBYID{k.capitalize()}',
+                        'parameters': [
+                            {'$ref': f"{OPENAPI_YAML['oaedr']}/parameters/{spatial_parameter}.yaml"},  # noqa
+                            {'$ref': f"{OPENAPI_YAML['oaedr']}/parameters/locationId.yaml"},  # noqa
                             {'$ref': f"{OPENAPI_YAML['oapif-1']}#/components/parameters/datetime"},  # noqa
                             {'$ref': f"{OPENAPI_YAML['oaedr']}/parameters/parameter-name.yaml"},  # noqa
                             {'$ref': f"{OPENAPI_YAML['oaedr']}/parameters/z.yaml"},  # noqa

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -645,12 +645,16 @@ api_routes = [
     Route('/collections/{collection_id:path}/radius', get_collection_edr_query),  # noqa
     Route('/collections/{collection_id:path}/trajectory', get_collection_edr_query),  # noqa
     Route('/collections/{collection_id:path}/corridor', get_collection_edr_query),  # noqa
+    Route('/collections/{collection_id:path}/locations', get_collection_edr_query),  # noqa
+    Route('/collections/{collection_id:path}/locations/{location_id}', get_collection_edr_query),  # noqa
     Route('/collections/{collection_id:path}/instances/{instance_id}/position', get_collection_edr_query),  # noqa
     Route('/collections/{collection_id:path}/instances/{instance_id}/area', get_collection_edr_query),  # noqa
     Route('/collections/{collection_id:path}/instances/{instance_id}/cube', get_collection_edr_query),  # noqa
     Route('/collections/{collection_id:path}/instances/{instance_id}/radius', get_collection_edr_query),  # noqa
     Route('/collections/{collection_id:path}/instances/{instance_id}/trajectory', get_collection_edr_query),  # noqa
     Route('/collections/{collection_id:path}/instances/{instance_id}/corridor', get_collection_edr_query),  # noqa
+    Route('/collections/{collection_id:path}/instances/{instance_id}/locations', get_collection_edr_query),  # noqa
+    Route('/collections/{collection_id:path}/instances/{instance_id}/locations/{location_id}', get_collection_edr_query),  # noqa
     Route('/collections', collections),
     Route('/collections/{collection_id:path}', collections),
     Route('/stac', stac_catalog_root),


### PR DESCRIPTION
# Overview

Enable EDR providers to implement locations query type, and have adherent OAS generated as well.

# Related issue / discussion

Issue: #1486 

# Additional information

I have not written any tests yet, as the built in EDR providers can not have a default locations implementation.

Is the way to test this feature, simply creating a new contrived EDR provider with some hardcoded test data, and write the test on that? Should these tests be in its own file, separate from the rest of the EDR API tests? I need a little bit of guidance here.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

I don't know how to this, or if it is relevant in this case.

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute feature to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
