### PR TITLE
expand TinyDB path message, for ProviderConnectionError

### DIFF
--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -62,7 +62,7 @@ class TinyDBCatalogueProvider(BaseProvider):
         LOGGER.debug(f'Connecting to TinyDB db at {self.data}')
 
         if not os.path.exists(self.data):
-            msg = 'TinyDB does not exist'
+            msg = 'TinyDB file does not exist, please check the path specified, or use a full path to the file'
             LOGGER.error(msg)
             raise ProviderConnectionError(msg)
 

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -62,7 +62,8 @@ class TinyDBCatalogueProvider(BaseProvider):
         LOGGER.debug(f'Connecting to TinyDB db at {self.data}')
 
         if not os.path.exists(self.data):
-            msg = 'TinyDB file does not exist, please check the path specified, or include the full path to the file'
+            msg = ('TinyDB file does not exist, please check the path specified,'
+                  'or include the full path to the file')
             LOGGER.error(msg)
             raise ProviderConnectionError(msg)
 

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -62,7 +62,7 @@ class TinyDBCatalogueProvider(BaseProvider):
         LOGGER.debug(f'Connecting to TinyDB db at {self.data}')
 
         if not os.path.exists(self.data):
-            msg = 'TinyDB file does not exist, please check the path specified, or use a full path to the file'
+            msg = 'TinyDB file does not exist, please check the path specified, or include the full path to the file'
             LOGGER.error(msg)
             raise ProviderConnectionError(msg)
 

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -62,8 +62,9 @@ class TinyDBCatalogueProvider(BaseProvider):
         LOGGER.debug(f'Connecting to TinyDB db at {self.data}')
 
         if not os.path.exists(self.data):
-            msg = ('TinyDB file does not exist, please check the path specified,'
-                  'or include the full path to the file')
+            msg = ('TinyDB file does not exist, please check '
+                   'the path specified, or include the full '
+                   'path to the file')
             LOGGER.error(msg)
             raise ProviderConnectionError(msg)
 


### PR DESCRIPTION
# Overview

Ambiguous message in logs, for when the path to a TinyDB file is not working.  This pull request expands the message, to help users. (instead of thinking that the `tinydb` Python package is not found, this change will point the user instead to the `file` path direction)

# Related issue / discussion

I hit this on Ubuntu 22.04, and solved it by specifying the full path to the TinyDB file.

# Dependency policy (RFC2)

- [ x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
