### PR TITLE
1600 allow providing default value in config

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -413,6 +413,28 @@ Below is an example of how to integrate system environment variables in pygeoapi
            port: ${MY_PORT}
 
 
+It is also possible to define a default value for a variable in case it does not exist in
+the environment using a syntax like: ``value: ${ENV_VAR:-the default}``
+
+.. code-block:: yaml
+
+   server:
+       bind:
+           host: ${MY_HOST:-localhost}
+           port: ${MY_PORT:-5000}
+
+
+If you need to refer to an environment variable in middle of the variable you must use the ``!env`` YAML tag,
+as shown in the example below:
+
+.. code-block:: yaml
+
+   metadata:
+       identification:
+           title:
+               en: !env This is pygeoapi host ${MY_HOST} and port ${MY_PORT:-5000}, nice to meet you!
+
+
 Hierarchical collections
 ------------------------
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -422,17 +422,10 @@ the environment using a syntax like: ``value: ${ENV_VAR:-the default}``
        bind:
            host: ${MY_HOST:-localhost}
            port: ${MY_PORT:-5000}
-
-
-If you need to refer to an environment variable in middle of the variable you must use the ``!env`` YAML tag,
-as shown in the example below:
-
-.. code-block:: yaml
-
    metadata:
        identification:
            title:
-               en: !env This is pygeoapi host ${MY_HOST} and port ${MY_PORT:-5000}, nice to meet you!
+               en: This is pygeoapi host ${MY_HOST} and port ${MY_PORT:-5000}, nice to meet you!
 
 
 Hierarchical collections

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -412,6 +412,11 @@ Below is an example of how to integrate system environment variables in pygeoapi
            host: ${MY_HOST}
            port: ${MY_PORT}
 
+Multiple environment variables are supported as follows:
+
+.. code-block:: yaml
+
+   data: ${MY_HOST}:${MY_PORT}
 
 It is also possible to define a default value for a variable in case it does not exist in
 the environment using a syntax like: ``value: ${ENV_VAR:-the default}``

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -167,13 +167,12 @@ def yaml_load(fh: IO) -> dict:
     # # https://stackoverflow.com/a/55301129
 
     path_matcher = re.compile(
-        r'\$\{?(?P<varname>\w+)(:-(?P<default>[^}]+))?\}?')
+        r'\$\{(?P<varname>\w+)(:-(?P<default>[^}]+))?\}')
 
     def path_constructor(loader, node):
         result = ""
         current_index = 0
         raw_value = node.value
-        print(f"{raw_value=}")
         for match_obj in path_matcher.finditer(raw_value):
             groups = match_obj.groupdict()
             result += raw_value[current_index:match_obj.start()]
@@ -194,9 +193,8 @@ def yaml_load(fh: IO) -> dict:
     class EnvVarLoader(yaml.SafeLoader):
         pass
 
-    EnvVarLoader.add_implicit_resolver('!path', path_matcher, None)
-    EnvVarLoader.add_constructor('!path', path_constructor)
-
+    EnvVarLoader.add_implicit_resolver('!env', path_matcher, None)
+    EnvVarLoader.add_constructor('!env', path_constructor)
     return yaml.load(fh, Loader=EnvVarLoader)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -31,6 +31,8 @@ from datetime import datetime, date, time
 from decimal import Decimal
 from contextlib import nullcontext as does_not_raise
 from copy import deepcopy
+from io import StringIO
+from unittest import mock
 
 import pytest
 from pyproj.exceptions import CRSError
@@ -75,6 +77,40 @@ def test_yaml_load(config):
     with pytest.raises(FileNotFoundError):
         with open(get_test_file_path('404.yml')) as fh:
             util.yaml_load(fh)
+
+
+@pytest.mark.parametrize('env,input_config,expected', [
+    pytest.param({}, 'foo: something', {'foo': 'something'}, id='no-env-expansion'),  # noqa
+    pytest.param({'FOO': 'this'}, 'foo: ${FOO}', {'foo': 'this'}),  # noqa
+    pytest.param({'FOO': 'this'}, 'foo: !env the value is ${FOO}', {'foo': 'the value is this'}, id='explicit-yaml-tag'),  # noqa
+    pytest.param({}, 'foo: ${FOO:-some default}', {'foo': 'some default'}),  # noqa
+    pytest.param({'FOO': 'this', 'BAR': 'that'}, 'composite: ${FOO}:${BAR}', {'composite': 'this:that'}),  # noqa
+    pytest.param({}, 'composite: ${FOO:-default-foo}:${BAR:-default-bar}', {'composite': 'default-foo:default-bar'}),  # noqa
+    pytest.param(
+        {
+            'HOST': 'fake-host',
+            'USER': 'fake',
+            'PASSWORD': 'fake-pass',
+            'DB': 'fake-db'
+        },
+        'connection: !env "postgres://${USER}:${PASSWORD}@${HOST}:${PORT:-5432}/${DB}"',
+        {
+            'connection': 'postgres://fake:fake-pass@fake-host:5432/fake-db'
+        },
+        id='multiple-yaml-tag'
+    ),
+])
+def test_yaml_load_with_env_variables(
+        env: dict[str, str], input_config: str, expected):
+
+    def mock_get_env(env_var_name):
+        result = env.get(env_var_name)
+        return result
+
+    with mock.patch('pygeoapi.util.os') as mock_os:
+        mock_os.getenv.side_effect = mock_get_env
+        loaded_config = util.yaml_load(StringIO(input_config))
+        assert loaded_config == expected
 
 
 def test_str2bool():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -80,12 +80,12 @@ def test_yaml_load(config):
 
 
 @pytest.mark.parametrize('env,input_config,expected', [
-    pytest.param({}, 'foo: something', {'foo': 'something'}, id='no-env-expansion'),  # noqa
-    pytest.param({'FOO': 'this'}, 'foo: ${FOO}', {'foo': 'this'}),  # noqa
-    pytest.param({'FOO': 'this'}, 'foo: !env the value is ${FOO}', {'foo': 'the value is this'}, id='explicit-yaml-tag'),  # noqa
-    pytest.param({}, 'foo: ${FOO:-some default}', {'foo': 'some default'}),  # noqa
-    pytest.param({'FOO': 'this', 'BAR': 'that'}, 'composite: ${FOO}:${BAR}', {'composite': 'this:that'}),  # noqa
-    pytest.param({}, 'composite: ${FOO:-default-foo}:${BAR:-default-bar}', {'composite': 'default-foo:default-bar'}),  # noqa
+    pytest.param({}, 'foo: something', {'foo': 'something'}, id='no-env-expansion'),  # noqa E501
+    pytest.param({'FOO': 'this'}, 'foo: ${FOO}', {'foo': 'this'}),  # noqa E501
+    pytest.param({'FOO': 'this'}, 'foo: !env the value is ${FOO}', {'foo': 'the value is this'}, id='explicit-yaml-tag'),  # noqa E501
+    pytest.param({}, 'foo: ${FOO:-some default}', {'foo': 'some default'}),  # noqa E501
+    pytest.param({'FOO': 'this', 'BAR': 'that'}, 'composite: ${FOO}:${BAR}', {'composite': 'this:that'}),  # noqa E501
+    pytest.param({}, 'composite: ${FOO:-default-foo}:${BAR:-default-bar}', {'composite': 'default-foo:default-bar'}),  # noqa E501
     pytest.param(
         {
             'HOST': 'fake-host',
@@ -93,7 +93,7 @@ def test_yaml_load(config):
             'PASSWORD': 'fake-pass',
             'DB': 'fake-db'
         },
-        'connection: !env "postgres://${USER}:${PASSWORD}@${HOST}:${PORT:-5432}/${DB}"',
+        'connection: !env "postgres://${USER}:${PASSWORD}@${HOST}:${PORT:-5432}/${DB}"',  # noqa E501
         {
             'connection': 'postgres://fake:fake-pass@fake-host:5432/fake-db'
         },

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -82,7 +82,7 @@ def test_yaml_load(config):
 @pytest.mark.parametrize('env,input_config,expected', [
     pytest.param({}, 'foo: something', {'foo': 'something'}, id='no-env-expansion'),  # noqa E501
     pytest.param({'FOO': 'this'}, 'foo: ${FOO}', {'foo': 'this'}),  # noqa E501
-    pytest.param({'FOO': 'this'}, 'foo: !env the value is ${FOO}', {'foo': 'the value is this'}, id='explicit-yaml-tag'),  # noqa E501
+    pytest.param({'FOO': 'this'}, 'foo: the value is ${FOO}', {'foo': 'the value is this'}, id='no-need-for-yaml-tag'),  # noqa E501
     pytest.param({}, 'foo: ${FOO:-some default}', {'foo': 'some default'}),  # noqa E501
     pytest.param({'FOO': 'this', 'BAR': 'that'}, 'composite: ${FOO}:${BAR}', {'composite': 'this:that'}),  # noqa E501
     pytest.param({}, 'composite: ${FOO:-default-foo}:${BAR:-default-bar}', {'composite': 'default-foo:default-bar'}),  # noqa E501
@@ -93,11 +93,11 @@ def test_yaml_load(config):
             'PASSWORD': 'fake-pass',
             'DB': 'fake-db'
         },
-        'connection: !env "postgres://${USER}:${PASSWORD}@${HOST}:${PORT:-5432}/${DB}"',  # noqa E501
+        'connection: postgres://${USER}:${PASSWORD}@${HOST}:${PORT:-5432}/${DB}',  # noqa E501
         {
             'connection': 'postgres://fake:fake-pass@fake-host:5432/fake-db'
         },
-        id='multiple-yaml-tag'
+        id='multiple-no-need-yaml-tag'
     ),
 ])
 def test_yaml_load_with_env_variables(


### PR DESCRIPTION
# Overview

This PR implements allowing default values for config variables that can come from the environment. Most notably it becomes possible to combine several env variables in a single config value. 

For the most common case of having the full variable correspond to some env value or else a default value, the syntax is `myvar: ${MY_VAR:-some default}`, as shown below:

```yaml
server:
    host: ${MY_HOST:-localhost}
    port: ${MY_PORT:-5000}
    combined: ${MY_HOST:-localhost} - ${MY_PORT:-5000}
```

**UPDATE:** With the latest commit, this paragraph below is no longer relevant - no need to use the `!env` YAML tag

~~For cases where the env variable is being used as part of a config variable and it shows up in the middle of the variable it becomes mandatory to use the `!env` YAML tag:~~

<strike>

```yaml
metadata:
    identification:
        title:
            en: !env This is pygeoapi host ${MY_HOST} and port ${MY_PORT:-5000}, nice to meet you!
```

</strike>


# Related Issue / discussion

- #1600 


# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
