### PR TITLE
Allow retrieving extra properties in oracle provider

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -382,7 +382,7 @@ Extra properties
         geom_field: geometry
         title_field: name
         extra_properties:
-        - "'Here we have " || name AS tooltip"
+        - "'Here we have ' || name AS tooltip"
 
 Extra properties is a list of strings which are added as fields for data retrieval in the SELECT clauses. They
 can be used to return expressions computed by the database.

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -357,12 +357,36 @@ Mandatory properties
         table: lakes
         geom_field: geometry
         title_field: name
-        manadory_properties:
+        mandatory_properties:
         - example_group_id
 
 On large tables it could be useful to disallow a query on the complete dataset. For this reason it is possible to 
 configure mandatory properties. When this is activated, the provoder throws an exception when the parameter
 is not in the query uri.
+
+Extra properties
+""""""""""""""""""""
+.. code-block:: yaml
+
+  providers:
+      - type: feature
+        name: OracleDB
+        data:
+            host: 127.0.0.1
+            port: 1521
+            service_name: XEPDB1
+            user: geo_test
+            password: geo_test
+        id_field: id
+        table: lakes
+        geom_field: geometry
+        title_field: name
+        extra_properties:
+        - "'Here we have " || name AS tooltip"
+
+Extra properties is a list of strings which are added as fields for data retrieval in the SELECT clauses. They
+can be used to return expressions computed by the database.
+
 
 Custom SQL Manipulator Plugin
 """""""""""""""""""""""""""""

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -55,7 +55,7 @@ class DatabaseConnection:
     The class returns a connection object.
     """
 
-    def __init__(self, conn_dic, table, properties=None, context="query"):
+    def __init__(self, conn_dic, table, properties=[], context="query"):
         """
         OracleProvider Class constructor
 
@@ -86,8 +86,7 @@ class DatabaseConnection:
         self.columns = (
             None  # Comma sepparated string with column names (for SQL query)
         )
-        self.properties = \
-            [item.lower() for item in properties] if properties else []
+        self.properties = [item.lower() for item in properties]
         self.fields = {}  # Dict of columns. Key is col name, value is type
         self.conn = None
 

--- a/tests/test_oracle_provider.py
+++ b/tests/test_oracle_provider.py
@@ -203,6 +203,14 @@ def config_properties(config):
 
 
 @pytest.fixture()
+def config_extra_properties(config):
+    return {
+        **config,
+        "extra_properties": ["'Here the name is ' || name || '!' as tooltip"],
+    }
+
+
+@pytest.fixture()
 def create_geojson():
     return {
         "type": "Feature",
@@ -356,6 +364,15 @@ def test_query_with_property_filter(config):
     assert features[0].get("id") == 12
 
 
+def test_query_with_extra_properties(config_extra_properties):
+    p = OracleProvider(config_extra_properties)
+
+    feature_collection = p.query(properties=[("name", "Aral Sea")])
+    features = feature_collection.get("features")
+
+    assert features[0]["properties"]["tooltip"] == "Here the name is Aral Sea!"
+
+
 def test_query_bbox(config):
     """Test query with a specified bounding box"""
     p = OracleProvider(config)
@@ -405,6 +422,17 @@ def test_get(config):
     assert result.get("id") == 5
     assert result.get("prev") == 4
     assert result.get("next") == 6
+
+
+def test_get_with_extra_properties(config_extra_properties):
+    """Test simple get"""
+    p = OracleProvider(config_extra_properties)
+    result = p.get(5)
+
+    assert (
+        result["properties"]["tooltip"] ==
+        "Here the name is L. Erie!"
+    )
 
 
 def test_create(config, create_geojson):


### PR DESCRIPTION
# Overview

These can be used to configure additional database-computed fields in the config file which are returned on `get` and `query` calls

See the changes in the documentation for more details.

# Related issue / discussion

# Additional information

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
