### PR TITLE
Clear up space before running CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,14 @@ jobs:
       PYGEOAPI_CONFIG: "$(pwd)/pygeoapi-config.yml"
     
     steps:
+    - name: Clear up github runner disc space
+      run: |
+        echo "Space before"
+        df -h /
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
+        echo "Space after"
+        df -h /
     - name: Chown user
       run: |
         sudo chown -R $USER:$USER $GITHUB_WORKSPACE


### PR DESCRIPTION

# Overview

With all the databases and dependencies more than the 19G is needed (this is the amount which is currenlty available on runners).

There is a github action which meddles with the disc layout, which is probably too much for our use case, but it gave me the idea that you can delete files which are needed to support certain platforms such as dotnet and android.
https://github.com/easimon/maximize-build-space

With only manually removing those files, around 30G are available which should be enough for the foreseeable future



# Additional information

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
