### PR TITLE
fix links for vector tiles

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1045,9 +1045,7 @@ class API:
             if 'format' in collection_data:
                 collection_data_format = collection_data['format']
 
-            is_vector_tile = (collection_data_type == 'tile' and
-                              collection_data_format['name'] not
-                              in [F_PNG, F_JPEG])
+            is_raster_tile = collection_data['name'] == 'WMTSFacade'
 
             collection = {
                 'id': k,
@@ -1161,7 +1159,8 @@ class API:
                     'href': f'{self.get_collections_url()}/{k}/schema?f={F_HTML}'  # noqa
                 })
 
-            if is_vector_tile or collection_data_type in ['feature', 'record']:
+            if (not is_raster_tile
+                    and collection_data_type in ['feature', 'record', 'tile']):
                 # TODO: translate
                 collection['itemType'] = collection_data_type
                 LOGGER.debug('Adding feature/record based links')


### PR DESCRIPTION
# Overview

This fixes the links for vector tiles that contained an error introduced by https://github.com/geopython/pygeoapi/pull/1473

# Related issue / discussion

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
