### PR TITLE
Replaced geoalchemy with geoalchemy2 and added numpy as explicit dependency

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,5 +1,5 @@
 elasticsearch-dsl<8
-geoalchemy
+geoalchemy2
 pygeofilter[backend-sqlalchemy]
 pygeoif
 pygeometa

--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -4,8 +4,9 @@ elasticsearch
 elasticsearch-dsl
 fiona
 GDAL<=3.8.4
-geoalchemy
+geoalchemy2
 netCDF4
+numpy
 oracledb
 pandas
 psycopg2


### PR DESCRIPTION
# Overview
This PR replaces the dependency on `geoalchemy` with `geoalchemy2`, as discussed in #1515 and it also adds `numpy` as an explicit top-level dependency, as discussed in #1426

# Related issue / discussion
- Fixes #1515 
- Fixes #1426 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
