### PR TITLE
Fix crash on json-ld generation regarding collection's CRS

### DIFF
--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -134,7 +134,7 @@ def jsonldify_collection(cls, collection: dict, locale_: str) -> dict:
 
     spatial_extent = collection.get('extent', {}).get('spatial', {})
     bbox = spatial_extent.get('bbox')
-    crs = spatial_extent.get('crs')
+    crs = collection.get('crs')[0]
     hascrs84 = crs.endswith('CRS84')
 
     dataset = {


### PR DESCRIPTION
# Overview

Found during the [OGC/OSGeo/ASF codesprint in Évora](https://github.com/opengeospatial/developer-events/wiki/2024-Joint-OGC-%E2%80%93-OSGeo-%E2%80%93-ASF-Code-Sprint). Briefly discussed in person with @tomkralidis.

While generating a json-ld document in my test instance (running `master` as of 2024-02-28, f4c2ff970fa2d42d3d5d5fd6952069162d5f823e), there's an error like

```
  File "..../pygeoapi/linked_data.py", line 138 in jsonldify_collection
    hascrs84 = crs.endswith('CRS84')
               ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'endswith'
```

During runtime, the collection `dict` received by `jsonldify` looks like:
```
{
        (snip)
  "extent": {
    "spatial": {
      "bbox": [343500.0, 4401700.0, 519700.0, 4572100.0],
      "grid": [
        { "cellsCount": 881, "resolution": 200.0 },
        { "cellsCount": 852, "resolution": 200.0 },
      ],
    },
    "temporal": { "interval": [[None, None]] },
  },
  "crs": ["http://www.opengis.net/def/crs/OGC/1.3/25830"],
};
```

So, by changing `crs = spatial_extent.get('crs')` into `crs = collection.get('crs')[0]` makes the problem go away.

Since I'm not a pygeoapi expert, I'm not 100% sure that the collection `dict` is supposed to look like this.

# Related issue / discussion

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
