### PR TITLE
run api in another thread when using starlette

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -370,7 +370,7 @@ class APIRequest:
                 # has been implemented, with_data() can become async too
                 loop = asyncio.get_event_loop()
                 api_req._data = asyncio.run_coroutine_threadsafe(
-                    request.body(), loop)
+                    request.body(), loop).result(1)
         return api_req
 
     @staticmethod


### PR DESCRIPTION
# Overview
This PR modifies the starlette execution code in order to run calls to pygeoapi `API` in a new thread, thus avoiding blocking the main event loop.

This fix is taken mostly verbatim from the changes committed by @constantinneagu's in 

[Geries-Ingenieure-GmbH/pygeoapi](https://github.com/geopython/pygeoapi/compare/master...Geries-Ingenieure-GmbH:pygeoapi:master)


# Related issue / discussion
- Fixes #1527 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
