### PR TITLE
Removed host and port from pygeoapi configuration

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -38,10 +38,7 @@ For more information related to API design rules (the ``api_rules`` property in 
 .. code-block:: yaml
 
   server:
-    bind:
-        host: 0.0.0.0  # listening address for incoming connections
-        port: 5000  # listening port for incoming connections
-    url: http://localhost:5000/  # url of server
+    url: http://localhost:5000/  # public url of server
     mimetype: application/json; charset=UTF-8  # default MIME type
     encoding: utf-8  # default server encoding
     language: en-US  # default server language

--- a/pygeoapi/__init__.py
+++ b/pygeoapi/__init__.py
@@ -90,21 +90,31 @@ def plugins():
 @click.option('--flask', 'server', flag_value="flask", default=True)
 @click.option('--starlette', 'server', flag_value="starlette")
 @click.option('--django', 'server', flag_value="django")
+@click.option(
+    '--host',
+    default='127.0.0.1', help='Bind socket to this host.',
+    show_default=True
+)
+@click.option(
+    '--port',
+    default=5000, show_default=True,
+    help='Bind socket to this port.'
+)
 @click.pass_context
-def serve(ctx, server):
+def serve(ctx, server, host, port):
     """Run the server with different daemon type (--flask is the default)"""
 
     if server == "flask":
         from pygeoapi.flask_app import serve as serve_flask
         ctx.forward(serve_flask)
-        ctx.invoke(serve_flask)
+        ctx.invoke(serve_flask, host, port)
     elif server == "starlette":
         from pygeoapi.starlette_app import serve as serve_starlette
         ctx.forward(serve_starlette)
-        ctx.invoke(serve_starlette)
+        ctx.invoke(serve_starlette, host, port)
     elif server == "django":
         from pygeoapi.django_app import main as serve_django
-        ctx.invoke(serve_django)
+        ctx.invoke(serve_django, host, port)
     else:
         raise click.ClickException('--flask/--starlette/--django is required')
 

--- a/pygeoapi/django_app.py
+++ b/pygeoapi/django_app.py
@@ -37,10 +37,8 @@ import os
 from pathlib import Path
 import sys
 
-from pygeoapi.config import get_config
 
-
-def main():
+def main(host, port):
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'django_.settings')
     django_app_path = Path(os.path.dirname(__file__))
     try:
@@ -51,17 +49,13 @@ def main():
             'available on your PYTHONPATH environment variable? Did you '
             'forget to activate a virtual environment?'
         ) from exc
-
-    CONFIG = get_config()
-
-    bind = f"{CONFIG['server']['bind']['host']}:{CONFIG['server']['bind']['port']}"  # noqa
-
-    sys.argv = [str(django_app_path / 'django_app.py'), 'runserver', bind]
-
     sys.path.append(str(django_app_path))
-
-    execute_from_command_line(sys.argv)
+    execute_from_command_line([
+        str(Path(__file__)),
+        'runserver',
+        f'{host}:{port}'
+    ])
 
 
 if __name__ == '__main__':
-    main()
+    main('127.0.0.1', 5000)

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -527,7 +527,7 @@ if CONFIG['server'].get('admin'):
 @click.command()
 @click.pass_context
 @click.option('--debug', '-d', default=False, is_flag=True, help='debug')
-def serve(ctx, server=None, debug=False):
+def serve(ctx, host, port, server=None, debug=False):
     """
     Serve pygeoapi via Flask. Runs pygeoapi
     as a flask server. Not recommend for production.
@@ -539,8 +539,7 @@ def serve(ctx, server=None, debug=False):
     """
 
     # setup_logger(CONFIG['logging'])
-    APP.run(debug=True, host=api_.config['server']['bind']['host'],
-            port=api_.config['server']['bind']['port'])
+    APP.run(debug=True, host=host, port=port)
 
 
 if __name__ == '__main__':  # run locally, for testing

--- a/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
+++ b/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
@@ -9,19 +9,6 @@ properties:
         type: object
         description: server object
         properties:
-            bind:
-                type: object
-                description: binding server information
-                properties:
-                    host:
-                        type: string
-                        description: binding IP
-                    port:
-                        type: integer
-                        description: binding port
-                required:
-                    - host
-                    - port
             url:
                 type: string
                 description: URL of server (as used by client)
@@ -124,7 +111,6 @@ properties:
                         type: string
                         description: API version response header (leave empty or unset to omit this header)
         required:
-            - bind
             - url
             - mimetype
             - encoding

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -658,7 +658,7 @@ if (OGC_SCHEMAS_LOCATION is not None and
 @click.command()
 @click.pass_context
 @click.option('--debug', '-d', default=False, is_flag=True, help='debug')
-def serve(ctx, server=None, debug=False):
+def serve(ctx, host, port, server=None, debug=False):
     """
     Serve pygeoapi via Starlette. Runs pygeoapi
     as a uvicorn server. Not recommend for production.
@@ -678,8 +678,8 @@ def serve(ctx, server=None, debug=False):
         reload=True,
         log_level=log_level,
         loop='asyncio',
-        host=api_.config['server']['bind']['host'],
-        port=api_.config['server']['bind']['port'])
+        host=host,
+        port=port)
 
 
 if __name__ == "__main__":  # run locally, for testing

--- a/tests/pygeoapi-test-config-admin.yml
+++ b/tests/pygeoapi-test-config-admin.yml
@@ -28,9 +28,6 @@
 # =================================================================
 
 server:
-    bind:
-        host: 0.0.0.0
-        port: 5000
     url: http://localhost:5000
     admin: true
     mimetype: application/json; charset=UTF-8

--- a/tests/pygeoapi-test-config-apirules.yml
+++ b/tests/pygeoapi-test-config-apirules.yml
@@ -30,9 +30,6 @@
 # =================================================================
 
 server:
-    bind:
-        host: 0.0.0.0
-        port: 5000
     url: http://localhost:5000/api
     mimetype: application/json; charset=UTF-8
     encoding: utf-8

--- a/tests/pygeoapi-test-config-enclosure.yml
+++ b/tests/pygeoapi-test-config-enclosure.yml
@@ -28,9 +28,6 @@
 # =================================================================
 
 server:
-    bind:
-        host: 0.0.0.0
-        port: 5000
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
     encoding: utf-8

--- a/tests/pygeoapi-test-config-envvars.yml
+++ b/tests/pygeoapi-test-config-envvars.yml
@@ -28,9 +28,6 @@
 # =================================================================
 
 server:
-    bind:
-        host: 0.0.0.0
-        port: ${PYGEOAPI_PORT}
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
     encoding: utf-8

--- a/tests/pygeoapi-test-config-hidden-resources.yml
+++ b/tests/pygeoapi-test-config-hidden-resources.yml
@@ -28,9 +28,6 @@
 # =================================================================
 
 server:
-    bind:
-        host: 0.0.0.0
-        port: 5000
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
     encoding: utf-8

--- a/tests/pygeoapi-test-config-ogr.yml
+++ b/tests/pygeoapi-test-config-ogr.yml
@@ -28,9 +28,6 @@
 # =================================================================
 
 server:
-  bind:
-    host: 0.0.0.0
-    port: 5000
   url: http://localhost:5000/
   mimetype: application/json; charset=UTF-8
   encoding: utf-8

--- a/tests/pygeoapi-test-config-postgresql.yml
+++ b/tests/pygeoapi-test-config-postgresql.yml
@@ -30,9 +30,6 @@
 # =================================================================
 
 server:
-    bind:
-        host: 0.0.0.0
-        port: 5000
     url: http://localhost:5000
     mimetype: application/json; charset=UTF-8
     encoding: utf-8

--- a/tests/pygeoapi-test-config.yml
+++ b/tests/pygeoapi-test-config.yml
@@ -28,9 +28,6 @@
 # =================================================================
 
 server:
-    bind:
-        host: 0.0.0.0
-        port: 5000
     url: http://localhost:5000/
     mimetype: application/json; charset=UTF-8
     encoding: utf-8

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,18 +46,16 @@ def config():
 
 
 def test_config_envvars():
-    os.environ['PYGEOAPI_PORT'] = '5001'
     os.environ['PYGEOAPI_TITLE'] = 'my title'
 
     with open(get_test_file_path('pygeoapi-test-config-envvars.yml')) as fh:
         config = yaml_load(fh)
 
     assert isinstance(config, dict)
-    assert config['server']['bind']['port'] == 5001
     assert config['metadata']['identification']['title'] == \
         'pygeoapi default instance my title'
 
-    os.environ.pop('PYGEOAPI_PORT')
+    os.environ.pop('PYGEOAPI_TITLE')
 
     with pytest.raises(EnvironmentError):
         with open(get_test_file_path('pygeoapi-test-config-envvars.yml')) as fh:  # noqa


### PR DESCRIPTION
This PR removes web application server initialization parameters from the pygeoapi configuration, specifically the `server.bind` section. This includes:

- `server.bind.host`
- `server.bind.port`

These now become initialization parameters, passed to `pygeoapi serve`. Included in this PR is a working implementation for all of:

- flask
- starlette
- django

`pygeoapi serve` now accepts two optional parameters:

- `host` - defaults to `"127.0.0.1"` - this is intentionally not set to `"0.0.0.0"` in order to prevent accidental exposure of private services.
- `port` - defaults to `5000`


# Related issue / discussion
- Fixes #1523 


# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
