### PR TITLE
Fix typo in schema location path for openapi document

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -640,7 +640,7 @@ def get_oas_30(cfg):
                 paths[items_path]['get']['parameters'].append(
                     {'$ref': f"{OPENAPI_YAML['oapir']}/parameters/q.yaml"})
             if p.fields:
-                schema_path = f'{collection_name_path}/schemna'
+                schema_path = f'{collection_name_path}/schema'
 
                 paths[schema_path] = {
                     'get': {


### PR DESCRIPTION
# Overview
Fix typo in `schema` path

# Related issue / discussion

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
