### PR TITLE
Return a 400 status code for an "out-of-range" get tile request

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -73,7 +73,7 @@ from pygeoapi.process.manager.base import get_manager
 from pygeoapi.plugin import load_plugin, PLUGINS
 from pygeoapi.provider.base import (
     ProviderGenericError, ProviderConnectionError, ProviderNotFoundError,
-    ProviderTypeError, ProviderInvalidQueryError)
+    ProviderTypeError)
 from pygeoapi.models.provider.base import TilesMetadataFormat
 
 from pygeoapi.models.cql import CQLModel
@@ -2759,11 +2759,6 @@ class API:
             return self.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, format_,
                 'InvalidParameterValue', msg)
-        except ProviderInvalidQueryError:
-            msg = 'Invalid tile request'
-            return self.get_exception(
-                HTTPStatus.BAD_REQUEST, headers, format_,
-                'InvalidRequest', msg)
         except ProviderGenericError as err:
             LOGGER.error(err)
             return self.get_exception(

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -73,7 +73,7 @@ from pygeoapi.process.manager.base import get_manager
 from pygeoapi.plugin import load_plugin, PLUGINS
 from pygeoapi.provider.base import (
     ProviderGenericError, ProviderConnectionError, ProviderNotFoundError,
-    ProviderTypeError)
+    ProviderTypeError, ProviderInvalidQueryError)
 from pygeoapi.models.provider.base import TilesMetadataFormat
 
 from pygeoapi.models.cql import CQLModel
@@ -2759,6 +2759,11 @@ class API:
             return self.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, format_,
                 'InvalidParameterValue', msg)
+        except ProviderInvalidQueryError:
+            msg = 'Invalid tile request'
+            return self.get_exception(
+                HTTPStatus.BAD_REQUEST, headers, format_,
+                'InvalidRequest', msg)
         except ProviderGenericError as err:
             LOGGER.error(err)
             return self.get_exception(

--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -170,14 +170,11 @@ class MVTElasticProvider(BaseMVTProvider):
                     resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}')  # noqa
                     resp.raise_for_status()
                     return resp.content
-            # Client is sending an invalid request
-            except requests.exceptions.HTTPError as e:
-                LOGGER.debug(e)
-                raise ProviderInvalidQueryError
-            # All other errors fall here
             except requests.exceptions.RequestException as e:
                 LOGGER.debug(e)
-                raise ProviderGenericError
+                if resp.status_code <= 500:
+                    raise ProviderInvalidQueryError  # Client is sending an invalid request # noqa
+                raise ProviderGenericError  # Server error
         else:
             msg = 'Wrong input format for Elasticsearch MVT'
             LOGGER.error(msg)

--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -172,7 +172,7 @@ class MVTElasticProvider(BaseMVTProvider):
                     return resp.content
             except requests.exceptions.RequestException as e:
                 LOGGER.debug(e)
-                if resp.status_code <= 500:
+                if resp.status_code < 500:
                     raise ProviderInvalidQueryError  # Client is sending an invalid request # noqa
                 raise ProviderGenericError  # Server error
         else:

--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -32,7 +32,9 @@ import requests
 from urllib.parse import urlparse
 
 from pygeoapi.provider.base_mvt import BaseMVTProvider
-from pygeoapi.provider.base import ProviderConnectionError
+from pygeoapi.provider.base import (ProviderConnectionError,
+                                    ProviderGenericError,
+                                    ProviderInvalidQueryError)
 from pygeoapi.models.provider.base import (
     TileSetMetadata, LinkType)
 from pygeoapi.util import is_url, url_join
@@ -162,11 +164,20 @@ class MVTElasticProvider(BaseMVTProvider):
             else:
                 url_query = ''
 
-            with requests.Session() as session:
-                session.get(base_url)
-                resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}')  # noqa
-                resp.raise_for_status()
-                return resp.content
+            try:
+                with requests.Session() as session:
+                    session.get(base_url)
+                    resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}')  # noqa
+                    resp.raise_for_status()
+                    return resp.content
+            # Client is sending an invalid request
+            except requests.exceptions.HTTPError as e:
+                LOGGER.debug(e)
+                raise ProviderInvalidQueryError
+            # All other errors fall here
+            except requests.exceptions.RequestException as e:
+                LOGGER.debug(e)
+                raise ProviderGenericError
         else:
             msg = 'Wrong input format for Elasticsearch MVT'
             LOGGER.error(msg)


### PR DESCRIPTION
# Overview
The MVT-elastic backend provider returns a 400 status code in response to a request for a tile out of range (e.g.: outside the limits of the TMS). This would satisfy req 6 A of the OGC API - Tiles standard (requirements class core). However, pygeoapi is transforming this into a 500 error.
This PR introduces a try/ except block on the MVT-elastic class, and makes sure that the Exception that arrives to the API class is appropriated. For that purpose, I reused the existing "ProviderInvalidQueryError", which is close enough in terms of semantics, but I could also have created a new Provider exception.

# Related issue / discussion
https://github.com/geopython/pygeoapi/issues/1502

# Additional information
OGC API - Tiles standard: https://docs.ogc.org/is/20-057/20-057.html

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
