### PR TITLE
add OGC API - Tiles as RI in docs

### DIFF
--- a/docs/source/_templates/indexsidebar.html
+++ b/docs/source/_templates/indexsidebar.html
@@ -13,6 +13,9 @@
     <a title="OGC Reference Implementation" href="https://www.ogc.org/resource/products/details/?pid=1663">
         <img alt="OGC Reference Implementation" src="https://portal.ogc.org/public_ogc/compliance/badge.php?s=ogcapi-edr-1%201.0.1&r=1&n=1)" width="164" height="44"/>
     </a>
+    <a title="OGC Reference Implementation" href="https://www.ogc.org/resource/products/details/?pid=1663">
+        <img alt="OGC Reference Implementation" src="https://portal.ogc.org/public_ogc/compliance/badge.php?s=ogcapi-tiles-1%201.0.1&r=1&n=1)" width="164" height="44"/>
+    </a>
     <a title="OSGeo Project" href="https://www.osgeo.org/projects/pygeoapi">
         <img style="background: white;" alt="OSGeo Project" src="https://raw.githubusercontent.com/OSGeo/osgeo/master/incubation/project/OSGeo_project.png" width="164" height="64"/>
     </a>

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -47,7 +47,7 @@ Standards are at the core of pygeoapi.  Below is the project's standards support
    `OGC API - Features`_,Reference Implementation
    `OGC API - Coverages`_,Implementing
    `OGC API - Maps`_,Implementing
-   `OGC API - Tiles`_,Implementing
+   `OGC API - Tiles`_,Reference Implementation
    `OGC API - Processes`_,Implementing
    `OGC API - Records`_,Implementing
    `OGC API - Environmental Data Retrieval`_,Reference Implementation


### PR DESCRIPTION
# Overview
add OGC API - Tiles as RI in docs
# Related issue / discussion
None
# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
