### PR TITLE
add cftime to requirements-provider

### DIFF
--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -1,5 +1,6 @@
 azure-identity
 azure-storage-blob
+cftime
 elasticsearch
 elasticsearch-dsl
 fiona


### PR DESCRIPTION
# Overview
Add `cftime` dependency to accommodate xarray datasets in the EDR provider that have cftimes. Installing cftime is all that's needed, so I didn't make any updates to the provider code or documentation, as this should all work under the hood.

# Related Issue / discussion
closes #1609 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute adding the cftime dependency to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
