### PR TITLE
Return 200 on the response headers of a successful get tile request

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2751,7 +2751,7 @@ class API:
                 return self.get_exception(
                     HTTPStatus.NOT_FOUND, headers, format_, 'NotFound', msg)
             else:
-                return headers, HTTPStatus.ACCEPTED, content
+                return headers, HTTPStatus.OK, content
 
         # @TODO: figure out if the spec requires to return json errors
         except KeyError:


### PR DESCRIPTION
# Overview
For a request like this:
http://localhost:5000/collections/lakes/tiles/WorldCRS84Quad/1/1/1?f=mvt
- If the request is successfull, the api should return status ok (200).

# Related issue / discussion
https://github.com/geopython/pygeoapi/issues/1499

# Additional information
https://docs.ogc.org/is/20-057/20-057.html#toc27

# Dependency policy (RFC2)
No dependencies are introduced in this PR

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
