### PR TITLE
Add tests for `get_job_result`

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3475,6 +3475,7 @@ class API:
                                      default=json_serial)
             else:
                 # HTML
+                headers['Content-Type'] = "text/html"
                 data = {
                     'job': {'id': job_id},
                     'result': job_output


### PR DESCRIPTION
This api method did not have any tests until now.

This also contains a small fix: If no content type was requested, then by default, the header specified the content type `application/json`, whereas the content was actually html. Note that this is rarely a problem because browsers do request html explicitly.

# Overview

# Related issue / discussion

# Additional information

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
