### PR TITLE
Stale bot hourly testing dry run

### DIFF
--- a/.github/workflows/manage-stale-issues-prs.yml
+++ b/.github/workflows/manage-stale-issues-prs.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: 'actions/stale@v9'
         with:
+          operations-per-run: 1000
           debug-only: true
           enable-statistics: true
           stale-issue-label: stale

--- a/.github/workflows/manage-stale-issues-prs.yml
+++ b/.github/workflows/manage-stale-issues-prs.yml
@@ -6,8 +6,8 @@ env:
 
 on:
   schedule:
-    - cron: '1 3 * * 0'  # runs every Sunday at 03h01 UTC
-
+    # - cron: '1 3 * * 0'  # runs every Sunday at 03h01 UTC
+    - cron: '0 * * * *'  # runs every hour, for debugging
 jobs:
   stale:
     permissions:


### PR DESCRIPTION
# Overview
While we are testing the stale-bot, run every hour.  Also increase GitHub API limit to 1000
# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc @ricardogsilva 
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
