### PR TITLE
Removed the dependency on nest-asyncio

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -358,18 +358,14 @@ class APIRequest:
                 # Set data from Django request
                 api_req._data = request.body
             else:
-                try:
-                    import nest_asyncio
-                    nest_asyncio.apply()
-                    # Set data from Starlette request after async
-                    # coroutine completion
-                    # TODO:
-                    # this now blocks, but once Flask v2 with async support
-                    # has been implemented, with_data() can become async too
-                    loop = asyncio.get_event_loop()
-                    api_req._data = loop.run_until_complete(request.body())
-                except ModuleNotFoundError:
-                    LOGGER.error('Module nest-asyncio not found')
+                # Set data from Starlette request after async
+                # coroutine completion
+                # TODO:
+                # this now blocks, but once Flask v2 with async support
+                # has been implemented, with_data() can become async too
+                loop = asyncio.get_event_loop()
+                api_req._data = asyncio.run_coroutine_threadsafe(
+                    request.body(), loop)
         return api_req
 
     @staticmethod

--- a/requirements-starlette.txt
+++ b/requirements-starlette.txt
@@ -1,4 +1,3 @@
 aiofiles
 starlette
 uvicorn[standard]
-nest-asyncio


### PR DESCRIPTION
# Overview

This PR removes the dependency on [nest-asyncio](https://github.com/erdewit/nest_asyncio), thus unlocking running pygeoapi's starlette webapp with uvicorn and the [uvloop](https://uvloop.readthedocs.io/index.html#) event loop.

Implementation makes use of the standard [asyncio.run_coroutine_threadsafe()](https://docs.python.org/3/library/asyncio-task.html#asyncio.run_coroutine_threadsafe) function, therefore not needing to rely on `nest-asyncio` anymore

# Related issue / discussion

- fixes #1492

# Additional information

pygeoapi can now be run with the `uvloop` event loop using an incantation like this:

```sh
export PYGEOAPI_CONFIG=example-config.yml
export PYGEOAPI_OPENAPI=example-openapi.yml

uvicorn pygeoapi.starlette_app:APP --port 5000
```

This will use `uvloop` automatically, if it is available.


# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements


# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
