### PR TITLE
Add stalebot config

### DIFF
--- a/.github/workflows/manage-stale-issues-prs.yml
+++ b/.github/workflows/manage-stale-issues-prs.yml
@@ -1,0 +1,38 @@
+name: 'Close stale issues and PRs'
+
+env:
+  STALE_AFTER_INACTIVE_DAYS: 90
+  CLOSE_AFTER_INACTIVE_DAYS: 5
+
+on:
+  schedule:
+    - cron: '1 3 * * 0'  # runs every Sunday at 03h01
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 'actions/stale@v9'
+        with:
+          debug-only: true
+          enable-statistics: true
+          stale-issue-label: Stale
+          stale-pr-label: Stale
+          days-before-stale: ${{ env.STALE_AFTER_INACTIVE_DAYS }}
+          days-before-close: ${{ env.CLOSE_AFTER_INACTIVE_DAYS }}
+          remove-stale-when-updated: true
+          stale-issue-message: >
+            This issue has been inactive for ${{ env.STALE_AFTER_INACTIVE_DAYS }} 
+            days. In order to reduce maintenance burden, it will be 
+            automatically closed in ${{ env.CLOSE_AFTER_INACTIVE_DAYS }} days.
+          stale-pr-message: >
+            This pull request has been inactive for 
+            ${{ env.STALE_AFTER_INACTIVE_DAYS }} days. In order to reduce 
+            maintenance burden, it will be automatically closed in 
+            ${{ env.CLOSE_AFTER_INACTIVE_DAYS }} days.
+          close-issue-message: >
+            This issue has been closed due to there being no activity 
+            for more than ${{ env.STALE_AFTER_INACTIVE_DAYS }} days.
+          close-pr-message: >
+            This pull request has been closed due to there being no activity 
+            for more than ${{ env.STALE_AFTER_INACTIVE_DAYS }} days.

--- a/.github/workflows/manage-stale-issues-prs.yml
+++ b/.github/workflows/manage-stale-issues-prs.yml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: 'Close stale Issues and Pull Requests'
 
 env:
   STALE_AFTER_INACTIVE_DAYS: 90
@@ -6,39 +6,42 @@ env:
 
 on:
   schedule:
-    - cron: '1 3 * * 0'  # runs every Sunday at 03h01
+    - cron: '1 3 * * 0'  # runs every Sunday at 03h01 UTC
 
 jobs:
   stale:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository_owner == 'geopython'
+    if: github.repository == 'geopython/pygeoapi'
     runs-on: ubuntu-latest
     steps:
       - uses: 'actions/stale@v9'
         with:
           debug-only: true
           enable-statistics: true
-          stale-issue-label: Stale
-          stale-pr-label: Stale
+          stale-issue-label: stale
+          stale-pr-label: stale
           exempt-issue-labels: blocker
           exempt-pr-labels: blocker
           days-before-stale: ${{ env.STALE_AFTER_INACTIVE_DAYS }}
           days-before-close: ${{ env.CLOSE_AFTER_INACTIVE_DAYS }}
           remove-stale-when-updated: true
           stale-issue-message: >
-            This issue has been inactive for ${{ env.STALE_AFTER_INACTIVE_DAYS }} 
-            days. In order to reduce maintenance burden, it will be 
-            automatically closed in ${{ env.CLOSE_AFTER_INACTIVE_DAYS }} days.
+            As per [RFC4](https://pygeoapi.io/development/rfc/4), this Issue has
+            been inactive for ${{env.STALE_AFTER_INACTIVE_DAYS }} days. In order
+            to manage maintenance burden, it will be automatically closed
+            in ${{ env.CLOSE_AFTER_INACTIVE_DAYS }} days.
           stale-pr-message: >
-            This pull request has been inactive for 
-            ${{ env.STALE_AFTER_INACTIVE_DAYS }} days. In order to reduce 
-            maintenance burden, it will be automatically closed in 
-            ${{ env.CLOSE_AFTER_INACTIVE_DAYS }} days.
+            As per [RFC4](https://pygeoapi.io/development/rfc/4), this Pull Request
+            has been inactive for ${{env.STALE_AFTER_INACTIVE_DAYS }} days. In order
+            to manage maintenance burden, it will be automatically closed
+            in ${{ env.CLOSE_AFTER_INACTIVE_DAYS }} days.
           close-issue-message: >
-            This issue has been closed due to there being no activity 
-            for more than ${{ env.STALE_AFTER_INACTIVE_DAYS }} days.
+            As per [RFC4](https://pygeoapi.io/development/rfc/4), this Issue has
+            been closed due to there being no activity for more
+            than ${{ env.STALE_AFTER_INACTIVE_DAYS }} days.
           close-pr-message: >
-            This pull request has been closed due to there being no activity 
-            for more than ${{ env.STALE_AFTER_INACTIVE_DAYS }} days.
+            As per [RFC4](https://pygeoapi.io/development/rfc/4), this Pull Request
+            has been closed due to there being no activity for more
+            than ${{ env.STALE_AFTER_INACTIVE_DAYS }} days.

--- a/.github/workflows/manage-stale-issues-prs.yml
+++ b/.github/workflows/manage-stale-issues-prs.yml
@@ -2,7 +2,7 @@ name: 'Close stale issues and PRs'
 
 env:
   STALE_AFTER_INACTIVE_DAYS: 90
-  CLOSE_AFTER_INACTIVE_DAYS: 5
+  CLOSE_AFTER_INACTIVE_DAYS: 7
 
 on:
   schedule:

--- a/.github/workflows/manage-stale-issues-prs.yml
+++ b/.github/workflows/manage-stale-issues-prs.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   stale:
+    permissions:
+      issues: write
+      pull-requests: write
+    if: github.repository_owner == 'geopython'
     runs-on: ubuntu-latest
     steps:
       - uses: 'actions/stale@v9'
@@ -18,6 +22,8 @@ jobs:
           enable-statistics: true
           stale-issue-label: Stale
           stale-pr-label: Stale
+          exempt-issue-labels: blocker
+          exempt-pr-labels: blocker
           days-before-stale: ${{ env.STALE_AFTER_INACTIVE_DAYS }}
           days-before-close: ${{ env.CLOSE_AFTER_INACTIVE_DAYS }}
           remove-stale-when-updated: true


### PR DESCRIPTION
# Overview

This PR adds a github CI workflow file to manage stale issues and pull requests in accordance with [RFC4](https://pygeoapi.io/development/rfc/4/).

It makes uses of the github [stale action](https://github.com/actions/stale?tab=readme-ov-file#repo-token) and is configured in such a way as to:

- Run every Sunday, at 03h01 
- Mark issues and PRs that have been inactive for 90 days with the ~~`Stale`~~ `stale` label
- Close issues and PRs that have previously been marked as `stale` and have had no further activity for 7 days
- Exempts all issues and PRs that have the `blocker` label from being marked as stale

Notably, this PR sets the `debug-only: true` flag, which has the effect of simply performing a dry-run - the intention is that we would remove the debug flag after verifying if the dry-run outputs the expected results

# Related issue / discussion

- [RFC4](https://pygeoapi.io/development/rfc/4/)
- Related to #1580

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
