### PR TITLE
clean up API docs, move plugins to wiki

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O) -W

--- a/docs/source/api-documentation.rst
+++ b/docs/source/api-documentation.rst
@@ -5,200 +5,23 @@ API documentation
 
 Top level code documentation. Follow the links in each section for module/class member information.
 
-API
----
-
 .. automodule:: pygeoapi.api
    :members:
    :private-members:
    :special-members:
 
-
-flask_app
----------
-
-.. automodule:: pygeoapi.flask_app
-   :show-inheritance:
+.. automodule:: pygeoapi.process.base
    :members:
    :private-members:
    :special-members:
 
-
-Logging
--------
-
-.. automodule:: pygeoapi.log
-   :show-inheritance:
+.. automodule:: pygeoapi.process.manager.base
    :members:
    :private-members:
    :special-members:
-
-
-OpenAPI
--------
-
-.. automodule:: pygeoapi.openapi
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-
-Plugins
--------
-
-.. seealso::
-   :ref:`plugins`
-
-.. automodule:: pygeoapi.plugin
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-
-Utils
------
-
-.. automodule:: pygeoapi.util
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-
-Formatter package
------------------
-
-.. automodule:: pygeoapi.formatter
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-
-Base class
-^^^^^^^^^^
 
 .. automodule:: pygeoapi.formatter.base
-   :show-inheritance:
    :members:
    :private-members:
    :special-members:
 
-
-csv
-^^^
-
-.. automodule:: pygeoapi.formatter.csv_
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-
-Process package
----------------
-
-.. automodule:: pygeoapi.process
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-
-Base class
-^^^^^^^^^^
-
-.. automodule:: pygeoapi.process.base
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-
-hello_world
-^^^^^^^^^^^
-
-Hello world example process
-
-.. automodule:: pygeoapi.process.hello_world
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-.. _data Provider:
-
-Provider
---------
-
-.. automodule:: pygeoapi.provider
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-
-Base class
-^^^^^^^^^^
-
-.. automodule:: pygeoapi.provider.base
-   :show-inheritance:
-   :members:
-   :private-members:
-   :special-members:
-
-
-CSV provider
-^^^^^^^^^^^^
-
-.. automodule:: pygeoapi.provider.csv_
-   :show-inheritance:
-   :members:
-   :private-members:
-
-
-Elasticsearch provider
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: pygeoapi.provider.elasticsearch_
-   :show-inheritance:
-   :members:
-   :private-members:
-
-
-GeoJSON
-^^^^^^^
-
-.. automodule:: pygeoapi.provider.geojson
-   :show-inheritance:
-   :members:
-   :private-members:
-
-
-OGR
-^^^
-
-.. automodule:: pygeoapi.provider.ogr
-   :show-inheritance:
-   :members:
-   :private-members:
-
-
-postgresql
-^^^^^^^^^^
-
-.. automodule:: pygeoapi.provider.postgresql
-   :show-inheritance:
-   :members:
-   :private-members:
-
-
-sqlite/geopackage
-^^^^^^^^^^^^^^^^^
-
-.. automodule:: pygeoapi.provider.sqlite
-   :show-inheritance:
-   :members:
-   :private-members:

--- a/docs/source/data-publishing/ogcapi-coverages.rst
+++ b/docs/source/data-publishing/ogcapi-coverages.rst
@@ -18,7 +18,7 @@ parameters.
    :header: Provider, properties, subset, bbox, datetime
    :align: left
 
-   :ref:`Rasterio<rasterio-provider>`,✅,✅,✅,
+   :ref:`Rasterio<rasterio-provider>`,✅,✅,✅,✅
    :ref:`Xarray<xarray-provider>`,✅,✅,✅,✅
 
 

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -21,7 +21,7 @@ parameters.
 
    `CSV`_,✅/✅,results/hits,❌,❌,❌,✅,❌,❌,✅
    `Elasticsearch`_,✅/✅,results/hits,✅,✅,✅,✅,✅,✅,✅
-   `ERDDAP Tabledap Service`_,❌/❌,results/hits,✅,✅,❌,❌,❌,❌
+   `ERDDAP Tabledap Service`_,❌/❌,results/hits,✅,✅,❌,❌,❌,❌,❌
    `ESRI Feature Service`_,✅/✅,results/hits,✅,✅,✅,✅,❌,❌,✅
    `GeoJSON`_,✅/✅,results/hits,❌,❌,❌,✅,❌,❌,✅
    `MongoDB`_,✅/❌,results,✅,✅,✅,✅,❌,❌,✅

--- a/docs/source/data-publishing/ogcapi-maps.rst
+++ b/docs/source/data-publishing/ogcapi-maps.rst
@@ -18,8 +18,8 @@ parameters.
    :header: Provider, bbox, width/height
    :align: left
 
-   `MapScript`,,✅,✅
-   `WMSFacade`_,,✅,✅
+   `MapScript`,✅,✅
+   `WMSFacade`_,✅,✅
 
 
 Below are specific connection examples based on supported providers.

--- a/docs/source/data-publishing/ogcapi-records.rst
+++ b/docs/source/data-publishing/ogcapi-records.rst
@@ -18,9 +18,9 @@ parameters.
    :header: Provider, properties (filters), resulttype, q, bbox, datetime, sortby, properties (display), CQL, transactions
    :align: left
 
-   `ElasticsearchCatalogue`_,✅,results/hits,✅,✅,✅,✅,✅,✅
-   `TinyDBCatalogue`_,✅,results/hits,✅,✅,✅,✅,❌,✅
-   `CSWFacade`_,✅,results/hits,✅,✅,✅,❌,❌,❌
+   `ElasticsearchCatalogue`_,✅,results/hits,✅,✅,✅,✅,✅,✅,✅
+   `TinyDBCatalogue`_,✅,results/hits,✅,✅,✅,✅,❌,✅,✅
+   `CSWFacade`_,✅,results/hits,✅,✅,✅,❌,❌,❌,❌
 
 
 Below are specific connection examples based on supported providers.

--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -54,7 +54,8 @@ This code block shows how to configure pygeoapi to read Mapbox vector tiles gene
              mimetype: application/vnd.mapbox-vector-tile
 
 .. tip::
-   On `this tutorial <https://dive.pygeoapi.io/publishing/ogcapi-tiles/#publish-pre-rendered-vector-tiles>`_  you can find detailed instructions on how-to generate tiles using tippecanoe and integrate them into pygeoapi.
+
+   In the diving into pygeoapi workshop `OGC API - Tiles Exercise <https://dive.pygeoapi.io/publishing/ogcapi-tiles/#publish-pre-rendered-vector-tiles>`_, detailed instructions can be found on how to generate tiles using tippecanoe and integrate them into pygeoapi.
 
 MVT-elastic
 ^^^^^^^^^^^
@@ -141,20 +142,21 @@ Currently only `WebMercatorQuad` and `WorldCRS84Quad` are available in pygeopi.
 This code block shows how to configure pygeoapi to read map tiles from a WMTS.
 
 .. code-block:: yaml
-      providers:
-          - type: tile
-            name: WMTSFacade
-            data: https://emotional.byteroad.net/geoserver/gwc/service/wmts
-            format:
-                name: png  # png or jpeg
-                mimetype: image/png
-            options:
-                wmts_layer: camb:hex350_grid_mental_1920 # the layer name of the wmts
-                wmts_tile_matrix_set: WebMercatorQuad  # the name of the tile matrix set of the wmts.
-                scheme: WebMercatorQuad  # the aligning scheme in pygeoapi.
-                zoom:
-                    min: 0
-                    max: 20
+
+   providers:
+       - type: tile
+         name: WMTSFacade
+         data: https://emotional.byteroad.net/geoserver/gwc/service/wmts
+         format:
+             name: png  # png or jpeg
+             mimetype: image/png
+         options:
+             wmts_layer: camb:hex350_grid_mental_1920 # the layer name of the wmts
+             wmts_tile_matrix_set: WebMercatorQuad  # the name of the tile matrix set of the wmts.
+             scheme: WebMercatorQuad  # the aligning scheme in pygeoapi.
+             zoom:
+                 min: 0
+                 max: 20
 
 Data access examples
 --------------------

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -147,7 +147,7 @@ option 2 above).
 Example: custom pygeoapi vector data provider
 ---------------------------------------------
 
-Lets consider the steps for a vector data provider plugin (source code is located here: :ref:`data Provider`).
+Lets consider the steps for a vector data provider plugin:
 
 Python code
 ^^^^^^^^^^^
@@ -220,7 +220,7 @@ Each base class documents the functions, arguments and return types required for
 Example: custom pygeoapi raster data provider
 ---------------------------------------------
 
-Lets consider the steps for a raster data provider plugin (source code is located here: :ref:`data Provider`).
+Lets consider the steps for a raster data provider plugin:
 
 Python code
 ^^^^^^^^^^^
@@ -317,28 +317,9 @@ for the time being.
 Featured plugins
 ----------------
 
-The following plugins provide useful examples of pygeoapi plugins implemented
-by downstream applications.
-
-.. csv-table::
-   :header: "Plugin(s)", "Organization/Project","Description"
-   :align: left
-
-   `msc-pygeoapi`_,Meteorological Service of Canada,processes for weather/climate/water data workflows
-   `pygeoapi-kubernetes-papermill`_,Euro Data Cube,processes for executing Jupyter notebooks via Kubernetes
-   `local-outlier-factor-plugin`_,Manaaki Whenua – Landcare Research,processes for local outlier detection
-   `ogc-edc`_,Euro Data Cube,coverage provider atop the EDC API
-   `nldi_xstool`_,United States Geological Survey,Water data processing
-   `pygeometa-plugin`_,pygeometa project,pygeometa as a service
-   `cgs-plugins`_,Center for Geospatial Solutions,feature and processes plugins
+Community based plugins can be found on the `pygeoapi Community Plugins wiki page`_.
 
 
-.. _`cgs-plugins`: https://github.com/cgs-earth/pygeoapi-plugins
+.. _`pygeoapi Community Plugins wiki page`: https://github.com/geopython/pygeoapi/wiki/CommunityPlugins
 .. _`Cookiecutter`: https://github.com/audreyfeldroy/cookiecutter-pypackage
-.. _`msc-pygeoapi`: https://github.com/ECCC-MSC/msc-pygeoapi
-.. _`pygeoapi-kubernetes-papermill`: https://github.com/eurodatacube/pygeoapi-kubernetes-papermill
-.. _`local-outlier-factor-plugin`: https://github.com/manaakiwhenua/local-outlier-factor-plugin
-.. _`ogc-edc`: https://github.com/eurodatacube/ogc-edc/tree/oapi/edc_ogc/pygeoapi
-.. _`nldi_xstool`: https://code.usgs.gov/wma/nhgf/toolsteam/nldi-xstool
 .. _`pygeoapi-plugin-cookiecutter`: https://code.usgs.gov/wma/nhgf/pygeoapi-plugin-cookiecutter
-.. _`pygeometa-plugin`: https://geopython.github.io/pygeometa/pygeoapi-plugin

--- a/pygeoapi/l10n.py
+++ b/pygeoapi/l10n.py
@@ -66,7 +66,7 @@ def str2locale(value, silent: bool = False) -> Union[Locale, None]:
 
     :returns: babel.core.Locale or None
 
-    :raises: LocaleError
+    :raises LocaleError:
     """
 
     if isinstance(value, Locale):
@@ -103,7 +103,7 @@ def locale2str(value: Locale) -> str:
     :returns: A string containing a web locale (e.g. 'fr-CH')
               or language tag (e.g. 'de').
 
-    :raises: LocaleError
+    :raises LocaleError:
     """
 
     if not isinstance(value, Locale):
@@ -145,7 +145,7 @@ def best_match(accept_languages, available_locales) -> Locale:
 
     :returns: babel.core.Locale
 
-    :raises: LocaleError
+    :raises LocaleError:
     """
 
     def get_match(locale_, available_locales_):
@@ -254,7 +254,7 @@ def translate(value, language: Union[Locale, str]):
 
     :returns: A translated string or the original value.
 
-    :raises: LocaleError
+    :raises LocaleError:
     """
 
     nested_dicts = isinstance(value, dict) and any(isinstance(v, dict)
@@ -386,7 +386,7 @@ def set_response_language(headers: dict, *locale_: Locale):
                     Multiple locales can be set for this header.
                     Note that duplicates will be removed.
 
-    :raises: LocaleError if no valid Babel Locale was found.
+    :raises LocaleError: if no valid Babel Locale was found.
     """
 
     if not hasattr(headers, '__setitem__'):
@@ -422,7 +422,7 @@ def add_locale(url, locale_) -> str:
 
     :returns: A new URL with a 'lang=<locale>' query parameter.
 
-    :raises: requests.exceptions.MissingSchema
+    :raises requests.exceptions.MissingSchema:
     """
 
     loc = str2locale(locale_, True)

--- a/pygeoapi/process/base.py
+++ b/pygeoapi/process/base.py
@@ -58,6 +58,7 @@ class BaseProcessor:
                      to execute
 
         :returns: tuple of MIME type and process response
+                  (string or bytes, or dict)
         """
 
         raise NotImplementedError()

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -90,7 +90,7 @@ class BaseManager:
 
         :param process_id: Identifier of the process
 
-        :raise UnknownProcessError: if the processor cannot be created
+        :raises UnknownProcessError: if the processor cannot be created
         :returns: instance of the processor
         """
 
@@ -142,8 +142,8 @@ class BaseManager:
 
         :param job_id: job identifier
 
-        :raises: JobNotFoundError: if the job_id does not correspond to a
-            known job
+        :raises JobNotFoundError: if the job_id does not correspond to a
+                                  known job
         :returns: `dict` of job result
         """
 
@@ -155,10 +155,10 @@ class BaseManager:
 
         :param job_id: job identifier
 
-        :raises: JobNotFoundError: if the job_id does not correspond to a
-            known job
-        :raises: JobResultNotFoundError: if the job-related result cannot
-            be returned
+        :raises JobNotFoundError: if the job_id does not correspond to a
+                                  known job
+        :raises JobResultNotFoundError: if the job-related result cannot
+                                         be returned
         :returns: `tuple` of mimetype and raw output
         """
 
@@ -170,8 +170,8 @@ class BaseManager:
 
         :param job_id: job identifier
 
-        :raises: JobNotFoundError: if the job_id does not correspond to a
-            known job
+        :raises JobNotFoundError: if the job_id does not correspond to a
+                                   known job
         :returns: `bool` of status result
         """
 
@@ -320,10 +320,10 @@ class BaseManager:
         :param process_id: process identifier
         :param data_dict: `dict` of data parameters
         :param execution_mode: `str` optionally specifying sync or async
-        processing.
+                               processing.
 
-        :raises: UnknownProcessError if the input process_id does not
-                 correspond to a known process
+        :raises UnknownProcessError: if the input process_id does not
+                                     correspond to a known process
         :returns: tuple of job_id, MIME type, response payload, status and
                   optionally additional HTTP headers to include in the final
                   response

--- a/pygeoapi/process/manager/tinydb_.py
+++ b/pygeoapi/process/manager/tinydb_.py
@@ -131,8 +131,8 @@ class TinyDBManager(BaseManager):
 
         :param job_id: job identifier
 
-        :raises: JobNotFoundError: if the job_id does not correspond to a
-            known job
+        :raises JobNotFoundError: if the job_id does not correspond to a
+                                  known job
         :return `bool` of status result
         """
         # delete result file if present
@@ -152,8 +152,8 @@ class TinyDBManager(BaseManager):
 
         :param job_id: job identifier
 
-        :raises: JobNotFoundError: if the job_id does not correspond to a
-            known job
+        :raises JobNotFoundError: if the job_id does not correspond to a
+                                  known job
         :returns: `dict`  # `pygeoapi.process.manager.Job`
         """
 
@@ -174,10 +174,10 @@ class TinyDBManager(BaseManager):
 
         :param job_id: job identifier
 
-        :raises: JobNotFoundError: if the job_id does not correspond to a
-            known job
-        :raises: JobResultNotFoundError: if the job-related result cannot
-            be returned
+        :raises JobNotFoundError: if the job_id does not correspond to a
+                                  known job
+        :raises JobResultNotFoundError: if the job-related result cannot
+                                        be returned
         :returns: `tuple` of mimetype and raw output
         """
 

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -674,11 +674,9 @@ def get_crs_from_uri(uri: str) -> pyproj.CRS:
     Author: @MTachon
 
     :param uri: Uniform resource identifier of the coordinate
-        reference system. In accordance with
-        https://docs.ogc.org/pol/09-048r5.html#_naming_rule URIs can
-        take either the form of a URL or a URN
-    :type uri: str
-
+                reference system. In accordance with
+                https://docs.ogc.org/pol/09-048r5.html#_naming_rule URIs can
+                take either the form of a URL or a URN
     :raises `CRSError`: Error raised if no CRS could be identified from the
         URI.
 
@@ -892,15 +890,15 @@ def modify_pygeofilter(
     Modifies the input pygeofilter with information from the provider.
 
     :param ast_tree: `pygeofilter.ast.Node` representing the
-    already parsed pygeofilter expression
+                     already parsed pygeofilter expression
     :param filter_crs_uri: URI of the CRS being used in the filtering
-    expression
+                           expression
     :param storage_crs_uri: An optional string containing the URI of
-    the provider's storage CRS
+                            the provider's storage CRS
     :param geometry_column_name: An optional string containing the
-    actual name of the provider's geometry field
+                                 actual name of the provider's geometry field
     :returns: A new pygeofilter.ast.Node, with the modified filter
-    expression
+              expression
 
     This function modifies the parsed pygeofilter that contains the raw
     filter expression provided by an external client. It performs the


### PR DESCRIPTION
# Overview
- cleans up API documentation (Sphinx autodoc) to contain base class documentation
- turns on strict checking (warnings as errors) as part of HTML building
- fixes resulting warnings
- moves example plugins section to [wiki page](https://github.com/geopython/pygeoapi/wiki/CommunityPlugins) and references
# Related issue / discussion
None
# Additional information

This PR should only be merged once #1571 is clarified/merged (cc @doublebyte1)

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
