### PR TITLE
Retrieve properties from elasticsearch on get tile request

### DIFF
--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -19,7 +19,7 @@ pygeoapi core tile providers are listed below, along with supported features.
    :align: left
 
    `MVT-tippecanoe`_,❌,✅,✅,❌
-   `MVT-elastic`_,✅,❌,✅,❌
+   `MVT-elastic`_,✅,✅,✅,❌
    `MVT-proxy`_,❓,❓,❓,❓
    `WMTSFacade`_,✅,❌,✅,✅
 

--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -173,8 +173,9 @@ class MVTElasticProvider(BaseMVTProvider):
 
             try:
                 with requests.Session() as session:
+                    data = {"fields": ["*"]}
                     session.get(base_url)
-                    resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}')  # noqa
+                    resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}', json=data)  # noqa
                     resp.raise_for_status()
                     return resp.content
             except requests.exceptions.RequestException as e:

--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -173,7 +173,7 @@ class MVTElasticProvider(BaseMVTProvider):
 
             try:
                 with requests.Session() as session:
-                    data = {"fields": ["*"]}
+                    data = {'fields': ['*']}
                     session.get(base_url)
                     resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}', json=data)  # noqa
                     resp.raise_for_status()


### PR DESCRIPTION
# Overview
This PR adds a body to the get tile request of the mvt-provider, in order to retireve the values for all the fields in that index. This enables tile clients to render styles based on the values of the fields (see image bellow).

![conditional-rendering](https://github.com/geopython/pygeoapi/assets/1038897/a675d19f-4747-4bf1-9197-b1e36e787407)


# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/1645

# Additional information

Client rendering before this change:

![get-tile-before-pr](https://github.com/geopython/pygeoapi/assets/1038897/e7e6e6ba-d9d2-42e6-8c4b-d9d062fb94f0)

Client rendering after this change:

![get -tile-after-pr](https://github.com/geopython/pygeoapi/assets/1038897/a60cb000-1560-45fe-acea-ecf9dd12af01)




# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
