### PR TITLE
Update conformance declaration for OGC API - Tiles

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -150,7 +150,11 @@ CONFORMANCE = {
     ],
     'tile': [
         'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core',
-        'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt'
+        'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/mvt',
+        'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset',
+        'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list',
+        'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/oas30',
+        'http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/geodata-tilesets'
     ],
     'record': [
         'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/core',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -607,7 +607,7 @@ def test_conformance(config, api_):
 
     assert isinstance(root, dict)
     assert 'conformsTo' in root
-    assert len(root['conformsTo']) == 30
+    assert len(root['conformsTo']) == 34
     assert 'http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs' \
            in root['conformsTo']
 


### PR DESCRIPTION
# Overview
This PR adds the missing tile conformance classes, with which this api conforms to.

```
http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset
http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tilesets-list
http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/oas30
http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/geodata-tilesets

```
It also updates the related api test.

# Additional information
https://docs.ogc.org/is/20-057/20-057.html

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
