### PR TITLE
Fixed warnings related to migration to sqlalchemy2 in tests

### DIFF
--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -239,8 +239,7 @@ class PostgreSQLProvider(BaseProvider):
         # Execute query within self-closing database Session context
         with Session(self._engine) as session:
             # Retrieve data from database as feature
-            query = session.query(self.table_model)
-            item = query.get(identifier)
+            item = session.get(self.table_model, identifier)
             if item is None:
                 msg = f"No such item: {self.id_field}={identifier}."
                 raise ProviderItemNotFoundError(msg)
@@ -331,12 +330,13 @@ class PostgreSQLProvider(BaseProvider):
         to target table.  This requires a database query and is expensive to
         perform.
         """
-        metadata = MetaData(engine)
+        metadata = MetaData()
 
         # Look for table in the first schema in the search path
         try:
             schema = self.db_search_path[0]
-            metadata.reflect(schema=schema, only=[self.table], views=True)
+            metadata.reflect(
+                bind=engine, schema=schema, only=[self.table], views=True)
         except OperationalError:
             msg = (f"Could not connect to {repr(engine.url)} "
                    "(password hidden).")


### PR DESCRIPTION
# Overview
This PR fixes warnings related to sqlalchemy v2, as reported when running tests with the [SQLALCHEMY_WARN_20](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-two-turn-on-removedin20warnings) flag:

```sh
export SQLALCHEMY_WARN_20=1 
pytest -v tests/test_postgresql_provider.py
```

# Related issue / discussion
- Related to #1123
- Related to #1519

# Additional information
This PR is a first step towards migrating to sqlalchemy v2 and can be merged unconditionally, as it works on both sqlalchemy v1.4 and v2.

Note however that `pygeofilter[backend-sqlalchemy]` which pygeoapi depends on, is still mandating `sqlalchemy <2` in its own requirements:

https://github.com/geopython/pygeofilter/blob/06254fca2c2e9157e7dd6f4656aec1efe6ed9e46/setup.py#L67

This means we need to ensure pygeofilter works with sqlalchemy v2 before we can claim sqlalchemy v2 as required by pygeoapi - perhaps by merging geopython/pygeofilter#73



# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
