### PR TITLE
Fixes for OGC API - Tiles endpoint on Django

### DIFF
--- a/pygeoapi/django_/urls.py
+++ b/pygeoapi/django_/urls.py
@@ -147,8 +147,8 @@ urlpatterns = [
         name='collection-tiles-metadata',
     ),
     path(
-        'collections/<str:collection_id>/tiles/\
-        <str:tileMatrixSetId>/<str:tile_matrix>/<str:tileRow>/<str:tileCol>',
+        'collections/<str:collection_id>/tiles/' +
+        '<str:tileMatrixSetId>/<str:tileMatrix>/<str:tileRow>/<str:tileCol>',
         views.collection_item_tiles,
         name='collection-item-tiles',
     ),

--- a/pygeoapi/django_/views.py
+++ b/pygeoapi/django_/views.py
@@ -345,7 +345,7 @@ def collection_item_tiles(request: HttpRequest, collection_id: str,
 
     response_ = _feed_response(
         request,
-        'get_collection_tiles_metadata',
+        'get_collection_tiles_data',
         collection_id,
         tileMatrixSetId,
         tileMatrix,


### PR DESCRIPTION
# Overview

The OGC API get Tiles endpoint is not working correctly on Django.
This is due to a wrong parameter name on urls.py and a method that calls `get_collection_tiles_metadata`, instead of `get_collection_tiles_data`. This PR fixes these two issues, enabling pygeoapi Django servers to publish OGC API - Tiles.

![Screenshot from 2024-03-19 18-48-56](https://github.com/geopython/pygeoapi/assets/1038897/8e23e736-d94a-453b-8364-b5ed0aefb60a)


# Related Issue / discussion

https://github.com/geopython/pygeoapi/issues/1595

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
