### PR TITLE
Revert pydantic method 'model_validate_json' to v1 version

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -2270,7 +2270,7 @@ class API:
         else:
             LOGGER.debug('processing Elasticsearch CQL_JSON data')
             try:
-                filter_ = CQLModel.model_validate_json(data)
+                filter_ = CQLModel.parse_raw(data)
             except Exception as err:
                 LOGGER.error(err)
                 msg = f'Bad CQL string : {data}'


### PR DESCRIPTION


# Overview

Fix bug when trying to process Elasticsearch CQL_JSON data on post_collection_items(), since it was using a method from pydantic v2.

Use method 'parse_raw' from pydantic v1 instead of 'model_validate_json'

# Related Issue / discussion

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
