### PR TITLE
Fixed typo in the tiling scheme "rel" property

### DIFF
--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -223,7 +223,7 @@ class MVTElasticProvider(BaseMVTProvider):
                 tiling_scheme_url_title = f'{schema.tileMatrixSet} tile matrix set definition' # noqa
 
                 tiling_scheme = LinkType(href=tiling_scheme_url,
-                                         el="http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme", # noqa
+                                         rel="http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme", # noqa
                                          type=tiling_scheme_url_type,
                                          title=tiling_scheme_url_title)
 


### PR DESCRIPTION
# Overview

This PR fixes a  typo in the `rel` property of the tileset metadata of the mvt_elastic provider. This bug is preventing the rel type to show.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
