### PR TITLE
fix missing Django processes endpoints (#1592)

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -158,8 +158,12 @@ main Django application urls:
    ]
 
 
-This integration can be seen in the provided example Django project. Refer to `examples/django/sample_project/README.md` 
+This integration can be seen in the provided example Django project. Refer to the `Django example in the pygeoapi-examples repository`_
 for the integration of pygeoapi with an already exising Django application.
+
+
+.. note::
+   To enable HTTP POST/PUT/PATCH/DELETE functionality, `django.middleware.csrf.CsrfViewMiddleware` must not be set.  Note that this enables create/replace/update/delete functionality against resources in your application.
 
 Hot-reloading
 ^^^^^^^^^^^^^
@@ -293,3 +297,4 @@ and modify accordingly.
 .. _`Uvicorn`: https://www.uvicorn.org
 .. _`mod_wsgi`: https://modwsgi.readthedocs.io/en/master
 .. _`Django`: https://www.djangoproject.com
+.. _`Django example in the pygeoapi-examples repository`: https://github.com/geopython/pygeoapi-examples/blob/main/django/sample_project/README.md

--- a/pygeoapi/django_/urls.py
+++ b/pygeoapi/django_/urls.py
@@ -234,6 +234,8 @@ urlpatterns = [
     ),
     path(apply_slash_rule('processes/'), views.processes, name='processes'),
     path('processes/<str:process_id>', views.processes, name='process-detail'),
+    path('processes/<str:process_id>/execution', views.process_execution,
+         name='process-execution'),
     path(apply_slash_rule('jobs/'), views.jobs, name='jobs'),
     path('jobs/<str:job_id>', views.jobs, name='job'),
     path(

--- a/pygeoapi/django_/views.py
+++ b/pygeoapi/django_/views.py
@@ -372,6 +372,20 @@ def processes(request: HttpRequest,
                                process_id)
 
 
+def process_execution(request: HttpRequest, process_id: str) -> HttpResponse:
+    """
+    OGC API - Processes execution endpoint
+
+    :request Django HTTP Request
+    :param process_id: process identifier
+
+    :returns: Django HTTP response
+    """
+
+    return execute_from_django(processes_api.execute_process, request,
+                               process_id)
+
+
 def jobs(request: HttpRequest, job_id: Optional[str] = None) -> HttpResponse:
     """
     OGC API - Jobs endpoint
@@ -382,7 +396,15 @@ def jobs(request: HttpRequest, job_id: Optional[str] = None) -> HttpResponse:
 
     :returns: Django HTTP response
     """
-    return execute_from_django(processes_api.get_jobs, request, job_id)
+
+    if job_id is None:
+        return execute_from_django(processes_api.get_jobs, request)
+    else:
+        if request.method == 'DELETE':  # dismiss job
+            return execute_from_django(processes_api.delete_job, request,
+                                       job_id)
+        else:  # Return status of a specific job
+            return execute_from_django(processes_api.get_jobs, request, job_id)
 
 
 def job_results(request: HttpRequest,

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -432,7 +432,8 @@ def get_jobs(job_id=None):
         return execute_from_flask(processes_api.get_jobs, request)
     else:
         if request.method == 'DELETE':  # dismiss job
-            return execute_from_flask(processes_api.delete_jobs, request)
+            return execute_from_flask(processes_api.delete_job, request,
+                                      job_id)
         else:  # Return status of a specific job
             return execute_from_flask(processes_api.get_jobs, request, job_id)
 


### PR DESCRIPTION
# Overview
Adds missing Django `/jobs` and `/processes/{processId}/execution` endpoints.  Also fixes process execution call in Flask.

# Related Issue / discussion

#1592

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
