### PR TITLE
fix Django EDR implementation on non-instance endpoints (#1528)

### DIFF
--- a/pygeoapi/django_/views.py
+++ b/pygeoapi/django_/views.py
@@ -348,7 +348,7 @@ def collection_tiles_metadata(request: HttpRequest, collection_id: str,
 
 def collection_item_tiles(request: HttpRequest, collection_id: str,
                           tileMatrixSetId: str, tileMatrix: str,
-                          tileRow: str, tileCol: str, ) -> HttpResponse:
+                          tileRow: str, tileCol: str) -> HttpResponse:
     """
     OGC API - Tiles collection tiles data endpoint
 

--- a/pygeoapi/django_/views.py
+++ b/pygeoapi/django_/views.py
@@ -36,6 +36,7 @@
 """Integration module for Django"""
 
 from typing import Tuple, Dict, Mapping, Optional
+
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 
@@ -347,7 +348,7 @@ def collection_tiles_metadata(request: HttpRequest, collection_id: str,
 
 def collection_item_tiles(request: HttpRequest, collection_id: str,
                           tileMatrixSetId: str, tileMatrix: str,
-                          tileRow: str, tileCol: str,) -> HttpResponse:
+                          tileRow: str, tileCol: str, ) -> HttpResponse:
     """
     OGC API - Tiles collection tiles data endpoint
 
@@ -449,14 +450,16 @@ def job_results_resource(request: HttpRequest, process_id: str, job_id: str,
     return response
 
 
-def get_collection_edr_query(request: HttpRequest, collection_id: str,
-                             instance_id: Optional[str] = None) -> HttpResponse:
+def get_collection_edr_query(
+        request: HttpRequest, collection_id: str,
+        instance_id: Optional[str] = None
+) -> HttpResponse:
     """
     OGC API - EDR endpoint
 
-    :request Django HTTP Request
-    :param job_id: job identifier
-    :param resource: job resource
+    :param request: Django HTTP Request
+    :param collection_id: collection identifier
+    :param instance_id: optional instance identifier. default is None
 
     :returns: Django HTTP response
     """

--- a/pygeoapi/django_/views.py
+++ b/pygeoapi/django_/views.py
@@ -450,7 +450,7 @@ def job_results_resource(request: HttpRequest, process_id: str, job_id: str,
 
 
 def get_collection_edr_query(request: HttpRequest, collection_id: str,
-                             instance_id: str) -> HttpResponse:
+                             instance_id: Optional[str] = None) -> HttpResponse:
     """
     OGC API - EDR endpoint
 


### PR DESCRIPTION
# Overview
The issue was created by using the same view for a instance and non-instance endpoint, while having the instance_id argument be mandatory. By making the argument optional, the view works with and without the instance argument.

# Related issue / discussion

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
