### PR TITLE
Fix indentation error in process.py

### DIFF
--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -663,15 +663,15 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
         if 'example' in p.metadata:
             paths[f'{process_name_path}/execution']['post']['requestBody']['content']['application/json']['example'] = p.metadata['example']  # noqa
 
-        name_in_path = {
-            'name': 'jobId',
-            'in': 'path',
-            'description': 'job identifier',
-            'required': True,
-            'schema': {
-                'type': 'string'
-            }
+    name_in_path = {
+        'name': 'jobId',
+        'in': 'path',
+        'description': 'job identifier',
+        'required': True,
+        'schema': {
+            'type': 'string'
         }
+    }
 
     paths['/jobs'] = {
         'get': {


### PR DESCRIPTION
# Overview
Fix indentation error so that the constant dictionary `name_in_path` is valid even when no pygeoapi processes are configured at runtime. 

# Related Issue / discussion
Addresses: https://github.com/geopython/pygeoapi/issues/1617
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
