### PR TITLE
add striptags to properties rendering

### DIFF
--- a/pygeoapi/templates/collections/items/index.html
+++ b/pygeoapi/templates/collections/items/index.html
@@ -92,7 +92,7 @@
               {% for k in data['features'][0]['properties'].keys() %}
                 {% if k not in [data.id_field, data.title_field, data.uri_field, 'extent'] %}
                   {% set props = props.append(k) %}
-                  <th>{{ k }}</th>
+                  <th>{{ k | striptags }}</th>
                 {% endif %}
               {% endfor %}
             </tr>


### PR DESCRIPTION
# Overview
Adds striptags to Jinja HTML rendering for item properties.

# Related Issue / discussion

None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc @david-i-berry 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
