### PR TITLE
Use get to fetch units attribute to avoid error if missing.

### DIFF
--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -439,10 +439,10 @@ class XarrayProvider(BaseProvider):
             if coord.lower() == 'time':
                 time_var = coord
                 continue
-            if self._data.coords[coord].attrs['units'] == 'degrees_north':
+            if self._data.coords[coord].attrs.get('units') == 'degrees_north':
                 y_var = coord
                 continue
-            if self._data.coords[coord].attrs['units'] == 'degrees_east':
+            if self._data.coords[coord].attrs.get('units') == 'degrees_east':
                 x_var = coord
                 continue
 


### PR DESCRIPTION
# Overview

# Related issue / discussion
#1538 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
