### PR TITLE
add api map-layer to map

### DIFF
--- a/pygeoapi/templates/collections/collection.html
+++ b/pygeoapi/templates/collections/collection.html
@@ -119,6 +119,14 @@
       }
     ));
 
+   {# if this collection has a map representation, add it to the map #}
+   {% for link in data['links'] %}
+      {% if link['rel'] == 'http://www.opengis.net/def/rel/ogc/1.0/map' and link['href'] %} 
+        L.tileLayer.wms("{{ link['href'] }}", {"opacity": .7, "transparent": true, "crs": L.CRS.EPSG4326}).addTo(map); 
+      {% endif %}
+    {% endfor %}
+
+
     var bbox_layer = L.polygon([
       ['{{ data['extent']['spatial']['bbox'][0][1] }}', '{{ data['extent']['spatial']['bbox'][0][0] }}'],
       ['{{ data['extent']['spatial']['bbox'][0][3] }}', '{{ data['extent']['spatial']['bbox'][0][0] }}'],


### PR DESCRIPTION
# Overview

This PR adds a vizualisation of the ogc api maps layer to the map at collection level, The code adds the map service as WMS, benefiting from the aspect that common parameters such as bbox,width,height align between ogc-api-maps and wms. It uses the 4326 projection because of error #1648 

![image](https://github.com/geopython/pygeoapi/assets/299829/e6beabc9-73ca-4474-b6cd-4276d9fcc510)

# Related Issue / discussion

in #668 ogc maps has been added

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
- [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
