### PR TITLE
fixed issue 1652 by removing the staticmethod decorators

### DIFF
--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -1182,7 +1182,6 @@ def get_collection_item(api: API, request: APIRequest,
     return headers, HTTPStatus.OK, to_json(content, api.pretty_print)
 
 
-@staticmethod
 def create_crs_transform_spec(
         config: dict, query_crs_uri: Optional[str] = None) -> Union[None, CrsTransformSpec]:  # noqa
     """
@@ -1245,7 +1244,6 @@ def create_crs_transform_spec(
         return None
 
 
-@staticmethod
 def set_content_crs_header(
         headers: dict, config: dict, query_crs_uri: Optional[str] = None):
     """


### PR DESCRIPTION
 fixed issue 1652 by removing the staticmethod decorators infront of function defintion

# Overview

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/1652
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
