### PR TITLE
Added a default configuration

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -8,10 +8,15 @@ in the `YAML`_ format which is then referenced via the ``PYGEOAPI_CONFIG`` envir
 file whatever you wish; typical filenames end with ``.yml``.
 
 .. note::
+   pygeoapi does not strictly require you to provide a configuration file, it is able to run with default values. These
+   are not very useful though, as the default configuration does not have any resources. The default configuration
+   can be found `here <https://github.com/geopython/pygeoapi/blob/master/pygeoapi/config.py>`_.
+
+.. note::
    A sample configuration can always be found in the pygeoapi `GitHub <https://github.com/geopython/pygeoapi/blob/master/pygeoapi-config.yml>`_
    repository.
 
-pygeoapi configuration contains the following core sections:
+pygeoapi configuration contains the following core sections, all of which are optional:
 
 - ``server``: server-wide settings
 - ``logging``: logging configuration
@@ -19,6 +24,9 @@ pygeoapi configuration contains the following core sections:
 - ``resources``: dataset collections, processes and stac-collections offered by the server
 
 The full configuration schema with descriptions of all available properties can be found `here <https://github.com/geopython/pygeoapi/blob/master/pygeoapi/schemas/config/pygeoapi-config-0.x.yml>`_.
+
+pygeoapi will merge your configuration with its own defaults, so it is OK for you to specify only some of these sections
+in your own configuration file.
 
 .. note::
    `Standard YAML mechanisms <https://en.wikipedia.org/wiki/YAML#Advanced_components>`_ can be used (anchors, references, etc.) for reuse and compactness.

--- a/pygeoapi/__init__.py
+++ b/pygeoapi/__init__.py
@@ -37,8 +37,8 @@ try:
     from importlib.metadata import entry_points
 except ImportError:
     from importlib_metadata import entry_points
-from pygeoapi.config import config
-from pygeoapi.openapi import openapi
+from pygeoapi.config import config as config_cli_group
+from pygeoapi.openapi import openapi as openapi_cli_group
 
 
 def _find_plugins():
@@ -109,5 +109,5 @@ def serve(ctx, server):
         raise click.ClickException('--flask/--starlette/--django is required')
 
 
-cli.add_command(config)
-cli.add_command(openapi)
+cli.add_command(config_cli_group)
+cli.add_command(openapi_cli_group)

--- a/pygeoapi/config.py
+++ b/pygeoapi/config.py
@@ -161,7 +161,7 @@ def _get_default_config() -> typing.Dict[str, typing.Dict]:
             'pretty_print': False,
             'limit': 10,
             'templates': {
-                'path': TEMPLATES,
+                'path': str(TEMPLATES),
                 'static': str(Path(__file__).parent / 'static'),
             },
             'map': {

--- a/pygeoapi/config.py
+++ b/pygeoapi/config.py
@@ -31,17 +31,20 @@
 
 import click
 import json
-from jsonschema import validate as jsonschema_validate
 import logging
 import os
-import yaml
+import typing
+from pathlib import Path
 
-from pygeoapi.util import to_json, yaml_load, THISDIR
+import yaml
+from jsonschema import validate as jsonschema_validate
+
+from pygeoapi.util import to_json, yaml_load, TEMPLATES, THISDIR
 
 LOGGER = logging.getLogger(__name__)
 
 
-def get_config(raw: bool = False) -> dict:
+def get_config(raw: bool = False) -> typing.Dict[str, typing.Dict]:
     """
     Get pygeoapi configurations
 
@@ -49,17 +52,44 @@ def get_config(raw: bool = False) -> dict:
 
     :returns: `dict` of pygeoapi configuration
     """
-
-    if not os.environ.get('PYGEOAPI_CONFIG'):
-        raise RuntimeError('PYGEOAPI_CONFIG environment variable not set')
-
-    with open(os.environ.get('PYGEOAPI_CONFIG'), encoding='utf8') as fh:
-        if raw:
-            CONFIG = yaml.safe_load(fh)
-        else:
-            CONFIG = yaml_load(fh)
-
-    return CONFIG
+    provided_config = {}
+    try:
+        with Path(os.getenv('PYGEOAPI_CONFIG')).open(encoding='utf-8') as fh:
+            if raw:
+                provided_config = yaml.safe_load(fh)
+            else:
+                provided_config = yaml_load(fh)
+    except TypeError:
+        LOGGER.warning(
+            'PYGEOAPI_CONFIG environment variable not set, using default '
+            'configuration'
+        )
+    except FileNotFoundError:
+        LOGGER.warning(
+            'PYGEOAPI_CONFIG environment variable points to non-existent '
+            'file, using default configuration'
+        )
+    print(f'{provided_config=}')
+    default_config = _get_default_config()
+    merged_config = {
+        'server': {
+            **default_config['server'],
+            **provided_config.get('server', {}),
+        },
+        'logging': {
+            **default_config['logging'],
+            **provided_config.get('logging', {}),
+        },
+        'metadata': {
+            **default_config['metadata'],
+            **provided_config.get('metadata', {}),
+        },
+        'resources': {
+            **default_config['resources'],
+            **provided_config.get('resources', {}),
+        },
+    }
+    return merged_config
 
 
 def load_schema() -> dict:
@@ -108,3 +138,88 @@ def validate(ctx, config_file):
 
 
 config.add_command(validate)
+
+
+def _get_default_config() -> typing.Dict[str, typing.Dict]:
+    """Returns a default configuration for pygeoapi."""
+    return {
+        'server': {
+            'admin': False,
+            'bind': {
+                'host': '0.0.0.0',
+                'port': 5000,
+            },
+            'url': 'http://localhost:5000',
+            'mimetype': 'application/json; charset=UTF-8',
+            'encoding': 'utf-8',
+            'gzip': False,
+            'languages': [
+                "en-US",
+                "fr-CA",
+            ],
+            'cors': True,
+            'pretty_print': False,
+            'limit': 10,
+            'templates': {
+                'path': TEMPLATES,
+                'static': str(Path(__file__).parent / 'static'),
+            },
+            'map': {
+                'url': 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                'attribution': (
+                    '&copy; <a href="https://openstreetmap.org/copyright">'
+                    'OpenStreetMap contributors</a>'
+                ),
+            },
+            'manager': {
+                'name': 'TinyDB',
+                'connection': '/tmp/pygeoapi-process-manager.db',
+                'output_dir': '/tmp',
+            },
+            # 'ogc_schemas_location': '/opt/schemas/opengis.net',
+        },
+        'logging': {
+            'level': 'ERROR',
+            # 'logfile': '/tmp/pygeoapi.log',
+        },
+        'metadata': {
+            'identification': {
+                'title': 'pygeoapi default instance',
+                'description': 'pygeoapi provides an API to geospatial data',
+                'keywords': [
+                    'geospatial',
+                    'data',
+                    'api',
+                ],
+                'keywords_type': 'theme',
+                'terms_of_service': (
+                    'https://creativecommons.org/licenses/by/4.0/'),
+                'url': 'https://example.org',
+            },
+            'license': {
+                'name': 'CC-BY 4.0 license',
+                'url': 'https://creativecommons.org/licenses/by/4.0/',
+            },
+            'provider': {
+                'name': 'Organization name',
+                'url': 'https://pygeoapi.io',
+            },
+            'contact': {
+                'name': 'Lastname, Firstname',
+                'position': 'Position Title',
+                'address': 'Mailing Address',
+                'city': 'City',
+                'stateorprovince': 'Administrative Area',
+                'postalcode': 'Zip or Postal Code',
+                'country': 'Country',
+                'phone': '+xx - xxx - xxx - xxxx',
+                'fax': '+xx - xxx - xxx - xxxx',
+                'email': 'you@example.org',
+                'url': 'Contact URL',
+                'hours': 'Mo - Fr 08: 00 - 17:00',
+                'instructions': 'During hours of service. Off on weekends.',
+                'role': 'pointOfContact',
+            },
+        },
+        'resources': {},
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,11 +29,12 @@
 
 import os
 from copy import deepcopy
+from unittest import mock
 
 from jsonschema.exceptions import ValidationError
 import pytest
 
-from pygeoapi.config import validate_config
+import pygeoapi.config
 from pygeoapi.util import yaml_load
 
 from .util import get_test_file_path
@@ -65,11 +66,11 @@ def test_config_envvars():
 
 
 def test_validate_config(config):
-    is_valid = validate_config(config)
+    is_valid = pygeoapi.config.validate_config(config)
     assert is_valid
 
     with pytest.raises(ValidationError):
-        validate_config({'foo': 'bar'})
+        pygeoapi.config.validate_config({'foo': 'bar'})
 
     # Test API rules
     cfg_copy = deepcopy(config)
@@ -79,7 +80,7 @@ def test_validate_config(config):
         'url_prefix': 'v{major_version}',
         'version_header': 'API-Version'
     }
-    assert validate_config(cfg_copy)
+    assert pygeoapi.config.validate_config(cfg_copy)
 
     cfg_copy['server']['api_rules'] = {
         'api_version': 123,
@@ -87,4 +88,38 @@ def test_validate_config(config):
         'strict_slashes': 'bad_value'
     }
     with pytest.raises(ValidationError):
-        validate_config(cfg_copy)
+        pygeoapi.config.validate_config(cfg_copy)
+
+
+def test_get_config_no_env():
+    with mock.patch('pygeoapi.config.os') as mock_os:
+        mock_os.getenv.return_value = None
+        default_conf = pygeoapi.config._get_default_config()
+        conf = pygeoapi.config.get_config()
+        assert conf == default_conf
+
+
+def test_get_config_merge_with_default():
+    # this test has some complex setup:
+    # - create a partial configuration
+    # - mock the response of os.getenv, pathlib.Path.open and yaml_load
+    #   in order to have pygeoapi think it is loading our partial config
+    #   from a file
+    # - ensure the partial config is merged with the default config by
+    #   asserting the value of the final config
+    fake_config = {'server': {'limit': 'fake_limit'}}
+    with \
+            mock.patch('pygeoapi.config.os') as mock_os, \
+            mock.patch('pygeoapi.config.Path') as mock_path, \
+            mock.patch('pygeoapi.config.yaml_load') as mock_yaml_load:
+        mock_os.getenv.return_value = 'something'
+        mock_path_instance = mock.MagicMock()
+        mock_path.return_value = mock_path_instance
+        mock_open = mock.Mock()
+        mock_open.__enter__ = mock.Mock()
+        mock_open.__exit__ = mock.Mock()
+        mock_path_instance.open.return_value = mock_open
+        mock_path_instance.__truediv__.return_value = mock.Mock()
+        mock_yaml_load.return_value = fake_config
+        conf = pygeoapi.config.get_config(raw=False)
+        assert conf['server']['limit'] == fake_config['server']['limit']


### PR DESCRIPTION
# Overview
This PR adds a default configuration to pygeoapi, making it optional that the user supplies a config file location. pygeoapi is able to run with this default config. Moreover, as discussed in #1512, it also allows user to supply a partial configuration, which is then merged with the default config.

# Related issue / discussion
- fixes #1512

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
