### PR TITLE
remove FutureWarning from Xarray providers

### DIFF
--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -211,9 +211,9 @@ class XarrayProvider(BaseProvider):
                 _to_datetime_string(data.coords[self.time_field].values[-1])
             ],
             "driver": "xarray",
-            "height": data.dims[self.y_field],
-            "width": data.dims[self.x_field],
-            "time_steps": data.dims[self.time_field],
+            "height": data.sizes[self.y_field],
+            "width": data.sizes[self.x_field],
+            "time_steps": data.sizes[self.time_field],
             "variables": {var_name: var.attrs
                           for var_name, var in data.variables.items()}
         }
@@ -385,9 +385,9 @@ class XarrayProvider(BaseProvider):
             'x_axis_label': self.x_field,
             'y_axis_label': self.y_field,
             'time_axis_label': self.time_field,
-            'width': self._data.dims[self.x_field],
-            'height': self._data.dims[self.y_field],
-            'time': self._data.dims[self.time_field],
+            'width': self._data.sizes[self.x_field],
+            'height': self._data.sizes[self.y_field],
+            'time': self._data.sizes[self.time_field],
             'time_duration': self.get_time_coverage_duration(),
             'bbox_units': 'degrees',
             'resx': np.abs(self._data.coords[self.x_field].values[1]

--- a/pygeoapi/provider/xarray_edr.py
+++ b/pygeoapi/provider/xarray_edr.py
@@ -138,11 +138,11 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
             raise ProviderNoDataError()
 
         try:
-            height = data.dims[self.y_field]
+            height = data.sizes[self.y_field]
         except KeyError:
             height = 1
         try:
-            width = data.dims[self.x_field]
+            width = data.sizes[self.x_field]
         except KeyError:
             width = 1
         time, time_steps = self._parse_time_metadata(data, kwargs)
@@ -215,8 +215,8 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
         except KeyError:
             raise ProviderNoDataError()
 
-        height = data.dims[self.y_field]
-        width = data.dims[self.x_field]
+        height = data.sizes[self.y_field]
+        width = data.sizes[self.x_field]
         time, time_steps = self._parse_time_metadata(data, kwargs)
 
         out_meta = {


### PR DESCRIPTION
# Overview
This PR removes FutureWarnings on Xarray-based backends:

```
 /home/runner/work/pygeoapi/pygeoapi/pygeoapi/provider/xarray_.py:389: FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
```

# Related Issue / discussion
None

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
