### PR TITLE
Make tiling scheme parameter optional

### DIFF
--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -78,8 +78,7 @@ This code block shows how to configure pygeoapi to read Mapbox vector tiles from
              zoom:
                  min: 0
                  max: 5
-             schemes:
-                 - WebMercatorQuad
+        # MVT-elastic always uses WebMercatorQuad tiling scheme
          format:
              name: pbf
              mimetype: application/vnd.mapbox-vector-tile

--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -15,13 +15,13 @@ Providers
 pygeoapi core tile providers are listed below, along with supported features.
 
 .. csv-table::
-   :header: Provider, rendered on-the-fly, properties
+   :header: Provider, rendered on-the-fly, properties, WebMercatorQuad, WorldCRS84Quad
    :align: left
 
-   `MVT-tippecanoe`_,❌,✅
-   `MVT-elastic`_,✅,❌
-   `MVT-proxy`_, N/A , N/A
-   `WMTSFacade`_,✅,❌
+   `MVT-tippecanoe`_,❌,✅,✅,❌
+   `MVT-elastic`_,✅,❌,✅,❌
+   `MVT-proxy`_,❔,❔,❔,❔
+   `WMTSFacade`_,✅,❌,✅,✅
 
 Below are specific connection examples based on supported providers.
 
@@ -48,8 +48,7 @@ This code block shows how to configure pygeoapi to read Mapbox vector tiles gene
              zoom:
                  min: 0
                  max: 5
-             schemes:
-                 - WebMercatorQuad
+        # MVT-elastic always uses WebMercatorQuad tiling scheme
          format:
              name: pbf
              mimetype: application/vnd.mapbox-vector-tile
@@ -107,7 +106,7 @@ Following block shows how to configure pygeoapi to read Mapbox vector tiles from
                 min: 0
                 max: 15
              schemes:
-                 - WebMercatorQuad
+                 - WebMercatorQuad # this option is needed in the MVT-proxy provider
          format:
              name: pbf
              mimetype: application/vnd.mapbox-vector-tile

--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -144,18 +144,17 @@ This code block shows how to configure pygeoapi to read map tiles from a WMTS.
       providers:
           - type: tile
             name: WMTSFacade
-            data: http://127.0.0.1:8080/service
+            data: https://emotional.byteroad.net/geoserver/gwc/service/wmts
             format:
                 name: png  # png or jpeg
                 mimetype: image/png
             options:
-                wmts_layer: bkg  # the layer name of the wmts
-                wmts_tile_matrix_set: webmercator  # the name of the tile matrix set of the wmts.
+                wmts_layer: camb:hex350_grid_mental_1920 # the layer name of the wmts
+                wmts_tile_matrix_set: WebMercatorQuad  # the name of the tile matrix set of the wmts.
                 scheme: WebMercatorQuad  # the aligning scheme in pygeoapi.
                 zoom:
                     min: 0
                     max: 20
-
 
 Data access examples
 --------------------

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2960,12 +2960,6 @@ class API:
         # Get provider language (if any)
         prv_locale = l10n.get_plugin_locale(t, request.raw_locale)
 
-        tiling_schemes = p.get_tiling_schemes()
-        if matrix_id not in [item.tileMatrixSet for item in tiling_schemes]:
-            msg = 'tileset not found'
-            return self.get_exception(HTTPStatus.NOT_FOUND, headers,
-                                      request.format, 'NotFound', msg)
-
         # Set response language to requested provider locale
         # (if it supports language) and/or otherwise the requested pygeoapi
         # locale (or fallback default locale)

--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -36,7 +36,7 @@ from pygeoapi.provider.base import (ProviderConnectionError,
                                     ProviderGenericError,
                                     ProviderInvalidQueryError)
 from pygeoapi.models.provider.base import (
-    TileSetMetadata, LinkType)
+    TileSetMetadata, TileMatrixSetEnum, LinkType)
 from pygeoapi.util import is_url, url_join
 
 LOGGER = logging.getLogger(__name__)
@@ -118,6 +118,13 @@ class MVTElasticProvider(BaseMVTProvider):
         LOGGER.debug(layer)
         LOGGER.debug('Removing leading "/"')
         return layer[1:]
+
+    def get_tiling_schemes(self):
+
+        "Only WebMercatorQuad tiling scheme is supported in elastic"
+        return [
+                TileMatrixSetEnum.WEBMERCATORQUAD.value
+            ]
 
     def get_tiles_service(self, baseurl=None, servicepath=None,
                           dirpath=None, tile_type=None):

--- a/pygeoapi/provider/mvt_tippecanoe.py
+++ b/pygeoapi/provider/mvt_tippecanoe.py
@@ -234,7 +234,6 @@ class MVTTippecanoeProvider(BaseMVTProvider):
         if format_ == 'mvt':
             format_ = self.format_type
 
-
         if isinstance(self.service_url, Path):
             return self.get_tiles_from_disk(layer, tileset, z, y, x, format_)
         elif is_url(self.data):

--- a/pygeoapi/provider/mvt_tippecanoe.py
+++ b/pygeoapi/provider/mvt_tippecanoe.py
@@ -40,7 +40,7 @@ from pygeoapi.provider.base import (ProviderConnectionError,
                                     ProviderGenericError)
 from pygeoapi.provider.base_mvt import BaseMVTProvider
 from pygeoapi.models.provider.base import (
-    TileSetMetadata, LinkType)
+    TileSetMetadata, TileMatrixSetEnum, LinkType)
 from pygeoapi.models.provider.mvt import MVTTilesJson
 
 from pygeoapi.util import is_url, url_join
@@ -136,6 +136,13 @@ class MVTTippecanoeProvider(BaseMVTProvider):
         else:
             return Path(self.data).name
 
+    def get_tiling_schemes(self):
+
+        "Only WebMercatorQuad tiling scheme is supported in elastic"
+        return [
+                TileMatrixSetEnum.WEBMERCATORQUAD.value
+            ]
+
     def get_tiles_service(self, baseurl=None, servicepath=None,
                           dirpath=None, tile_type=None):
         """
@@ -226,6 +233,7 @@ class MVTTippecanoeProvider(BaseMVTProvider):
 
         if format_ == 'mvt':
             format_ = self.format_type
+
 
         if isinstance(self.service_url, Path):
             return self.get_tiles_from_disk(layer, tileset, z, y, x, format_)

--- a/pygeoapi/templates/collections/tiles/index.html
+++ b/pygeoapi/templates/collections/tiles/index.html
@@ -88,10 +88,10 @@
         .replace('{dataset}', '{{ data["id"] }}')
         .replace('{tileMatrixSetId}', scheme)
         .replace("tileMatrix", "z")
-        .replace("tileRow", "y")
-        .replace("tileCol", "x");
-
     {% if data['tile_type'] == 'raster' %}
+        url = url
+            .replace("tileRow", "y")
+            .replace("tileCol", "x");
         map.addLayer(new L.TileLayer(
             url, {
                 maxZoom: {{ data['maxzoom'] }},
@@ -99,6 +99,9 @@
             }
         ));
     {% elif data['tile_type'] == 'vector' %}
+        url = url
+            .replace("tileRow", "x")
+            .replace("tileCol", "y");
         var VectorTileOptions = {
             interactive: true,
             rendererFactory: L.canvas.tile,


### PR DESCRIPTION
# Overview
This PR makes the tiling scheme in the configuration file, optional. In the case of MVT-tipepcanoe and MVT-elastic providers, only WebMercatorQuad is supported, so that is built-in in the code. In the case of MVT-proxy, as it is a more generic provider, the user still needs to input that parameter.

# Related issue / discussion
https://github.com/geopython/pygeoapi/issues/1559

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
