### PR TITLE
Removed encoding parameter from pygeoapi config

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -43,7 +43,6 @@ For more information related to API design rules (the ``api_rules`` property in 
         port: 5000  # listening port for incoming connections
     url: http://localhost:5000/  # url of server
     mimetype: application/json; charset=UTF-8  # default MIME type
-    encoding: utf-8  # default server encoding
     language: en-US  # default server language
     locale_dir: /path/to/translations
     gzip: false # default server config to gzip/compress responses to requests with gzip in the Accept-Encoding header

--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -33,7 +33,6 @@ server:
         port: 5000
     url: http://localhost:5000
     mimetype: application/json; charset=UTF-8
-    encoding: utf-8
     gzip: false
     languages:
         # First language is the default language

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -94,7 +94,6 @@ HEADERS = {
     'X-Powered-By': f'pygeoapi {__version__}'
 }
 
-CHARSET = ['utf-8']
 F_JSON = 'json'
 F_HTML = 'html'
 F_JSONLD = 'jsonld'
@@ -215,16 +214,13 @@ def gzip(func):
 
     def inner(*args, **kwargs):
         headers, status, content = func(*args, **kwargs)
-        charset = CHARSET[0]
         if F_GZIP in headers.get('Content-Encoding', []):
             try:
                 if isinstance(content, bytes):
                     # bytes means Content-Type needs to be set upstream
                     content = compress(content)
                 else:
-                    headers['Content-Type'] = \
-                        f"{headers['Content-Type']}; charset={charset}"
-                    content = compress(content.encode(charset))
+                    content = compress(content.encode())
             except TypeError as err:
                 headers.pop('Content-Encoding')
                 LOGGER.error(f'Error in compression: {err}')
@@ -649,7 +645,6 @@ class API:
         self.base_url = get_base_url(self.config)
         self.prefetcher = UrlPrefetcher()
 
-        CHARSET[0] = config['server'].get('encoding', 'utf-8')
         if config['server'].get('gzip'):
             FORMAT_TYPES[F_GZIP] = 'application/gzip'
             FORMAT_TYPES.move_to_end(F_JSON)

--- a/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
+++ b/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
@@ -32,9 +32,6 @@ properties:
             mimetype:
                 type: string
                 description: default MIME type
-            encoding:
-                type: string
-                description: default server encoding
             gzip:
                 type: boolean
                 description: default server config to gzip/compress responses to requests with gzip in the Accept-Encoding header
@@ -127,7 +124,6 @@ properties:
             - bind
             - url
             - mimetype
-            - encoding
             - map
     logging:
         type: object

--- a/tests/pygeoapi-test-config-admin.yml
+++ b/tests/pygeoapi-test-config-admin.yml
@@ -34,8 +34,7 @@ server:
     url: http://localhost:5000
     admin: true
     mimetype: application/json; charset=UTF-8
-    encoding: utf-8
-    languages: 
+    languages:
         - en-US
     cors: true
     pretty_print: true

--- a/tests/pygeoapi-test-config-apirules.yml
+++ b/tests/pygeoapi-test-config-apirules.yml
@@ -35,7 +35,6 @@ server:
         port: 5000
     url: http://localhost:5000/api
     mimetype: application/json; charset=UTF-8
-    encoding: utf-8
     gzip: false
     languages:
         # First language is the default language

--- a/tests/pygeoapi-test-config-enclosure.yml
+++ b/tests/pygeoapi-test-config-enclosure.yml
@@ -33,7 +33,6 @@ server:
         port: 5000
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
-    encoding: utf-8
     gzip: false
     languages:
         # First language is the default language

--- a/tests/pygeoapi-test-config-envvars.yml
+++ b/tests/pygeoapi-test-config-envvars.yml
@@ -33,7 +33,6 @@ server:
         port: ${PYGEOAPI_PORT}
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
-    encoding: utf-8
     language: en-US
     gzip: false
     cors: true

--- a/tests/pygeoapi-test-config-hidden-resources.yml
+++ b/tests/pygeoapi-test-config-hidden-resources.yml
@@ -33,7 +33,6 @@ server:
         port: 5000
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
-    encoding: utf-8
     gzip: false
     languages:
         # First language is the default language

--- a/tests/pygeoapi-test-config-ogr.yml
+++ b/tests/pygeoapi-test-config-ogr.yml
@@ -33,7 +33,6 @@ server:
     port: 5000
   url: http://localhost:5000/
   mimetype: application/json; charset=UTF-8
-  encoding: utf-8
   language: en-US
   cors: true
   gzip: false

--- a/tests/pygeoapi-test-config-postgresql.yml
+++ b/tests/pygeoapi-test-config-postgresql.yml
@@ -35,7 +35,6 @@ server:
         port: 5000
     url: http://localhost:5000
     mimetype: application/json; charset=UTF-8
-    encoding: utf-8
     gzip: false
     languages:
         # First language is the default language

--- a/tests/pygeoapi-test-config.yml
+++ b/tests/pygeoapi-test-config.yml
@@ -33,7 +33,6 @@ server:
         port: 5000
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
-    encoding: utf-8
     gzip: false
     languages:
         # First language is the default language


### PR DESCRIPTION
# Overview
This PR removes the `encoding` configuration parameter. As discussed in #1521, this parameter only affected the charset of gzipped responses and was thus not being used very consistently. This proposed implementation simply removes this parameter from pygeoapi config and therefore makes gzipped responses use the default charset of `utf-8`, which is what the normal, non-gzipped responses were already doing.

# Related issue / discussion
- Fixes #1521

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
