### PR TITLE
Generalize provider error handling to processes

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -3385,10 +3385,9 @@ class API:
             headers['Location'] = f'{self.base_url}/jobs/{job_id}'
         except ProcessorExecuteError as err:
             LOGGER.error(err)
-            msg = 'Processing error'
             return self.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR, headers,
-                request.format, 'NoApplicableCode', msg)
+                err.http_status_code, headers,
+                request.format, err.ogc_exception_code, err.message)
 
         response = {}
         if status == JobStatus.failed:

--- a/pygeoapi/error.py
+++ b/pygeoapi/error.py
@@ -1,0 +1,53 @@
+# =================================================================
+#
+# Authors: Bernhard Mallinger <bernhard.mallinger@eox.at>
+#
+# Copyright (c) 2024 Bernhard Mallinger
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+
+from http import HTTPStatus
+
+
+class GenericError(Exception):
+    """Exception class where error codes and messages
+    can be defined in custom error subclasses, so custom
+    providers and processes can raise appropriate errors.
+    """
+
+    ogc_exception_code = 'NoApplicableCode'
+    http_status_code = HTTPStatus.INTERNAL_SERVER_ERROR
+    default_msg = 'Unknown error'
+
+    def __init__(self, msg=None, *args, user_msg=None) -> None:
+        # if only a user_msg is provided, use it as msg
+        if user_msg and not msg:
+            msg = user_msg
+        super().__init__(msg, *args)
+        self.user_msg = user_msg
+
+    @property
+    def message(self):
+        return self.user_msg if self.user_msg else self.default_msg

--- a/pygeoapi/process/base.py
+++ b/pygeoapi/process/base.py
@@ -30,6 +30,8 @@
 import logging
 from typing import Any, Tuple
 
+from pygeoapi.error import GenericError
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -64,14 +66,14 @@ class BaseProcessor:
         return f'<BaseProcessor> {self.name}'
 
 
-class ProcessorGenericError(Exception):
+class ProcessorGenericError(GenericError):
     """processor generic error"""
     pass
 
 
 class ProcessorExecuteError(ProcessorGenericError):
     """query / backend error"""
-    pass
+    default_msg = "generic error (check logs)"
 
 
 class JobError(Exception):

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -32,6 +32,8 @@ import logging
 from enum import Enum
 from http import HTTPStatus
 
+from pygeoapi.error import GenericError
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -272,22 +274,9 @@ class BaseProvider:
         return f'<BaseProvider> {self.type}'
 
 
-class ProviderGenericError(Exception):
+class ProviderGenericError(GenericError):
     """provider generic error"""
-    ogc_exception_code = 'NoApplicableCode'
-    http_status_code = HTTPStatus.INTERNAL_SERVER_ERROR
     default_msg = 'generic error (check logs)'
-
-    def __init__(self, msg=None, *args, user_msg=None) -> None:
-        # if only a user_msg is provided, use it as msg
-        if user_msg and not msg:
-            msg = user_msg
-        super().__init__(msg, *args)
-        self.user_msg = user_msg
-
-    @property
-    def message(self):
-        return self.user_msg if self.user_msg else self.default_msg
 
 
 class ProviderConnectionError(ProviderGenericError):


### PR DESCRIPTION
# Overview

This allows triggering errors from a processor with specific http status code, ogc exception code and a custom message.

This is very useful the processor realizes that the input parameters don't make sense or are not allowed, in which case it can supply a descriptive error message and an http status code different from 500.

# Related issue / discussion

Recent PR introducing the base behavior for providers: https://github.com/geopython/pygeoapi/pull/1392

# Additional information

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing
(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
