### PR TITLE
fixed failing starlette tests

### DIFF
--- a/tests/util.py
+++ b/tests/util.py
@@ -161,18 +161,10 @@ def mock_starlette(config_file: str = 'pygeoapi-test-config.yml',
         # Force a module reload to make sure we really use another config
         reload(starlette_app)
 
-        # Get server root path
-        public_base_url = starlette_app.CONFIG['server']['url'].rstrip('/')
-        root_path = urlsplit(public_base_url).path.rstrip('/') or ''
-
         # Create and return test client
         # Note: setting the 'root_path' does NOT really work and
         # does not have the same effect as Flask's APPLICATION_ROOT
-        client = StarletteClient(
-            starlette_app.APP,
-            root_path=root_path,
-            **kwargs
-        )
+        client = StarletteClient(starlette_app.APP, **kwargs)
         # Override follow_redirects so behavior is the same as Flask mock
         client.follow_redirects = False
         yield client


### PR DESCRIPTION
# Overview

This PR modifies the initialization of the starlette test client used in pygeoapi tests in order to comply with
the lastest changes introduced in starlette v0.35.0, specifically the merge of encode/starlette#2400

The change proposed in this PR is to not pass a `root_path` to the starlette test client, as the new starlette behavior is now to have mounted apps remove the root path when routing - since in the failing tests, which are checking the _apirules_ functionality, pygeoapi is submounting routes under the `url_prefix` path. 

# Related issue / discussion

- fixes #1490

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
