### PR TITLE
use typing.Union for pre-3.10 compat

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -198,7 +198,7 @@ def gzip(func):
     return inner
 
 
-def apply_gzip(headers: dict, content: str | bytes) -> str | bytes:
+def apply_gzip(headers: dict, content: Union[str, bytes]) -> Union[str, bytes]:
     """
     Compress content if requested in header.
     """

--- a/pygeoapi/django_/views.py
+++ b/pygeoapi/django_/views.py
@@ -35,7 +35,7 @@
 
 """Integration module for Django"""
 
-from typing import Tuple, Dict, Mapping, Optional
+from typing import Tuple, Dict, Mapping, Optional, Union
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
@@ -562,7 +562,7 @@ def execute_from_django(api_function, request: HttpRequest, *args,
         api_ = API(settings.PYGEOAPI_CONFIG, settings.OPENAPI_DOCUMENT)
 
     api_request = APIRequest.from_django(request, api_.locales)
-    content: str | bytes
+    content: Union[str, bytes]
     if not skip_valid_check and not api_request.is_valid():
         headers, status, content = api_.get_format_exception(api_request)
     else:
@@ -575,7 +575,7 @@ def execute_from_django(api_function, request: HttpRequest, *args,
 
 # TODO: inline this to execute_from_django after refactoring
 def _to_django_response(headers: Mapping, status_code: int,
-                        content: str | bytes) -> HttpResponse:
+                        content: Union[str, bytes]) -> HttpResponse:
     """Convert API payload to a django response"""
 
     response = HttpResponse(content, status=status_code)

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -31,9 +31,9 @@
 """Flask module providing the route paths to the api"""
 
 import os
+from typing import Union
 
 import click
-
 from flask import (Flask, Blueprint, make_response, request,
                    send_from_directory, Response, Request)
 
@@ -152,7 +152,7 @@ def execute_from_flask(api_function, request: Request, *args,
 
     api_request = APIRequest.from_flask(request, api_.locales)
 
-    content: str | bytes
+    content: Union[str, bytes]
 
     if not skip_valid_check and not api_request.is_valid():
         headers, status, content = api_.get_format_exception(api_request)

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -38,7 +38,6 @@ from typing import Callable, Union
 from pathlib import Path
 
 import click
-
 from starlette.routing import Route, Mount
 from starlette.staticfiles import StaticFiles
 from starlette.applications import Starlette
@@ -142,7 +141,7 @@ def _to_response(headers, status, content):
 async def execute_from_starlette(api_function, request: Request, *args,
                                  skip_valid_check=False) -> Response:
     api_request = await APIRequest.from_starlette(request, api_.locales)
-    content: str | bytes
+    content: Union[str, bytes]
     if not skip_valid_check and not api_request.is_valid():
         headers, status, content = api_.get_format_exception(api_request)
     else:


### PR DESCRIPTION
# Overview
Non-breaking change to use `typing.Union`, which work pre 3.10 installs.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
