### PR TITLE
Provide flask integration as a flask extension

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,7 +185,7 @@ jobs:
         gunicorn --bind 0.0.0.0:5000 \
                  --reload \
                  --reload-extra-file ${PYGEOAPI_CONFIG} \
-                 pygeoapi.flask_app:APP &
+                 'pygeoapi.flask_app:create_app()' &
     - name: run integration tests ⚙️
       run: |
         pytest tests/test_admin_api.py

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -100,7 +100,7 @@ case ${entry_cmd} in
 				--timeout ${WSGI_WORKER_TIMEOUT} \
 				--name=${CONTAINER_NAME} \
 				--bind ${CONTAINER_HOST}:${CONTAINER_PORT} \
-				pygeoapi.flask_app:APP
+				'pygeoapi.flask_app:create_app()'
 	  ;;
 	*)
 	  error "unknown command arg: must be run (default) or test"

--- a/pygeoapi/config.py
+++ b/pygeoapi/config.py
@@ -35,10 +35,17 @@ from jsonschema import validate as jsonschema_validate
 import logging
 import os
 import yaml
+from pathlib import Path
 
 from pygeoapi.util import to_json, yaml_load, THISDIR
 
 LOGGER = logging.getLogger(__name__)
+
+
+def get_config_from_path(config_path: Path) -> dict:
+    """Read pygeoapi configuration from the input config_path."""
+    with config_path.open() as fh:
+        return yaml_load(fh)
 
 
 def get_config(raw: bool = False) -> dict:

--- a/pygeoapi/config.py
+++ b/pygeoapi/config.py
@@ -35,17 +35,10 @@ from jsonschema import validate as jsonschema_validate
 import logging
 import os
 import yaml
-from pathlib import Path
 
 from pygeoapi.util import to_json, yaml_load, THISDIR
 
 LOGGER = logging.getLogger(__name__)
-
-
-def get_config_from_path(config_path: Path) -> dict:
-    """Read pygeoapi configuration from the input config_path."""
-    with config_path.open() as fh:
-        return yaml_load(fh)
 
 
 def get_config(raw: bool = False) -> dict:

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -50,8 +50,10 @@ from flask import (
 )
 
 import pygeoapi.util
+from pygeoapi.admin import Admin
 from pygeoapi.api import API
 from pygeoapi.config import yaml_load
+from pygeoapi.models import config as config_models
 from pygeoapi.openapi import load_openapi_document
 
 
@@ -86,7 +88,7 @@ def schemas(path):
     :returns: HTTP response
     """
 
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     ogc_schemas_location = api.config.get(
         'server', {}).get('ogc_schemas_location')
     got_local_schemas = not ogc_schemas_location.startswith('http')
@@ -123,7 +125,7 @@ def landing_page():
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.landing_page(request))
 
 
@@ -134,7 +136,7 @@ def openapi():
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.openapi_(request))
 
 
@@ -145,7 +147,7 @@ def conformance():
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.conformance(request))
 
 
@@ -159,7 +161,7 @@ def collections(collection_id=None):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.describe_collections(request, collection_id))
 
 
@@ -172,7 +174,7 @@ def collection_queryables(collection_id=None):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_collection_queryables(request, collection_id))
 
 
@@ -192,7 +194,7 @@ def collection_items(collection_id, item_id=None):
     :returns: HTTP response
     """
 
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     if item_id is None:
         if request.method == 'GET':  # list items
             return get_response(
@@ -240,7 +242,7 @@ def collection_coverage(collection_id):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_collection_coverage(request, collection_id))
 
 
@@ -253,7 +255,7 @@ def collection_coverage_domainset(collection_id):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_collection_coverage_domainset(
         request, collection_id))
 
@@ -267,7 +269,7 @@ def collection_coverage_rangetype(collection_id):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_collection_coverage_rangetype(
         request, collection_id))
 
@@ -281,7 +283,7 @@ def get_collection_tiles(collection_id=None):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_collection_tiles(
         request, collection_id))
 
@@ -297,7 +299,7 @@ def get_collection_tiles_metadata(collection_id=None, tileMatrixSetId=None):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_collection_tiles_metadata(
         request, collection_id, tileMatrixSetId))
 
@@ -317,7 +319,7 @@ def get_collection_tiles_data(collection_id=None, tileMatrixSetId=None,
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_collection_tiles_data(
         request, collection_id, tileMatrixSetId, tileMatrix, tileRow, tileCol))
 
@@ -334,7 +336,7 @@ def collection_map(collection_id, style_id=None):
     :returns: HTTP response
     """
 
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     headers, status_code, content = api.get_collection_map(
         request, collection_id, style_id)
 
@@ -356,7 +358,7 @@ def get_processes(process_id=None):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.describe_processes(request, process_id))
 
 
@@ -372,7 +374,7 @@ def get_jobs(job_id=None):
     :returns: HTTP response
     """
 
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     if job_id is None:
         return get_response(api.get_jobs(request))
     else:
@@ -392,7 +394,7 @@ def execute_process_jobs(process_id):
     :returns: HTTP response
     """
 
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.execute_process(request, process_id))
 
 
@@ -406,7 +408,7 @@ def get_job_result(job_id=None):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_job_result(request, job_id))
 
 
@@ -421,7 +423,7 @@ def get_job_result_resource(job_id, resource):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_job_result_resource(
         request, job_id, resource))
 
@@ -447,7 +449,7 @@ def get_collection_edr_query(collection_id, instance_id=None):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     query_type = request.path.split('/')[-1]
     return get_response(api.get_collection_edr_query(request, collection_id,
                                                      instance_id, query_type))
@@ -460,7 +462,7 @@ def stac_catalog_root():
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_stac_root(request))
 
 
@@ -473,7 +475,7 @@ def stac_catalog_path(path):
 
     :returns: HTTP response
     """
-    api: API = current_app.config['PYGEOAPI']['api']
+    api: API = current_app.extensions['pygeoapi']['api']
     return get_response(api.get_stac_path(request, path))
 
 
@@ -485,7 +487,7 @@ def admin_config():
     :returns: HTTP response
     """
 
-    admin = current_app.config['PYGEOAPI']['admin']
+    admin = current_app.extensions['pygeoapi']['admin']
     if request.method == 'GET':
         return get_response(admin.get_config(request))
 
@@ -504,7 +506,7 @@ def admin_config_resources():
     :returns: HTTP response
     """
 
-    admin = current_app.config['PYGEOAPI']['admin']
+    admin = current_app.extensions['pygeoapi']['admin']
     if request.method == 'GET':
         return get_response(admin.get_resources(request))
 
@@ -521,7 +523,7 @@ def admin_config_resource(resource_id):
 
     :returns: HTTP response
     """
-    admin = current_app.config['PYGEOAPI']['admin']
+    admin = current_app.config['pygeoapi']['admin']
     if request.method == 'GET':
         return get_response(admin.get_resource(request, resource_id))
 
@@ -535,46 +537,74 @@ def admin_config_resource(resource_id):
         return get_response(admin.patch_resource(request, resource_id))
 
 
-def create_app(
-        pygeoapi_config: dict,
-        pygeoapi_openapi: typing.Union[dict, str],
-) -> Flask:
-    """Create the pygeoapi flask application"""
-    pygeoapi_api = API(config=pygeoapi_config, openapi=pygeoapi_openapi)
-    static_folder = (
-        pygeoapi_config.get('server', {})
-        .get('templates', {})
-        .get('static', 'static')
-    )
-    app = Flask(
-        __name__,
-        static_folder=static_folder,
-        static_url_path='/static',
-    )
-    api_rules = pygeoapi.util.get_api_rules(pygeoapi_config)
-    app.url_map.strict_slashes = api_rules.strict_slashes
-    app.config['JSONIFY_PRETTYPRINT_REGULAR'] = pygeoapi_config.get(
-        'server', {}).get('pretty_print', True)
-    app.config['PYGEOAPI'] = {
-        'api': pygeoapi_api,
-        'api_rules': api_rules,
-    }
-    if pygeoapi_config.get('server', {}).get('cors', False):
-        try:
-            from flask_cors import CORS
-            CORS(app)
-        except ModuleNotFoundError:
-            print('Python package flask-cors required for CORS support')
+class FlaskPygeoapi:
+    api: API
+    api_rules: config_models.APIRules
+    admin: typing.Optional[Admin]
 
-    BLUEPRINT.url_prefix = api_rules.get_url_prefix('flask')
-    BLUEPRINT.static_folder = static_folder
-    app.register_blueprint(BLUEPRINT)
-    if pygeoapi_api.config['server'].get('admin'):
-        from pygeoapi.admin import Admin
-        pygeoapi_admin = Admin(pygeoapi_config, pygeoapi_openapi)
-        app.config['PYGEOAPI']['admin'] = pygeoapi_admin
-        ADMIN_BLUEPRINT.static_folder = static_folder
-        app.register_blueprint(ADMIN_BLUEPRINT)
+    def __init__(
+            self,
+            pygeoapi_config: dict,
+            pygeoapi_openapi: typing.Union[dict, str]
+    ):
+        self.api = API(config=pygeoapi_config, openapi=pygeoapi_openapi)
+        self.api_rules = pygeoapi.util.get_api_rules(pygeoapi_config)
+        if pygeoapi_config['server'].get('admin'):
+            self.admin = Admin(pygeoapi_config, pygeoapi_openapi)
+        else:
+            self.admin = None
+
+    def init_app(
+            self,
+            app: Flask,
+            api_blueprint_prefix: str = '',
+            admin_blueprint_prefix: str = ''
+    ):
+        static_folder = (
+            self.api.config.get('server', {})
+            .get('templates', {})
+            .get('static', 'static')
+        )
+        print(f"{static_folder=}")
+        app.static_folder = static_folder
+        app.url_map.strict_slashes = self.api_rules.strict_slashes
+        app.config['JSONIFY_PRETTYPRINT_REGULAR'] = self.api.config.get(
+            'server', {}).get('pretty_print', True)
+        app.extensions['pygeoapi'] = {
+            'api': self.api,
+            'api_rules': self.api_rules,
+            'admin': self.admin,
+        }
+        BLUEPRINT.url_prefix = '/'.join((
+            api_blueprint_prefix, self.api_rules.get_url_prefix('flask')))
+        BLUEPRINT.static_folder = static_folder
+        app.register_blueprint(BLUEPRINT)
+        if self.admin:
+            ADMIN_BLUEPRINT.static_folder = static_folder
+            app.register_blueprint(
+                ADMIN_BLUEPRINT, url_prefix=admin_blueprint_prefix)
+        if self.api.config.get('server', {}).get('cors', False):
+            try:
+                from flask_cors import CORS
+                CORS(app)
+            except ModuleNotFoundError:
+                print('Python package flask-cors required for CORS support')
+
+
+def create_app():
+    if (pygeoapi_config_path := os.getenv('PYGEOAPI_CONFIG')) is not None:
+        with Path(pygeoapi_config_path).open() as fh:
+            pygeoapi_config = yaml_load(fh)
+    else:
+        raise RuntimeError('PYGEOAPI_CONFIG environment variable not set')
+    if (pygeoapi_openapi_path := os.getenv('PYGEOAPI_OPENAPI')) is not None:
+        pygeoapi_openapi = load_openapi_document(
+            Path(pygeoapi_openapi_path))
+    else:
+        raise RuntimeError('PYGEOAPI_OPENAPI environment variable not set')
+    pygeoapi_extension = FlaskPygeoapi(pygeoapi_config, pygeoapi_openapi)
+    app = Flask('pygeoapi')
+    pygeoapi_extension.init_app(app)
     return app
 
 
@@ -591,23 +621,8 @@ def serve(ctx, server=None, debug=False):
 
     :returns: void
     """
-    if (pygeoapi_config_path := os.getenv('PYGEOAPI_CONFIG')) is not None:
-        with Path(pygeoapi_config_path).open() as fh:
-            pygeoapi_config = yaml_load(fh)
-    else:
-        raise RuntimeError('PYGEOAPI_CONFIG environment variable not set')
-    if (pygeoapi_openapi_path := os.getenv('PYGEOAPI_OPENAPI')) is not None:
-        pygeoapi_openapi = load_openapi_document(
-            Path(pygeoapi_openapi_path))
-    else:
-        raise RuntimeError('PYGEOAPI_OPENAPI environment variable not set')
-
-    app = create_app(
-        pygeoapi_config=pygeoapi_config,
-        pygeoapi_openapi=pygeoapi_openapi
-    )
-    pygeoapi_api = app.config['PYGEOAPI']['api']
-    # setup_logger(CONFIG['logging'])
+    app = create_app()
+    pygeoapi_api = app.extensions['pygeoapi']['api']
     app.run(
         debug=True,
         host=pygeoapi_api.config['server']['bind']['host'],

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -2,8 +2,10 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #          Norman Barker <norman.barker@gmail.com>
+#          Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
 #
 # Copyright (c) 2023 Tom Kralidis
+# Copyright (c) 2024 Ricardo Garcia Silva
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -84,8 +86,8 @@ def schemas(path):
     :returns: HTTP response
     """
 
-    api_: API = current_app.config['PYGEOAPI']['api']
-    ogc_schemas_location = api_.config.get(
+    api: API = current_app.config['PYGEOAPI']['api']
+    ogc_schemas_location = api.config.get(
         'server', {}).get('ogc_schemas_location')
     got_local_schemas = not ogc_schemas_location.startswith('http')
     if ogc_schemas_location is not None:
@@ -199,8 +201,9 @@ def collection_items(collection_id, item_id=None):
             if request.content_type is not None:
                 if request.content_type == 'application/geo+json':
                     return get_response(
-                        api.manage_collection_item(request, 'create',
-                                                    collection_id))
+                        api.manage_collection_item(
+                            request, 'create', collection_id)
+                    )
                 else:
                     return get_response(
                         api.post_collection_items(request, collection_id))
@@ -210,16 +213,19 @@ def collection_items(collection_id, item_id=None):
 
     elif request.method == 'DELETE':
         return get_response(
-            api.manage_collection_item(request, 'delete',
-                                        collection_id, item_id))
+            api.manage_collection_item(
+                request, 'delete', collection_id, item_id)
+        )
     elif request.method == 'PUT':
         return get_response(
-            api.manage_collection_item(request, 'update',
-                                        collection_id, item_id))
+            api.manage_collection_item(
+                request, 'update', collection_id, item_id)
+        )
     elif request.method == 'OPTIONS':
         return get_response(
-            api.manage_collection_item(request, 'options',
-                                        collection_id, item_id))
+            api.manage_collection_item(
+                request, 'options', collection_id, item_id)
+        )
     else:
         return get_response(
             api.get_collection_item(request, collection_id, item_id))

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -523,7 +523,7 @@ def admin_config_resource(resource_id):
 
     :returns: HTTP response
     """
-    admin = current_app.config['pygeoapi']['admin']
+    admin = current_app.extensions['pygeoapi']['admin']
     if request.method == 'GET':
         return get_response(admin.get_resource(request, resource_id))
 
@@ -565,7 +565,6 @@ class FlaskPygeoapi:
             .get('templates', {})
             .get('static', 'static')
         )
-        print(f"{static_folder=}")
         app.static_folder = static_folder
         app.url_map.strict_slashes = self.api_rules.strict_slashes
         app.config['JSONIFY_PRETTYPRINT_REGULAR'] = self.api.config.get(

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -1586,17 +1586,15 @@ def generate_openapi_document(cfg_file: Union[Path, io.TextIOWrapper],
     return content
 
 
-def load_openapi_document() -> dict:
+def load_openapi_document(openapi_document_path: Path) -> Union[dict, str]:
     """
     Open OpenAPI document from `PYGEOAPI_OPENAPI` environment variable
 
     :returns: `dict` of OpenAPI document
     """
 
-    pygeoapi_openapi = os.environ.get('PYGEOAPI_OPENAPI')
-
-    with open(pygeoapi_openapi, encoding='utf8') as ff:
-        if pygeoapi_openapi.endswith(('.yaml', '.yml')):
+    with openapi_document_path.open(encoding='utf-8') as ff:
+        if openapi_document_path.suffix in ('.yaml', '.yml'):
             openapi_ = yaml_load(ff)
         else:  # JSON string, do not transform
             openapi_ = ff.read()

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -56,10 +56,10 @@ from pygeoapi.util import get_api_rules
 
 CONFIG = get_config()
 
-if 'PYGEOAPI_OPENAPI' not in os.environ:
+if (pygeoapi_openapi := os.getenv('PYGEOAPI_OPENAPI')) is not None:
+    OPENAPI = load_openapi_document(Path(pygeoapi_openapi))
+else:
     raise RuntimeError('PYGEOAPI_OPENAPI environment variable not set')
-
-OPENAPI = load_openapi_document()
 
 if CONFIG['server'].get('admin'):
     from pygeoapi.admin import Admin

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -280,7 +280,6 @@ def test_apirequest(api_):
 def test_apirules_active_flask(flask_app_with_api_rules):
     api_rules = flask_app_with_api_rules.extensions['pygeoapi']['api_rules']
     url_prefix = api_rules.get_url_prefix('flask')
-    print(f"{url_prefix=}")
     with flask_app_with_api_rules.test_client() as test_client:
         # Test happy path
         response = test_client.get(f'{url_prefix}/conformance')
@@ -1232,10 +1231,10 @@ def test_manage_collection_item_editable_options_req(config):
     assert rsp_headers['Allow'] == 'HEAD, GET, PUT, DELETE'
 
 
-def test_describe_collections_enclosures(enclosure_api):
+def test_describe_collections_enclosures(config_enclosure, enclosure_api):
     original_enclosures = {
         lnk['title']: lnk
-        for lnk in enclosure_api.config['resources']['objects']['links']
+        for lnk in config_enclosure['resources']['objects']['links']
         if lnk['rel'] == 'enclosure'
     }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,7 +46,6 @@ import pyproj
 from shapely.geometry import Point
 
 import pygeoapi.flask_app
-from pygeoapi.flask_app import create_app as create_flask_app
 from pygeoapi.api import (
     API, APIRequest, FORMAT_TYPES, validate_bbox, validate_datetime,
     validate_subset, F_HTML, F_JSON, F_JSONLD, F_GZIP, __version__

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,6 @@ import logging
 import time
 import gzip
 from http import HTTPStatus
-from pathlib import Path
 
 from pyld import jsonld
 import pytest
@@ -53,8 +52,7 @@ from pygeoapi.api import (
 from pygeoapi.util import (yaml_load, get_crs_from_uri,
                            get_api_rules, get_base_url)
 
-from .util import (get_test_file_path, mock_request,
-                   mock_flask, mock_starlette)
+from .util import get_test_file_path, mock_request, mock_starlette
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -76,11 +76,9 @@ def mock_request(params: dict = None, data=None, **headers) -> Request:
 
 
 @contextmanager
-def mock_starlette(
-        config_file: str = 'pygeoapi-test-config.yml',
-        openapi_file: str = 'pygeoapi-test-openapi.yml',
-        **kwargs
-) -> StarletteClient:  # noqa
+def mock_starlette(config_file: str = 'pygeoapi-test-config.yml',
+                   openapi_file: str = 'pygeoapi-test-openapi.yml',
+                   **kwargs) -> StarletteClient:
     """
     Mocks a Starlette client so we can test the API routing with applied
     API rules.
@@ -89,8 +87,10 @@ def mock_starlette(
 
     :param config_file: Optional configuration YAML file to use.
                         If not set, the default test configuration is used.
+
     :param openapi_file: Optional OpenAPI YAML file to use.
     """
+
     starlette_app = None
     env_conf = os.getenv('PYGEOAPI_CONFIG')
     env_openapi = os.getenv('PYGEOAPI_OPENAPI')

--- a/tests/util.py
+++ b/tests/util.py
@@ -132,9 +132,11 @@ def mock_flask(config_file: str = 'pygeoapi-test-config.yml',
 
 
 @contextmanager
-def mock_starlette(config_file: str = 'pygeoapi-test-config.yml',
-                   openapi_file: str = 'pygeoapi-test-openapi.yml',
-                   **kwargs) -> StarletteClient:
+def mock_starlette(
+        config_file: str = 'pygeoapi-test-config.yml',
+        openapi_file: str = 'pygeoapi-test-openapi.yml',
+        **kwargs
+) -> StarletteClient:  # noqa
     """
     Mocks a Starlette client so we can test the API routing with applied
     API rules.
@@ -143,10 +145,8 @@ def mock_starlette(config_file: str = 'pygeoapi-test-config.yml',
 
     :param config_file: Optional configuration YAML file to use.
                         If not set, the default test configuration is used.
-
     :param openapi_file: Optional OpenAPI YAML file to use.
     """
-
     starlette_app = None
     env_conf = os.getenv('PYGEOAPI_CONFIG')
     env_openapi = os.getenv('PYGEOAPI_OPENAPI')

--- a/tests/util.py
+++ b/tests/util.py
@@ -30,11 +30,9 @@
 import sys
 import logging
 import os.path
-from urllib.parse import urlsplit
 from importlib import reload
 from contextlib import contextmanager
 
-from flask.testing import FlaskClient
 from starlette.testclient import TestClient as StarletteClient
 from werkzeug.test import create_environ
 from werkzeug.wrappers import Request
@@ -75,60 +73,6 @@ def mock_request(params: dict = None, data=None, **headers) -> Request:
     request = Request(environ)
     request.args = ImmutableMultiDict(params.items())  # noqa
     return request
-
-
-@contextmanager
-def mock_flask(config_file: str = 'pygeoapi-test-config.yml',
-               openapi_file: str = 'pygeoapi-test-openapi.yml',
-               **kwargs) -> FlaskClient:
-    """
-    Mocks a Flask client so we can test the API routing with applied API rules.
-    Does not follow redirects by default. Set `follow_redirects=True` option
-    on individual requests to enable.
-
-    :param config_file: Optional configuration YAML file to use.
-                        If not set, the default test configuration is used.
-
-    :param openapi_file: Optional OpenAPI YAML file to use.
-    """
-    flask_app = None
-    env_conf = os.getenv('PYGEOAPI_CONFIG')
-    env_openapi = os.getenv('PYGEOAPI_OPENAPI')
-    try:
-        # Temporarily override environment variable so we can import Flask app
-        os.environ['PYGEOAPI_CONFIG'] = get_test_file_path(config_file)
-        os.environ['PYGEOAPI_OPENAPI'] = get_test_file_path(openapi_file)
-
-        # Import current pygeoapi Flask app module
-        from pygeoapi import flask_app
-
-        # Force a module reload to make sure we really use another config
-        reload(flask_app)
-
-        # Set server root path
-        url_parts = urlsplit(flask_app.CONFIG['server']['url'])
-        app_root = url_parts.path.rstrip('/') or '/'
-        flask_app.APP.config['SERVER_NAME'] = url_parts.netloc
-        flask_app.APP.config['APPLICATION_ROOT'] = app_root
-
-        # Create and return test client
-        client = flask_app.APP.test_client(**kwargs)
-        yield client
-
-    finally:
-        if env_conf is None and env_openapi is None:
-            # Remove env variable again if it was not set initially
-            del os.environ['PYGEOAPI_CONFIG']
-            del os.environ['PYGEOAPI_OPENAPI']
-            # Unload Flask app module
-            del sys.modules['pygeoapi.flask_app']
-        else:
-            # Restore env variable to its original value and reload Flask app
-            os.environ['PYGEOAPI_CONFIG'] = env_conf
-            os.environ['PYGEOAPI_OPENAPI'] = env_openapi
-            if flask_app:
-                reload(flask_app)
-        del client
 
 
 @contextmanager


### PR DESCRIPTION
# Overview

This PR converts the pygeoapi flask application into a flask extension, thus enabling third-party flask applications to load and use pygeoapi.

As an example, with this PR it becomes possible to create a new flask application and simply add pygeoapi to it, like this:

```python
# file my_custom_flask_app.py

from pathlib import Path

import flask
from pygeoapi.flask_app import FlaskPygeoapi
from pygeoapi.openapi import load_openapi_document

my_blueprint = flask.Blueprint('my_blueprint', __name__, url_prefix='/')


def create_app():
    pygeoapi_extension = FlaskPygeoapi(
        pygeoapi.util.yaml_load((Path(__file__).parent / 'example-config.yml').open()),
        load_openapi_document(Path(__file__).parent / 'example-openapi.yml')
    )
    app = flask.Flask(__name__)
    app.register_blueprint(my_blueprint)
    pygeoapi_extension.init_app(app, api_blueprint_prefix='/my-pygeoapi')
    return app


@my_blueprint.route('/')
def hello_world():
    pygeoapi_api = flask.current_app.extensions['pygeoapi']['api']
    description = pygeoapi_api.config['metadata']['identification']['title']['en']
    return (
        f'<h1>Hi this is a pygeoapi-enabled flask app</h1>'
        f'<p>Oh, and the pygeoapi server description is: {description}</p>'
        f'<p><a href="{flask.url_for("pygeoapi.landing_page")}">my custom pygeoapi landing page</a>'
    )
```

And then running this custom flask app like this:

```sh
flask --app my_custom_flask_app:create_app run

# or with gunicorn
gunicorn 'my_flask_app:create_app()'
```

pygeoapi will thus be available at `http://localhost:5000/my-pygeoapi` and the `hello_world()` view will be available at `http://localhost:5000/` 

The approach taken is to follow the standard flask docs:

- Create an extension according to: https://flask.palletsprojects.com/en/3.0.x/extensiondev/#flask-extension-development
- Use an application factory pattern to initialize the default pygeoapi flask application, as shown in: https://flask.palletsprojects.com/en/3.0.x/patterns/appfactories/

This has a number of benefits:

- Follows flask recommended practices, which are nicely documented in the flask docs, so it is easier for pygeoapi contributors to get help on the flask related stuff;

- Removes a number of global variables from `flask_app`, thus making pygeoapi easier to test, and in my opinion, more maintainable. This PR already includes the removal of the `tests/util/mock_flask()` function, which was doing some advanced stuff like manipulating the environment, reloading modules and messing with the `sys` module. This now becomes simpler, as creating the flask app does not rely on global variables that hold state;

- Provides an easy way for pygeoapi to be incorporated into third-party flask applications.


The main modifications included in this PR are thus:

-  The `flask_app.FlaskPygeoapi` flask extension;

-  The `flask_app.create_app()` function, which contains the logic to create the official pygeoapi flask web application;

-  The runtime instances of `pygeoapi.API` and `pygeoapi.admin.Admin` are now stored in the flask app under the `app.extensions['pygeoapi']` key. This means that each flask view is now able to get the pygeoapi api by doing `api = current_app.config['pygeoapi]['api']` rather than relying on the app instance being a global module variable

-  Both the docker `entrypoint.sh` script and the CI file related to admin testing are modified to update the way that gunicorn should now be called in order to start pygeoapi, which this PR changes to:

   ```diff
   - gunicorn pygeoapi.flask_app:APP
   + gunicorn 'pygeoapi.flask_app:create_app()'
   ```


### NOTE1

I pulled the core of these changes from my previous PR about using gunicorn as the default web server (#1401), which was not accepted by pygeoapi maintainers. I think these changes are valuable and would make the codebase more maintainable, so I'm proposing them in isolation, with the addition of the pygeoapi flask extension, which is a novel thing. 

If reviewed favorably, I'm willing to submit analogous PRs to use a similar function factory pattern for the pygeoapi starlette app too.


### NOTE2

This PR makes some light use of Python's [assignment expressions (AKA the walrus operator)](https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions) - this is a language feature that was introduced in Python 3.8, which is now the minimum supported version in pygeoapi.

# Related issue / discussion
- #1401

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
