### PR TITLE
PostgreSQL provider: fix paging (#1594)

### DIFF
--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -158,6 +158,21 @@ def test_query_with_property_filter(config):
     assert feature_collection['numberReturned'] == 50
 
 
+def test_query_with_paging(config):
+    """Test query valid features with paging"""
+    p = PostgreSQLProvider(config)
+    feature_collection = p.query(limit=50)
+
+    assert feature_collection['numberMatched'] == 14776
+    assert feature_collection['numberReturned'] == 50
+
+    offset = feature_collection['numberMatched'] - 10
+
+    feature_collection = p.query(offset=offset)
+    assert feature_collection['numberMatched'] == 14776
+    assert feature_collection['numberReturned'] == 10
+
+
 def test_query_with_config_properties(config):
     """
     Test that query is restricted by properties in the config.


### PR DESCRIPTION
# Overview
This PR updates the PostgreSQL provider to determine numberMatched prior to applying sort/limit/offset.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
Fixes #1594 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
