### PR TITLE
CRS handling in xarray provider properties

### DIFF
--- a/docs/source/data-publishing/ogcapi-coverages.rst
+++ b/docs/source/data-publishing/ogcapi-coverages.rst
@@ -75,6 +75,9 @@ The `Xarray`_ provider plugin reads and extracts `NetCDF`_ and `Zarr`_ data.
          x_field: lon
          y_field: lat
          time_field: time
+         # optionally specify the coordinate reference system of your dataset
+         # else pygeoapi assumes it is WGS84 (EPSG:4326).
+         storage_crs: 4326
          format:
             name: netcdf
             mimetype: application/x-netcdf
@@ -95,6 +98,11 @@ The `Xarray`_ provider plugin reads and extracts `NetCDF`_ and `Zarr`_ data.
    When referencing `NetCDF`_ or `Zarr`_ data stored in an S3 bucket, 
    be sure to provide the full S3 URL. Any parameters required to open the dataset
    using fsspec can be added to the config file under `options` and `s3`.
+
+.. note::
+   When providing a `storage_crs` value in the xarray configuration, specify the 
+   coordinate reference system using any valid input for 
+   `pyproj.CRS.from_user_input`_. 
 
 Data access examples
 --------------------
@@ -146,3 +154,4 @@ Data access examples
 .. _`NetCDF`: https://en.wikipedia.org/wiki/NetCDF
 .. _`Zarr`: https://zarr.readthedocs.io/en/stable
 .. _`GDAL raster driver short name`: https://gdal.org/drivers/raster/index.html
+.. _`pyproj.CRS.from_user_input`: https://pyproj4.github.io/pyproj/stable/api/crs/coordinate_system.html#pyproj.crs.CoordinateSystem.from_user_input

--- a/docs/source/data-publishing/ogcapi-edr.rst
+++ b/docs/source/data-publishing/ogcapi-edr.rst
@@ -47,6 +47,9 @@ The `xarray-edr`_ provider plugin reads and extracts `NetCDF`_ and `Zarr`_ data 
          x_field: lon
          y_field: lat
          time_field: time
+         # optionally specify the coordinate reference system of your dataset
+         # else pygeoapi assumes it is WGS84 (EPSG:4326).
+         storage_crs: 4326
          format:
             name: netcdf
             mimetype: application/x-netcdf
@@ -81,6 +84,11 @@ The `xarray-edr`_ provider plugin reads and extracts `NetCDF`_ and `Zarr`_ data 
    S3 URL. Any parameters required to open the dataset using fsspec can be added
    to the config file under `options` and `s3`, as shown above.
 
+.. note::
+   When providing a `storage_crs` value in the EDR configuration, specify the 
+   coordinate reference system using any valid input for 
+   `pyproj.CRS.from_user_input`_. 
+
 
 Data access examples
 --------------------
@@ -105,6 +113,7 @@ Data access examples
 .. _`xarray`: https://docs.xarray.dev/en/stable/
 .. _`NetCDF`: https://en.wikipedia.org/wiki/NetCDF
 .. _`Zarr`: https://zarr.readthedocs.io/en/stable
+.. _`pyproj.CRS.from_user_input`: https://pyproj4.github.io/pyproj/stable/api/crs/coordinate_system.html#pyproj.crs.CoordinateSystem.from_user_input
 
 
 .. _`OGC Environmental Data Retrieval (EDR) (API)`: https://github.com/opengeospatial/ogcapi-coverages

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -409,10 +409,11 @@ class XarrayProvider(BaseProvider):
             if epsg_code == 4326:
                 pass
             elif epsg_code is None:
-                LOGGER.debug(f'No epsg code parsed. Default CRS used.')
+                LOGGER.debug('No epsg code parsed. Default CRS used.')
             else:
-                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{self._data.crs.epsg_code}'
-                properties['inverse_flattening'] = crs_attrs['inverse_flattening']
+                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{epsg_code}'  # noqa
+                properties['inverse_flattening'] = \
+                    crs_attrs['inverse_flattening']
                 if crs_attrs['grid_mapping_name '] != 'latitude_longitude':
                     properties['crs_type'] = 'ProjectedCRS'
 
@@ -427,7 +428,7 @@ class XarrayProvider(BaseProvider):
 
                 properties['crs_type'] = 'ProjectedCRS'
             except KeyError:
-                LOGGER.debug('Unable to parse CRS information from dataset. Assuming default WGS84.')
+                LOGGER.debug('Unable to parse CRS. Assuming default WGS84.')
 
         properties['axes'] = [
             properties['x_axis_label'],
@@ -492,7 +493,7 @@ class XarrayProvider(BaseProvider):
                  in time_dict.items() if val > 0]
 
         return ', '.join(times)
-    
+
     def parse_grid_mapping(self):
         spatiotemporal_dims = (self.time_field, self.y_field, self.x_field)
         grid_mapping_name = None

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -37,6 +37,7 @@ import zipfile
 import xarray
 import fsspec
 import numpy as np
+import pyproj
 
 from pygeoapi.provider.base import (BaseProvider,
                                     ProviderConnectionError,
@@ -401,16 +402,32 @@ class XarrayProvider(BaseProvider):
             'restime': self.get_time_resolution()
         }
 
-        if 'crs' in self._data.variables.keys():
-            try:
-                properties['bbox_crs'] = f'http://www.opengis.net/def/crs/OGC/1.3/{self._data.crs.epsg_code}'  # noqa
+        grid_mapping = self.parse_grid_mapping()
+        if grid_mapping is not None:
+            crs_attrs = pyproj.CRS.to_cf(self._data[grid_mapping].attrs)
+            epsg_code = crs_attrs.to_epsg()
+            if epsg_code == 4326:
+                pass
+            elif epsg_code is None:
+                LOGGER.debug(f'No epsg code parsed. Default CRS used.')
+            else:
+                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{self._data.crs.epsg_code}'
+                properties['inverse_flattening'] = crs_attrs['inverse_flattening']
+                if crs_attrs['grid_mapping_name '] != 'latitude_longitude':
+                    properties['crs_type'] = 'ProjectedCRS'
 
+        elif 'crs' in self._data.variables.keys():
+            try:
+                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{self._data.crs.epsg_code}'  # noqa
+
+                properties['inverse_flattening'] = self._data.crs.\
+                    inverse_flattening
                 properties['inverse_flattening'] = self._data.crs.\
                     inverse_flattening
 
                 properties['crs_type'] = 'ProjectedCRS'
-            except AttributeError:
-                pass
+            except KeyError:
+                LOGGER.debug('Unable to parse CRS information from dataset. Assuming default WGS84.')
 
         properties['axes'] = [
             properties['x_axis_label'],
@@ -475,6 +492,17 @@ class XarrayProvider(BaseProvider):
                  in time_dict.items() if val > 0]
 
         return ', '.join(times)
+    
+    def parse_grid_mapping(self):
+        spatiotemporal_dims = (self.time_field, self.y_field, self.x_field)
+        grid_mapping_name = None
+        for var_name, var in self._data.variables.items():
+            if all(dim in var.dims for dim in spatiotemporal_dims):
+                try:
+                    grid_mapping_name = self._data[var_name].attrs['grid_mapping']
+                except KeyError:
+                    LOGGER.debug()
+        return grid_mapping_name
 
 
 def _to_datetime_string(datetime_obj):

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -89,10 +89,7 @@ class XarrayProvider(BaseProvider):
                 data_to_open = self.data
 
             self._data = open_func(data_to_open)
-            self.storage_crs = self._parse_storage_crs(
-                self,
-                provider_def
-            )
+            self.storage_crs = self._parse_storage_crs(provider_def)
             self._coverage_properties = self._get_coverage_properties()
 
             self.axes = [self._coverage_properties['x_axis_label'],
@@ -420,7 +417,7 @@ class XarrayProvider(BaseProvider):
             properties['bbox_crs'] = \
                 f'https://www.opengis.net/def/crs/EPSG/0/{epsg_code}'
             properties['inverse_flattening'] = \
-                self.storage_crs.inverse_flattening
+                self.storage_crs.ellipsoid.inverse_flattening
             if self.storage_crs.is_projected:
                 properties['crs_type'] = 'ProjectedCRS'
 
@@ -489,6 +486,11 @@ class XarrayProvider(BaseProvider):
         return ', '.join(times)
 
     def _parse_grid_mapping(self):
+        """
+        Identifies grid_mapping.
+    
+        :returns: name of xarray data variable that contains CRS information.
+        """
         spatiotemporal_dims = (self.time_field, self.y_field, self.x_field)
         grid_mapping_name = None
         for var_name, var in self._data.variables.items():
@@ -502,22 +504,26 @@ class XarrayProvider(BaseProvider):
     def _parse_storage_crs(
         self,
         provider_def: dict
-    ) -> pyproj.CRS
+    ) -> pyproj.CRS:
         """
         Parse the storage CRS from an xarray dataset.
+
         :param provider_def: provider definition
+    
         :returns: `pyproj.CRS` instance parsed from dataset
         """
-        
+        storage_crs = None
+
         try:
             storage_crs = provider_def['storage_crs']
-            crs_function = pyproj.CRS.from_user_input            
+            crs_function = pyproj.CRS.from_user_input
         except KeyError:
-            LOGGER.debug('''
+            LOGGER.debug(
+                '''
                 No storage crs provided in the provider configuration.
                 Attempting to parse the CRS.
                 '''
-            )
+                )
 
         if storage_crs is None:
             grid_mapping = self._parse_grid_mapping()

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -351,9 +351,14 @@ class XarrayProvider(BaseProvider):
 
         return cj
 
-    def _get_coverage_properties(self):
+    def _get_coverage_properties(
+            self,
+            provider_def: dict
+        ):
         """
         Helper function to normalize coverage properties
+
+        :param provider_def: provider definition
 
         :returns: `dict` of coverage properties
         """
@@ -414,31 +419,42 @@ class XarrayProvider(BaseProvider):
             'restime': self.get_time_resolution()
         }
 
-        grid_mapping = self.parse_grid_mapping()
-        if grid_mapping is not None:
-            crs_attrs = pyproj.CRS.to_cf(self._data[grid_mapping].attrs)
-            epsg_code = crs_attrs.to_epsg()
-            if epsg_code == 4326:
-                pass
-            elif epsg_code is None:
-                LOGGER.debug('No epsg code parsed. Default CRS used.')
-            else:
-                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{epsg_code}'  # noqa
-                properties['inverse_flattening'] = \
-                    crs_attrs['inverse_flattening']
-                if crs_attrs['grid_mapping_name '] != 'latitude_longitude':
-                    properties['crs_type'] = 'ProjectedCRS'
+        # TODO break some of this up into separate functions.
+        # TODO add some better error handling for pyproj?
+        try:
+            user_crs = provider_def['extents']['spatial']['crs']
+        except KeyError:
+            LOGGER.debug('No CRS provided in the configuration.')
+        
+        if isinstance(user_crs, pyproj.CRS):
+            ## add some error handling here in case users provide invalid CRS info
+            crs = pyproj.CRS.from_user_input(user_crs)
+            epsg_code = crs.to_epsg()
+            # This can return nothing (e.g. if a custom proj) -- add handling for that case 
+        else: 
+            grid_mapping = self.parse_grid_mapping()
+            if grid_mapping is not None:
+                crs = pyproj.CRS.from_dict(
+                    self._data[grid_mapping].attrs
+                )
+                epsg_code = crs.to_epsg()
+            # check if CRS included in dataset
+            elif 'crs' in self._data.variables.keys():
+                try:
+                    epsg_code = pyproj.CRS.from_epsg(
+                        self._data.crs.epsg_code
+                    )
+                except KeyError:
+                    LOGGER.debug('Unable to parse CRS. Assuming default WGS84.')
 
-        elif 'crs' in self._data.variables.keys():
-            try:
-                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{self._data.crs.epsg_code}'  # noqa
-
-                properties['inverse_flattening'] = self._data.crs.\
-                    inverse_flattening
-
+        if epsg_code == 4326:
+            pass
+        else:
+            properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{epsg_code}'  # noqa
+            properties['inverse_flattening'] = \
+                crs.inverse_flattening
+            if crs.is_projected:
                 properties['crs_type'] = 'ProjectedCRS'
-            except KeyError:
-                LOGGER.debug('Unable to parse CRS. Assuming default WGS84.')
 
         properties['axes'] = [
             properties['x_axis_label'],

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -571,7 +571,7 @@ class XarrayProvider(BaseProvider):
     def _parse_storage_crs(
         self,
         provider_def: dict
-    ) -> pyproj.CRS
+    ) -> pyproj.CRS:
         """
         Parse the storage CRS from an xarray dataset.
         :param provider_def: provider definition

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -545,8 +545,8 @@ class XarrayProvider(BaseProvider):
         LOGGER.debug(f'Parsing CRS {storage_crs} with {crs_function}')
         try:
             crs = crs_function(storage_crs)
-        except CRSError as e:
-            LOGGER.debug(f'Unable to parse projection with pyproj: {e}')
+        except CRSError as err:
+            LOGGER.debug(f'Unable to parse projection with pyproj: {err}')
             LOGGER.debug('Assuming default WGS84.')
             crs = get_crs_from_uri(DEFAULT_STORAGE_CRS)
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -89,7 +89,9 @@ class XarrayProvider(BaseProvider):
                 data_to_open = self.data
 
             self._data = open_func(data_to_open)
-            self._coverage_properties = self._get_coverage_properties(provider_def)
+            self._coverage_properties = self._get_coverage_properties(
+                provider_def
+            )
 
             self.axes = [self._coverage_properties['x_axis_label'],
                          self._coverage_properties['y_axis_label'],
@@ -493,7 +495,7 @@ class XarrayProvider(BaseProvider):
     def _parse_grid_mapping(self):
         """
         Identifies grid_mapping.
-    
+
         :returns: name of xarray data variable that contains CRS information.
         """
         LOGGER.debug('Parsing grid mapping...')
@@ -503,9 +505,10 @@ class XarrayProvider(BaseProvider):
         for var_name, var in self._data.variables.items():
             if all(dim in var.dims for dim in spatiotemporal_dims):
                 try:
-                    grid_mapping_name = self._data[var_name].attrs['grid_mapping']
+                    grid_mapping_name = self._data[var_name].attrs['grid_mapping']  # noqa 
                     LOGGER.debug(f'Grid mapping: {grid_mapping_name}')
-                except KeyError as e:
+                except KeyError as err:
+                    LOGGER.debug(err)
                     LOGGER.debug('No grid mapping information found.')
         return grid_mapping_name
 
@@ -525,7 +528,8 @@ class XarrayProvider(BaseProvider):
         try:
             storage_crs = provider_def['storage_crs']
             crs_function = pyproj.CRS.from_user_input
-        except KeyError as e:
+        except KeyError as err:
+            LOGGER.debug(err)
             LOGGER.debug('No storage_crs found. Attempting to parse the CRS.')
 
         if storage_crs is None:

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -38,12 +38,18 @@ import xarray
 import fsspec
 import numpy as np
 import pyproj
+from pyproj.exceptions import CRSError
+
+from pygeoapi.api import DEFAULT_STORAGE_CRS
 
 from pygeoapi.provider.base import (BaseProvider,
                                     ProviderConnectionError,
                                     ProviderNoDataError,
                                     ProviderQueryError)
-from pygeoapi.util import read_data
+from pygeoapi.util import (
+    read_data,
+    get_crs_from_uri
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -83,6 +89,10 @@ class XarrayProvider(BaseProvider):
                 data_to_open = self.data
 
             self._data = open_func(data_to_open)
+            self.storage_crs = self._parse_storage_crs(
+                self,
+                provider_def
+            )
             self._coverage_properties = self._get_coverage_properties(
                 provider_def
             )
@@ -341,14 +351,9 @@ class XarrayProvider(BaseProvider):
 
         return cj
 
-    def _get_coverage_properties(
-            self,
-            provider_def: dict
-        ):
+    def _get_coverage_properties(self):
         """
         Helper function to normalize coverage properties
-
-        :param provider_def: provider definition
 
         :returns: `dict` of coverage properties
         """
@@ -409,41 +414,16 @@ class XarrayProvider(BaseProvider):
             'restime': self.get_time_resolution()
         }
 
-        # TODO break some of this up into separate functions.
-        # TODO add some better error handling for pyproj?
-        try:
-            user_crs = provider_def['extents']['spatial']['crs']
-        except KeyError:
-            LOGGER.debug('No CRS provided in the configuration.')
-        
-        if isinstance(user_crs, pyproj.CRS):
-            ## add some error handling here in case users provide invalid CRS info
-            crs = pyproj.CRS.from_user_input(user_crs)
-            epsg_code = crs.to_epsg()
-            # This can return nothing (e.g. if a custom proj) -- add handling for that case 
-        else: 
-            grid_mapping = self.parse_grid_mapping()
-            if grid_mapping is not None:
-                crs = pyproj.CRS.from_dict(
-                    self._data[grid_mapping].attrs
-                )
-                epsg_code = crs.to_epsg()
-            # check if CRS included in dataset
-            elif 'crs' in self._data.variables.keys():
-                try:
-                    epsg_code = pyproj.CRS.from_epsg(
-                        self._data.crs.epsg_code
-                    )
-                except KeyError:
-                    LOGGER.debug('Unable to parse CRS. Assuming default WGS84.')
-
+        # Update properties based on the xarray's CRS
+        epsg_code = self.storage_crs.to_epsg()
         if epsg_code == 4326:
             pass
         else:
-            properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{epsg_code}'  # noqa
+            properties['bbox_crs'] = \
+                f'https://www.opengis.net/def/crs/EPSG/0/{epsg_code}'
             properties['inverse_flattening'] = \
-                crs.inverse_flattening
-            if crs.is_projected:
+                self.storage_crs.inverse_flattening
+            if self.storage_crs.is_projected:
                 properties['crs_type'] = 'ProjectedCRS'
 
         properties['axes'] = [
@@ -510,7 +490,7 @@ class XarrayProvider(BaseProvider):
 
         return ', '.join(times)
 
-    def parse_grid_mapping(self):
+    def _parse_grid_mapping(self):
         spatiotemporal_dims = (self.time_field, self.y_field, self.x_field)
         grid_mapping_name = None
         for var_name, var in self._data.variables.items():
@@ -520,6 +500,48 @@ class XarrayProvider(BaseProvider):
                 except KeyError:
                     LOGGER.debug()
         return grid_mapping_name
+    
+    def _parse_storage_crs(
+        self,
+        provider_def: dict
+    ) -> pyproj.CRS
+        """
+        Parse the storage CRS from an xarray dataset.
+        :param provider_def: provider definition
+        :returns: `pyproj.CRS` instance parsed from dataset
+        """
+        
+        try:
+            storage_crs = provider_def['storage_crs']
+            crs_function = pyproj.CRS.from_user_input            
+        except KeyError:
+            LOGGER.debug('''
+                No storage crs provided in the provider configuration.
+                Attempting to parse the CRS.
+                '''
+            )
+
+        if storage_crs is None:
+            grid_mapping = self._parse_grid_mapping()
+            crs_function = pyproj.CRS.from_dict
+            if grid_mapping is not None:
+                storage_crs = self._data[grid_mapping].attrs
+            elif 'crs' in self._data.variables.keys():
+                storage_crs = self._data['crs'].attrs
+            else:
+                storage_crs = DEFAULT_STORAGE_CRS
+                crs_function = get_crs_from_uri
+                LOGGER.debug('Failed to parse dataset CRS. Assuming WGS84.')
+
+        LOGGER.debug(f'Parsing CRS {storage_crs} with {crs_function}')
+        try:
+            crs = crs_function(storage_crs)
+        except CRSError as e:
+            LOGGER.debug(f'Unable to parse projection with pyproj: {e}')
+            LOGGER.debug('Assuming default WGS84.')
+            crs = get_crs_from_uri(DEFAULT_STORAGE_CRS)
+
+        return crs
 
 
 def _to_datetime_string(datetime_obj):

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -86,9 +86,8 @@ class XarrayProvider(BaseProvider):
                 data_to_open = self.data
 
             self._data = open_func(data_to_open)
-            self._coverage_properties = self._get_coverage_properties(
-                provider_def
-            )
+            self.storage_crs = self._parse_storage_crs(provider_def)
+            self._coverage_properties = self._get_coverage_properties()
 
             self.axes = [self._coverage_properties['x_axis_label'],
                          self._coverage_properties['y_axis_label'],
@@ -344,7 +343,7 @@ class XarrayProvider(BaseProvider):
 
         return cj
 
-    def _get_coverage_properties(self, provider_def: dict):
+    def _get_coverage_properties(self):
         """
         Helper function to normalize coverage properties
         :param provider_def: provider definition
@@ -409,7 +408,6 @@ class XarrayProvider(BaseProvider):
         }
 
         # Update properties based on the xarray's CRS
-        self.storage_crs = self._parse_storage_crs(provider_def)
         epsg_code = self.storage_crs.to_epsg()
         LOGGER.debug(f'{epsg_code}')
         if epsg_code == 4326 or self.storage_crs == 'OGC:CRS84':

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -83,7 +83,9 @@ class XarrayProvider(BaseProvider):
                 data_to_open = self.data
 
             self._data = open_func(data_to_open)
-            self._coverage_properties = self._get_coverage_properties()
+            self._coverage_properties = self._get_coverage_properties(
+                provider_def
+            )
 
             self.axes = [self._coverage_properties['x_axis_label'],
                          self._coverage_properties['y_axis_label'],
@@ -339,9 +341,14 @@ class XarrayProvider(BaseProvider):
 
         return cj
 
-    def _get_coverage_properties(self):
+    def _get_coverage_properties(
+            self,
+            provider_def: dict
+        ):
         """
         Helper function to normalize coverage properties
+
+        :param provider_def: provider definition
 
         :returns: `dict` of coverage properties
         """
@@ -402,33 +409,42 @@ class XarrayProvider(BaseProvider):
             'restime': self.get_time_resolution()
         }
 
-        grid_mapping = self.parse_grid_mapping()
-        if grid_mapping is not None:
-            crs_attrs = pyproj.CRS.to_cf(self._data[grid_mapping].attrs)
-            epsg_code = crs_attrs.to_epsg()
-            if epsg_code == 4326:
-                pass
-            elif epsg_code is None:
-                LOGGER.debug('No epsg code parsed. Default CRS used.')
-            else:
-                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{epsg_code}'  # noqa
-                properties['inverse_flattening'] = \
-                    crs_attrs['inverse_flattening']
-                if crs_attrs['grid_mapping_name '] != 'latitude_longitude':
-                    properties['crs_type'] = 'ProjectedCRS'
+        # TODO break some of this up into separate functions.
+        # TODO add some better error handling for pyproj?
+        try:
+            user_crs = provider_def['extents']['spatial']['crs']
+        except KeyError:
+            LOGGER.debug('No CRS provided in the configuration.')
+        
+        if isinstance(user_crs, pyproj.CRS):
+            ## add some error handling here in case users provide invalid CRS info
+            crs = pyproj.CRS.from_user_input(user_crs)
+            epsg_code = crs.to_epsg()
+            # This can return nothing (e.g. if a custom proj) -- add handling for that case 
+        else: 
+            grid_mapping = self.parse_grid_mapping()
+            if grid_mapping is not None:
+                crs = pyproj.CRS.from_dict(
+                    self._data[grid_mapping].attrs
+                )
+                epsg_code = crs.to_epsg()
+            # check if CRS included in dataset
+            elif 'crs' in self._data.variables.keys():
+                try:
+                    epsg_code = pyproj.CRS.from_epsg(
+                        self._data.crs.epsg_code
+                    )
+                except KeyError:
+                    LOGGER.debug('Unable to parse CRS. Assuming default WGS84.')
 
-        elif 'crs' in self._data.variables.keys():
-            try:
-                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{self._data.crs.epsg_code}'  # noqa
-
-                properties['inverse_flattening'] = self._data.crs.\
-                    inverse_flattening
-                properties['inverse_flattening'] = self._data.crs.\
-                    inverse_flattening
-
+        if epsg_code == 4326:
+            pass
+        else:
+            properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{epsg_code}'  # noqa
+            properties['inverse_flattening'] = \
+                crs.inverse_flattening
+            if crs.is_projected:
                 properties['crs_type'] = 'ProjectedCRS'
-            except KeyError:
-                LOGGER.debug('Unable to parse CRS. Assuming default WGS84.')
 
         properties['axes'] = [
             properties['x_axis_label'],

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -46,10 +46,7 @@ from pygeoapi.provider.base import (BaseProvider,
                                     ProviderConnectionError,
                                     ProviderNoDataError,
                                     ProviderQueryError)
-from pygeoapi.util import (
-    read_data,
-    get_crs_from_uri
-)
+from pygeoapi.util import get_crs_from_uri, read_data
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -421,10 +421,11 @@ class XarrayProvider(BaseProvider):
             if epsg_code == 4326:
                 pass
             elif epsg_code is None:
-                LOGGER.debug(f'No epsg code parsed. Default CRS used.')
+                LOGGER.debug('No epsg code parsed. Default CRS used.')
             else:
-                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{self._data.crs.epsg_code}'
-                properties['inverse_flattening'] = crs_attrs['inverse_flattening']
+                properties['bbox_crs'] = f'https://www.opengis.net/def/crs/EPSG/0/{epsg_code}'  # noqa
+                properties['inverse_flattening'] = \
+                    crs_attrs['inverse_flattening']
                 if crs_attrs['grid_mapping_name '] != 'latitude_longitude':
                     properties['crs_type'] = 'ProjectedCRS'
 
@@ -437,7 +438,7 @@ class XarrayProvider(BaseProvider):
 
                 properties['crs_type'] = 'ProjectedCRS'
             except KeyError:
-                LOGGER.debug('Unable to parse CRS information from dataset. Assuming default WGS84.')
+                LOGGER.debug('Unable to parse CRS. Assuming default WGS84.')
 
         properties['axes'] = [
             properties['x_axis_label'],
@@ -502,7 +503,7 @@ class XarrayProvider(BaseProvider):
                  in time_dict.items() if val > 0]
 
         return ', '.join(times)
-    
+
     def parse_grid_mapping(self):
         spatiotemporal_dims = (self.time_field, self.y_field, self.x_field)
         grid_mapping_name = None

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -412,7 +412,7 @@ class XarrayProvider(BaseProvider):
         self.storage_crs = self._parse_storage_crs(provider_def)
         epsg_code = self.storage_crs.to_epsg()
         LOGGER.debug(f'{epsg_code}')
-        if (epsg_code == 4326) | (self.storage_crs == 'OGC:CRS84'):
+        if epsg_code == 4326 or self.storage_crs == 'OGC:CRS84':
             pass
             LOGGER.debug('Confirmed default of WGS 84')
         else:

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -93,9 +93,7 @@ class XarrayProvider(BaseProvider):
                 self,
                 provider_def
             )
-            self._coverage_properties = self._get_coverage_properties(
-                provider_def
-            )
+            self._coverage_properties = self._get_coverage_properties()
 
             self.axes = [self._coverage_properties['x_axis_label'],
                          self._coverage_properties['y_axis_label'],


### PR DESCRIPTION
# Overview
As discussed in #1578, I was experiencing a build failure for several EDR datasets that had a `crs` variable that did not have very specific attributes. 

This solution adds a `storage_crs` variable/attribute to the `XarrayProvider` -- I named it that based on CRS handling in the `features` provider, but am open to other naming schemes if you think something else is more appropriate. I had considered using the `crs` under `extents` in the config, but could see an instance where the extents are in WGS84 while the data itself are projected to some other coordinate system. 

`storage_crs` is defined with the added `_parse_storage_crs` method, which does the following:
1. Looks to the config file for a `storage_crs`. As noted in the documentation change, this value in the config could be anything accepted by [`pyproj.CRS.from_user_input`](https://pyproj4.github.io/pyproj/stable/api/crs/crs.html#pyproj.crs.CRS.from_user_input). If no `storage_crs` is found in the config, we attempt to parse the crs information directly from the zarr/netCDF file with the following steps.
2. Start by checking to see if the xarray dataset is CF-compliant ([details on grid mapping here](https://cfconventions.org/cf-conventions/cf-conventions.html#grid-mappings-and-projections)). This code looks to see if there is a grid mapping attribute for spatiotemporal variables. If there is, then we will parse crs information from the variable with that name in the xarray using [`pyproj.CRS.from_cf`](https://pyproj4.github.io/pyproj/stable/api/crs/crs.html#pyproj.crs.CRS.from_cf).
3. If a grid mapping does not exist, but a variable named `crs` does, then we will attempt to parse the crs information from the attributes of that variable using [`pyproj.CRS.from_dict`](https://pyproj4.github.io/pyproj/stable/api/crs/crs.html#pyproj.crs.CRS.from_dict).
4. If all else fails, assume a default storage CRS of http://www.opengis.net/def/crs/OGC/1.3/CRS84

In this fix, we just use `storage_crs` to define properties for the dataset, including `bbox_crs`, `inverse_flattening`, and `crs_type`. I'd envision in the future, the `storage_crs` could be used much like it is for features, or as `crs_src` is handled in the `rasterio_.py` to support a CRS query parameter.

I appreciate any feedback on any additional widely-used cases we should consider for CRS handling in the xarray provider and/or chagnes to make this more helpful for addressing future EDR development (e.g., #1104).

# Related Issue / discussion
Addresses #1578 
Will help pave a way forward for #1104 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo
- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

The netcdf file in the config above does not have a CRS variable or any grid mapping information, so the changes would assume WGS84 lat/lon.

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this feature to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
