### PR TITLE
Removed duplicate running of pygeoapi in serve cli command

### DIFF
--- a/pygeoapi/__init__.py
+++ b/pygeoapi/__init__.py
@@ -96,11 +96,9 @@ def serve(ctx, server):
 
     if server == "flask":
         from pygeoapi.flask_app import serve as serve_flask
-        ctx.forward(serve_flask)
         ctx.invoke(serve_flask)
     elif server == "starlette":
         from pygeoapi.starlette_app import serve as serve_starlette
-        ctx.forward(serve_starlette)
         ctx.invoke(serve_starlette)
     elif server == "django":
         from pygeoapi.django_app import main as serve_django


### PR DESCRIPTION
# Overview

This PR removes the additional calling of click's `ctx.forward()` which was causing duplicate launching of pygeoapi's web app when used via `pygeoapi serve`, as mentioned in #1504 

# Related issue / discussion
- fixes #1504

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
