### PR TITLE
Convert coordinates to storage crs when filtering via cql

### DIFF
--- a/docs/source/cql.rst
+++ b/docs/source/cql.rst
@@ -40,6 +40,15 @@ Using Elasticsearch the following type of queries are supported right now:
 * Logical ``and`` query with ``between`` and ``eq`` expression
 * Spatial query with ``bbox``
 
+Note that when using a spatial operator in your filter expression, geometries are by default interpreted as being
+in the OGC:CRS84 Coordinate Reference System. If you wish to provide geometries in other CRS, use the ``filter-crs``
+query parameter with a suitable value.
+
+Alternatively, a geometry's CRS may also be included using Extended Well-Known Text, in which case it will override
+the value of ``filter-crs`` (if any) - this can be useful if your filtering expression is complex enough to
+need multiple geometries expressed in different CRSs. The standard way of providing ``filter-crs`` as an additional
+query parameter is preferable for most cases.
+
 Examples
 ^^^^^^^^
 
@@ -92,5 +101,21 @@ A ``CROSSES`` example via an HTTP GET request.  The CQL text is passed via the `
 .. code-block:: bash
 
   curl "http://localhost:5000/collections/hot_osm_waterways/items?f=json&filter=CROSSES(foo_geom,%20LINESTRING(28%20-2,%2030%20-4))"
+
+A ``DWITHIN`` example via HTTP GET and using a custom CRS for the filter geometry:
+
+.. code-block:: bash
+
+  curl "http://localhost:5000/collections/beni/items?filter=DWITHIN(geometry,POINT(1392921%205145517),100,meters)&filter-crs=http://www.opengis.net/def/crs/EPSG/0/3857"
+
+
+The same example, but this time providing a geometry in EWKT format:
+
+.. code-block:: bash
+
+  curl "http://localhost:5000/collections/beni/items?filter=DWITHIN(geometry,SRID=3857;POINT(1392921%205145517),100,meters)"
+
+
+
 
 Note that the CQL text has been URL encoded. This is required in curl commands but when entering in a browser, plain text can be used e.g. ``CROSSES(foo_geom, LINESTRING(28 -2, 30 -4))``.

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1894,7 +1894,7 @@ class API:
 
         try:
             provider_def = get_provider_by_type(
-                collections[dataset]['providers'],'feature')
+                collections[dataset]['providers'], 'feature')
         except ProviderTypeError:
             try:
                 provider_def = get_provider_by_type(

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1376,7 +1376,7 @@ class API:
         reserved_fieldnames = ['bbox', 'bbox-crs', 'crs', 'f', 'lang', 'limit',
                                'offset', 'resulttype', 'datetime', 'sortby',
                                'properties', 'skipGeometry', 'q',
-                               'filter', 'filter-lang']
+                               'filter', 'filter-lang', 'filter-crs']
 
         collections = filter_dict_by_key_value(self.config['resources'],
                                                'type', 'collection')
@@ -1589,6 +1589,8 @@ class API:
         else:
             skip_geometry = False
 
+        LOGGER.debug('Processing filter-crs parameter')
+        filter_crs_uri = request.params.get('filter-crs', DEFAULT_CRS)
         LOGGER.debug('processing filter parameter')
         cql_text = request.params.get('filter')
         if cql_text is not None:
@@ -1596,8 +1598,9 @@ class API:
                 filter_ = parse_ecql_text(cql_text)
                 filter_ = modify_pygeofilter(
                     filter_,
+                    filter_crs_uri=filter_crs_uri,
                     storage_crs_uri=provider_def.get('storage_crs'),
-                    geometry_column_name=provider_def.get('geom_field')
+                    geometry_column_name=provider_def.get('geom_field'),
                 )
             except Exception as err:
                 LOGGER.error(err)
@@ -1616,7 +1619,6 @@ class API:
             return self.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'InvalidParameterValue', msg)
-
         # Get provider locale (if any)
         prv_locale = l10n.get_plugin_locale(provider_def, request.raw_locale)
 
@@ -1637,6 +1639,7 @@ class API:
         LOGGER.debug(f'cql_text: {cql_text}')
         LOGGER.debug(f'filter_: {filter_}')
         LOGGER.debug(f'filter-lang: {filter_lang}')
+        LOGGER.debug(f'filter-crs: {filter_crs_uri}')
 
         try:
             content = p.query(offset=offset, limit=limit,
@@ -1806,7 +1809,7 @@ class API:
         reserved_fieldnames = ['bbox', 'f', 'limit', 'offset',
                                'resulttype', 'datetime', 'sortby',
                                'properties', 'skipGeometry', 'q',
-                               'filter-lang']
+                               'filter-lang', 'filter-crs']
 
         collections = filter_dict_by_key_value(self.config['resources'],
                                                'type', 'collection')
@@ -1969,6 +1972,8 @@ class API:
         else:
             skip_geometry = False
 
+        LOGGER.debug('Processing filter-crs parameter')
+        filter_crs = request.params.get('filter-crs', DEFAULT_CRS)
         LOGGER.debug('Processing filter-lang parameter')
         filter_lang = request.params.get('filter-lang')
         if filter_lang != 'cql-json':  # @TODO add check from the configuration
@@ -1988,6 +1993,7 @@ class API:
         LOGGER.debug(f'skipGeometry: {skip_geometry}')
         LOGGER.debug(f'q: {q}')
         LOGGER.debug(f'filter-lang: {filter_lang}')
+        LOGGER.debug(f'filter-crs: {filter_crs}')
 
         LOGGER.debug('Processing headers')
 
@@ -2027,6 +2033,7 @@ class API:
                 filter_ = parse_cql_json(data)
                 filter_ = modify_pygeofilter(
                     filter_,
+                    filter_crs_uri=filter_crs,
                     storage_crs_uri=provider_def.get('storage_crs'),
                     geometry_column_name=provider_def.get('geom_field')
                 )

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -55,7 +55,6 @@ from geoalchemy2 import Geometry  # noqa - this isn't used explicitly but is nee
 from geoalchemy2.functions import ST_MakeEnvelope
 from geoalchemy2.shape import to_shape
 from pygeofilter.backends.sqlalchemy.evaluate import to_filter
-import pygeofilter.ast
 import pyproj
 import shapely
 from sqlalchemy import create_engine, MetaData, PrimaryKeyConstraint, asc, desc
@@ -139,8 +138,9 @@ class PostgreSQLProvider(BaseProvider):
 
         LOGGER.debug('Preparing filters')
         property_filters = self._get_property_filters(properties)
-        modified_filterq = self._modify_pygeofilter(filterq)
-        cql_filters = self._get_cql_filters(modified_filterq)
+        cql_filters = self._get_cql_filters(filterq)
+        # modified_filterq = self._modify_pygeofilter(filterq)
+        # cql_filters = self._get_cql_filters(modified_filterq)
         bbox_filter = self._get_bbox_filter(bbox)
         order_by_clauses = self._get_order_by_clauses(sortby, self.table_model)
         selected_properties = self._select_properties_clause(select_properties,
@@ -497,40 +497,3 @@ class PostgreSQLProvider(BaseProvider):
         else:
             crs_transform = None
         return crs_transform
-
-    def _modify_pygeofilter(
-            self,
-            ast_tree: pygeofilter.ast.Node,
-    ) -> pygeofilter.ast.Node:
-        """
-        Prepare the input pygeofilter for querying the database.
-
-        Returns a new ``pygeofilter.ast.Node`` object that can be used for
-        querying the database.
-        """
-        new_tree = deepcopy(ast_tree)
-        _inplace_replace_geometry_filter_name(new_tree, self.geom)
-        return new_tree
-
-
-def _inplace_replace_geometry_filter_name(
-        node: pygeofilter.ast.Node,
-        geometry_column_name: str
-):
-    """Recursively traverse node tree and rename nodes of type ``Attribute``.
-
-    Nodes of type ``Attribute`` named ``geometry`` are renamed to the value of
-    the ``geometry_column_name`` parameter.
-    """
-    try:
-        sub_nodes = node.get_sub_nodes()
-    except AttributeError:
-        pass
-    else:
-        for sub_node in sub_nodes:
-            is_attribute_node = isinstance(sub_node, pygeofilter.ast.Attribute)
-            if is_attribute_node and sub_node.name == "geometry":
-                sub_node.name = geometry_column_name
-            else:
-                _inplace_replace_geometry_filter_name(
-                    sub_node, geometry_column_name)

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -139,8 +139,6 @@ class PostgreSQLProvider(BaseProvider):
         LOGGER.debug('Preparing filters')
         property_filters = self._get_property_filters(properties)
         cql_filters = self._get_cql_filters(filterq)
-        # modified_filterq = self._modify_pygeofilter(filterq)
-        # cql_filters = self._get_cql_filters(modified_filterq)
         bbox_filter = self._get_bbox_filter(bbox)
         order_by_clauses = self._get_order_by_clauses(sortby, self.table_model)
         selected_properties = self._select_properties_clause(select_properties,

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -964,8 +964,6 @@ def _inplace_transform_filter_geometries(
                     crs = get_crs_from_uri(crs_urn_provided_in_ewkt)
                 else:
                     crs = filter_crs
-                print(f"{crs=}")
-                print(f"{storage_crs=}")
                 if crs != storage_crs:
                     # convert geometry coordinates to storage crs
                     geom = geojson_to_geom(sub_node.geometry)

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -44,9 +44,7 @@ import pytest
 import pyproj
 from http import HTTPStatus
 
-import pygeofilter.ast
 from pygeofilter.parsers.ecql import parse
-from pygeofilter.values import Geometry
 
 from pygeoapi.api import API
 
@@ -750,69 +748,3 @@ def test_get_collection_items_postgresql_automap_naming_conflicts(pg_api_):
     assert code == HTTPStatus.OK
     features = json.loads(response).get('features')
     assert len(features) == 0
-
-
-@pytest.mark.parametrize('original_filter, expected', [
-    pytest.param(
-        "INTERSECTS(geometry, POINT(1 1))",
-        pygeofilter.ast.GeometryIntersects(
-            pygeofilter.ast.Attribute(name='custom_geom_name'),
-            Geometry({'type': 'Point', 'coordinates': (1, 1)})
-        ),
-        id='unnested-geometry'
-    ),
-    pytest.param(
-        "some_attribute = 10 AND INTERSECTS(geometry, POINT(1 1))",
-        pygeofilter.ast.And(
-            pygeofilter.ast.Equal(
-                pygeofilter.ast.Attribute(name='some_attribute'), 10),
-            pygeofilter.ast.GeometryIntersects(
-                pygeofilter.ast.Attribute(name='custom_geom_name'),
-                Geometry({'type': 'Point', 'coordinates': (1, 1)})
-            ),
-        ),
-        id='nested-geometry'
-    ),
-    pytest.param(
-        "(some_attribute = 10 AND INTERSECTS(geometry, POINT(1 1))) OR "
-        "DWITHIN(geometry, POINT(2 2), 10, meters)",
-        pygeofilter.ast.Or(
-            pygeofilter.ast.And(
-                pygeofilter.ast.Equal(
-                    pygeofilter.ast.Attribute(name='some_attribute'), 10),
-                pygeofilter.ast.GeometryIntersects(
-                    pygeofilter.ast.Attribute(name='custom_geom_name'),
-                    Geometry({'type': 'Point', 'coordinates': (1, 1)})
-                ),
-            ),
-            pygeofilter.ast.DistanceWithin(
-                pygeofilter.ast.Attribute(name='custom_geom_name'),
-                Geometry({'type': 'Point', 'coordinates': (2, 2)}),
-                distance=10,
-                units='meters',
-            )
-        ),
-        id='complex-filter'
-    ),
-])
-def test_modify_pygeofilter(original_filter, expected):
-
-    class _CustomPostgreSqlProvider(PostgreSQLProvider):
-        """This is a subclass of the original PostgreSQLProvider.
-
-        The current test is only interested in verifying the correctness of
-        the logic that modifies the parsed filter. As such, in order
-        to simplify instantiating the postgresql pygeoapi provider, and
-        in order to avoid dealing with mocking out the sqlalchemy table
-        reflection mechanism, this class overrides the __init__() method
-        and can be used to test the implementation of the base class'
-        `self._modify_pygeofilter()` method, which is really all we want
-        to test here.
-        """
-        def __init__(self):
-            self.geom = 'custom_geom_name'
-
-    provider = _CustomPostgreSqlProvider()
-    parsed_filter = parse(original_filter)
-    result = provider._modify_pygeofilter(parsed_filter)
-    assert result == expected

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -29,6 +29,7 @@
 
 from datetime import datetime, date, time
 from decimal import Decimal
+from contextlib import nullcontext as does_not_raise
 from copy import deepcopy
 
 import pytest
@@ -267,19 +268,28 @@ def test_get_supported_crs_list():
             assert DUTCH_CRS in crs_list
 
 
-def test_get_crs_from_uri():
-    with pytest.raises(CRSError):
-        util.get_crs_from_uri('http://www.opengis.net/not/a/valid/crs/uri')
-    with pytest.raises(CRSError):
-        util.get_crs_from_uri('http://www.opengis.net/def/crs/EPSG/0/0')
-    CRS_DICT = {
-        'http://www.opengis.net/def/crs/OGC/1.3/CRS84': 'OGC:CRS84',
-        'http://www.opengis.net/def/crs/EPSG/0/4326': 'EPSG:4326',
-        'http://www.opengis.net/def/crs/EPSG/0/28992': 'EPSG:28992'
-    }
-    for key in CRS_DICT:
-        crs_obj = util.get_crs_from_uri(key)
-        assert crs_obj.srs == CRS_DICT[key]
+@pytest.mark.parametrize('uri, expected_raise, expected', [
+    pytest.param('http://www.opengis.net/not/a/valid/crs/uri', pytest.raises(CRSError), None),
+    pytest.param('http://www.opengis.net/def/crs/EPSG/0/0', pytest.raises(CRSError), None),
+    pytest.param('http://www.opengis.net/def/crs/OGC/1.3/CRS84', does_not_raise(), 'OGC:CRS84'),
+    pytest.param('http://www.opengis.net/def/crs/EPSG/0/4326', does_not_raise(), 'EPSG:4326'),
+    pytest.param('http://www.opengis.net/def/crs/EPSG/0/28992', does_not_raise(), 'EPSG:28992'),
+    pytest.param('urn:ogc:def:crs:not:a:valid:crs:urn', pytest.raises(CRSError), None),
+    pytest.param('urn:ogc:def:crs:epsg:0:0', pytest.raises(CRSError), None),
+    pytest.param('urn:ogc:def:crs:epsg::0', pytest.raises(CRSError), None),
+    pytest.param('urn:ogc:def:crs:OGC::0', pytest.raises(CRSError), None),
+    pytest.param('urn:ogc:def:crs:OGC:0:0', pytest.raises(CRSError), None),
+    pytest.param('urn:ogc:def:crs:OGC:0:CRS84', does_not_raise(), "OGC:CRS84"),
+    pytest.param('urn:ogc:def:crs:OGC::CRS84', does_not_raise(), "OGC:CRS84"),
+    pytest.param('urn:ogc:def:crs:EPSG:0:4326', does_not_raise(), "EPSG:4326"),
+    pytest.param('urn:ogc:def:crs:EPSG::4326', does_not_raise(), "EPSG:4326"),
+    pytest.param('urn:ogc:def:crs:epsg:0:4326', does_not_raise(), "EPSG:4326"),
+    pytest.param('urn:ogc:def:crs:epsg:0:28992', does_not_raise(), "EPSG:28992"),
+])
+def test_get_crs_from_uri(uri, expected_raise, expected):
+    with expected_raise:
+        crs = util.get_crs_from_uri(uri)
+        assert crs.srs.upper() == expected
 
 
 def test_transform_bbox():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -34,6 +34,9 @@ from copy import deepcopy
 
 import pytest
 from pyproj.exceptions import CRSError
+import pygeofilter.ast
+from pygeofilter.parsers.ecql import parse
+from pygeofilter.values import Geometry
 from shapely.geometry import Point
 
 from pygeoapi import util
@@ -269,12 +272,12 @@ def test_get_supported_crs_list():
 
 
 @pytest.mark.parametrize('uri, expected_raise, expected', [
-    pytest.param('http://www.opengis.net/not/a/valid/crs/uri', pytest.raises(CRSError), None),
-    pytest.param('http://www.opengis.net/def/crs/EPSG/0/0', pytest.raises(CRSError), None),
-    pytest.param('http://www.opengis.net/def/crs/OGC/1.3/CRS84', does_not_raise(), 'OGC:CRS84'),
-    pytest.param('http://www.opengis.net/def/crs/EPSG/0/4326', does_not_raise(), 'EPSG:4326'),
-    pytest.param('http://www.opengis.net/def/crs/EPSG/0/28992', does_not_raise(), 'EPSG:28992'),
-    pytest.param('urn:ogc:def:crs:not:a:valid:crs:urn', pytest.raises(CRSError), None),
+    pytest.param('http://www.opengis.net/not/a/valid/crs/uri', pytest.raises(CRSError), None),  # noqa
+    pytest.param('http://www.opengis.net/def/crs/EPSG/0/0', pytest.raises(CRSError), None),  # noqa
+    pytest.param('http://www.opengis.net/def/crs/OGC/1.3/CRS84', does_not_raise(), 'OGC:CRS84'),  # noqa
+    pytest.param('http://www.opengis.net/def/crs/EPSG/0/4326', does_not_raise(), 'EPSG:4326'),  # noqa
+    pytest.param('http://www.opengis.net/def/crs/EPSG/0/28992', does_not_raise(), 'EPSG:28992'),  # noqa
+    pytest.param('urn:ogc:def:crs:not:a:valid:crs:urn', pytest.raises(CRSError), None),  # noqa
     pytest.param('urn:ogc:def:crs:epsg:0:0', pytest.raises(CRSError), None),
     pytest.param('urn:ogc:def:crs:epsg::0', pytest.raises(CRSError), None),
     pytest.param('urn:ogc:def:crs:OGC::0', pytest.raises(CRSError), None),
@@ -284,7 +287,7 @@ def test_get_supported_crs_list():
     pytest.param('urn:ogc:def:crs:EPSG:0:4326', does_not_raise(), "EPSG:4326"),
     pytest.param('urn:ogc:def:crs:EPSG::4326', does_not_raise(), "EPSG:4326"),
     pytest.param('urn:ogc:def:crs:epsg:0:4326', does_not_raise(), "EPSG:4326"),
-    pytest.param('urn:ogc:def:crs:epsg:0:28992', does_not_raise(), "EPSG:28992"),
+    pytest.param('urn:ogc:def:crs:epsg:0:28992', does_not_raise(), "EPSG:28992"),  # noqa
 ])
 def test_get_crs_from_uri(uri, expected_raise, expected):
     with expected_raise:
@@ -326,3 +329,140 @@ def test_prefetcher():
     headers = prefetcher.get_headers(headers['location'])
     assert int(headers.get('content-length', 0)) == length
     assert headers.get('content-type') == 'image/png'
+
+
+@pytest.mark.parametrize('original_filter, storage_crs, geometry_colum_name, expected', [  # noqa
+    pytest.param(
+        "INTERSECTS(geometry, POINT(1 1))",
+        None,
+        None,
+        pygeofilter.ast.GeometryIntersects(
+            pygeofilter.ast.Attribute(name='geometry'),
+            Geometry({'type': 'Point', 'coordinates': (1, 1)})
+        ),
+        id='passthrough'
+    ),
+    pytest.param(
+        "INTERSECTS(geometry, POINT(1 1))",
+        None,
+        'custom_geom_name',
+        pygeofilter.ast.GeometryIntersects(
+            pygeofilter.ast.Attribute(name='custom_geom_name'),
+            Geometry({'type': 'Point', 'coordinates': (1, 1)})
+        ),
+        id='unnested-geometry-name'
+    ),
+    pytest.param(
+        "some_attribute = 10 AND INTERSECTS(geometry, POINT(1 1))",
+        None,
+        'custom_geom_name',
+        pygeofilter.ast.And(
+            pygeofilter.ast.Equal(
+                pygeofilter.ast.Attribute(name='some_attribute'), 10),
+            pygeofilter.ast.GeometryIntersects(
+                pygeofilter.ast.Attribute(name='custom_geom_name'),
+                Geometry({'type': 'Point', 'coordinates': (1, 1)})
+            ),
+        ),
+        id='nested-geometry-name'
+    ),
+    pytest.param(
+        "(some_attribute = 10 AND INTERSECTS(geometry, POINT(1 1))) OR "
+        "DWITHIN(geometry, POINT(2 2), 10, meters)",
+        None,
+        'custom_geom_name',
+        pygeofilter.ast.Or(
+            pygeofilter.ast.And(
+                pygeofilter.ast.Equal(
+                    pygeofilter.ast.Attribute(name='some_attribute'), 10),
+                pygeofilter.ast.GeometryIntersects(
+                    pygeofilter.ast.Attribute(name='custom_geom_name'),
+                    Geometry({'type': 'Point', 'coordinates': (1, 1)})
+                ),
+            ),
+            pygeofilter.ast.DistanceWithin(
+                pygeofilter.ast.Attribute(name='custom_geom_name'),
+                Geometry({'type': 'Point', 'coordinates': (2, 2)}),
+                distance=10,
+                units='meters',
+            )
+        ),
+        id='complex-filter-name'
+    ),
+    pytest.param(
+        "INTERSECTS(geometry, POINT(12.512829 41.896698))",
+        'http://www.opengis.net/def/crs/EPSG/0/3004',
+        None,
+        pygeofilter.ast.GeometryIntersects(
+            pygeofilter.ast.Attribute(name='geometry'),
+            Geometry({'type': 'Point', 'coordinates': (2313682.387730346, 4641308.550187246)})  # noqa
+        ),
+        id='unnested-geometry-transformed-coords'
+    ),
+    pytest.param(
+        "some_attribute = 10 AND INTERSECTS(geometry, POINT(12.512829 41.896698))",  # noqa
+        'http://www.opengis.net/def/crs/EPSG/0/3004',
+        None,
+        pygeofilter.ast.And(
+            pygeofilter.ast.Equal(
+                pygeofilter.ast.Attribute(name='some_attribute'), 10),
+            pygeofilter.ast.GeometryIntersects(
+                pygeofilter.ast.Attribute(name='geometry'),
+                Geometry({'type': 'Point', 'coordinates': (2313682.387730346, 4641308.550187246)})  # noqa
+            ),
+        ),
+        id='nested-geometry-transformed-coords'
+    ),
+    pytest.param(
+        "(some_attribute = 10 AND INTERSECTS(geometry, POINT(12.512829 41.896698))) OR "  # noqa
+        "DWITHIN(geometry, POINT(12 41), 10, meters)",
+        'http://www.opengis.net/def/crs/EPSG/0/3004',
+        None,
+        pygeofilter.ast.Or(
+            pygeofilter.ast.And(
+                pygeofilter.ast.Equal(
+                    pygeofilter.ast.Attribute(name='some_attribute'), 10),
+                pygeofilter.ast.GeometryIntersects(
+                    pygeofilter.ast.Attribute(name='geometry'),
+                    Geometry({'type': 'Point', 'coordinates': (2313682.387730346, 4641308.550187246)})  # noqa
+                ),
+            ),
+            pygeofilter.ast.DistanceWithin(
+                pygeofilter.ast.Attribute(name='geometry'),
+                Geometry({'type': 'Point', 'coordinates': (2267681.8892602, 4543101.513292163)}),  # noqa
+                distance=10,
+                units='meters',
+            )
+        ),
+        id='complex-filter-transformed-coords'
+    ),
+    pytest.param(
+        "INTERSECTS(geometry, SRID=3857;POINT(1392921 5145517))",
+        'http://www.opengis.net/def/crs/EPSG/0/3004',
+        None,
+        pygeofilter.ast.GeometryIntersects(
+            pygeofilter.ast.Attribute(name='geometry'),
+            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955416)})  # noqa
+        ),
+        id='unnested-geometry-transformed-coords-explicit-input-crs'
+    ),
+    pytest.param(
+        "INTERSECTS(geometry, POINT(12.512829 41.896698))",
+        'http://www.opengis.net/def/crs/EPSG/0/3004',
+        'custom_geom_name',
+        pygeofilter.ast.GeometryIntersects(
+            pygeofilter.ast.Attribute(name='custom_geom_name'),
+            Geometry({'type': 'Point', 'coordinates': (2313682.387730346, 4641308.550187246)})  # noqa
+        ),
+        id='unnested-geometry-name-and-transformed-coords'
+    ),
+])
+def test_modify_pygeofilter(
+        original_filter, storage_crs, geometry_colum_name, expected):
+    parsed_filter = parse(original_filter)
+    result = util.modify_pygeofilter(
+        parsed_filter,
+        storage_crs_uri=storage_crs,
+        geometry_column_name=geometry_colum_name
+    )
+    assert result == expected


### PR DESCRIPTION
# Overview

This PR implements conversion of geometries supplied in CQL filters to the storage CRS of a feature collection.

The main part of the implementation follows this logic:

1. Iterate through the nodes of the previously-parsed pygeofilter filter
2. If a node is of type `pygeofilter.values.Geometry`, retrieve its CRS information or default to the `OGC:CRS84` CRS if none is provided - CRS information is gotten from the `filter-crs` query parameter, if present - it can also be provided in the geometry definition, using EWKT notation
3. Depending on the CRS of the collection, as designated in the `storage_crs` configuration option of the relevant provider, determine whether it is necessary to transform the geometry to match the same CRS and the one used by the provider
4. If needed, convert the filter geometry's coordinates using a combination of pyproj and shapely, in similar fashion as the approach already being used elsewhere in the pygeoapi codebase
5. Update the pygeofilter node tree with the converted geometry, which will subsequently be used by the provider to query its datasource

This PR includes the following related modifications:

- `pygeoapi.util.get_crs_from_uri()` has been refactored in order to support both URN and URL types of URI. This was done in order to accomodate the fact that pygeofilter is using the URN form internally
- the logic to iterate through the pygeofilter node tree was previously only available inside the postgres provider. It has been moved out to the `pygeoapi.util.modify_pygeofilter()` function. This function now performs two checks:

    - Translates from the generic `geometry` name to whatever name the provider specifies in its `geom_field` configuration parameter - This is the same functionality introduced recently in #1453 
    - Converts coordinates to the appropriate storage CRS, _i.e._ the main purpose of this PR

This PR enables the use cases mentioned in #1488, which is basically to use whatever CRS when defining a geometry in a CQL filter, and default to assuming `OGC:CRS84`.

Example requests:

```sh

# no CRS specified - pygeoapi assumes OGC:CRS84 by default
curl http://localhost:5000/collections/beni_confiscati/items?\
    filter=DWITHIN(geometry,POINT(12.626000006069875 41.8108000011414),100,meters)

# CRS specified by means of the filter-crs query parameter
curl http://localhost:5000/collections/beni_confiscati/items?\
    filter=DWITHIN(geometry,POINT(2313683.65%204641312.29),100,meters)&\
    filter-crs=http://www.opengis.net/def/crs/EPSG/0/3004

# CRS specified by defining the filter geometry as EWKT
curl http://localhost:5000/collections/beni_confiscati/items?\
    filter=DWITHIN(geometry,SRID=3004;POINT(2313683.65%204641312.29),100,meters)
```

Note that regardless of the CRS being defined in the request, this PR makes pygeoapi ensure that it will always use the CRS of the underlying collection (as defined in its `storage_crs` configuration parameter), converting the filter geometry to the correct CRS if needed.

# Related issue / discussion
- fixes #1488

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
