### PR TITLE
Give support to serving mvt-tippecanoe tiles from an url

### DIFF
--- a/pygeoapi/provider/mvt_tippecanoe.py
+++ b/pygeoapi/provider/mvt_tippecanoe.py
@@ -32,7 +32,6 @@ import logging
 import requests
 from pathlib import Path
 from urllib.parse import urlparse
-import os.path
 
 from pygeoapi.provider.tile import (
     ProviderTileNotFoundError)
@@ -73,7 +72,7 @@ class MVTTippecanoeProvider(BaseMVTProvider):
         if is_url(self.data):
             url = urlparse(self.data)
             baseurl = f'{url.scheme}://{url.netloc}'
-            extension = os.path.splitext(url.path)[-1]  # e.g. ".pbf"
+            extension = Path(url.path).suffix  # e.g. ".pbf"
             layer = f'/{self.get_layer()}'
 
             LOGGER.debug('Extracting layer name from URL')
@@ -175,7 +174,7 @@ class MVTTippecanoeProvider(BaseMVTProvider):
         url = urlparse(self.data)
         base_url = f'{url.scheme}://{url.netloc}'
 
-        extension = os.path.splitext(url.path)[-1]  # e.g. ".pbf"
+        extension = Path(url.path).suffix  # e.g. ".pbf"
 
         try:
             with requests.Session() as session:


### PR DESCRIPTION
# Overview
This PR fixes a regression bug, introduced by the MVT class refactoring.

# Related issue / discussion
https://github.com/geopython/pygeoapi/issues/1506

# Additional information
The response status codes were fixed, to address the 5 and 6A core requirements from the OGC API - TIles standard.
https://docs.ogc.org/is/20-057/20-057.html

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
