### PR TITLE
docs: point to combined plugins and themes wiki page

### DIFF
--- a/docs/source/html-templating.rst
+++ b/docs/source/html-templating.rst
@@ -36,21 +36,13 @@ Linking to a static file in your HTML templates can be done using Jinja syntax a
   <img src="{{ config['server']['url'] }}/static/img/logo.png" title="{{ config['metadata']['identification']['title'] }}" />
 
 
-Featured templates
-------------------
+Featured themes
+----------------
 
-The following themes provide useful examples of pygeoapi templates implemented
-by downstream applications.
-
-.. csv-table::
-   :header: "Plugin(s)", "Organization/Project","Description"
-   :align: left
-
-   `pygeoapi-skin-dashboard`_,GeoCat bv,skin for pygeoapi based on a typical dashboard interface
-
+Community based themes can be found on the `pygeoapi Community Plugins and Themes wiki page`_.
 
 .. _`Jinja`: https://palletsprojects.com/p/jinja/
 .. _`Jinja documentation`: https://jinja.palletsprojects.com
 .. _`Flask`: https://palletsprojects.com/p/flask/
 .. _`Flask documentation`: https://flask.palletsprojects.com
-.. _`pygeoapi-skin-dashboard`: https://github.com/GeoCat/pygeoapi-skin-dashboard
+.. _`pygeoapi Community Plugins and Themes wiki page`: https://github.com/geopython/pygeoapi/wiki/CommunityPluginsThemes

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -374,9 +374,9 @@ The below template provides a minimal example (let's call the file ``mycooljsonf
 Featured plugins
 ----------------
 
-Community based plugins can be found on the `pygeoapi Community Plugins wiki page`_.
+Community based plugins can be found on the `pygeoapi Community Plugins and Themes wiki page`_.
 
 
-.. _`pygeoapi Community Plugins wiki page`: https://github.com/geopython/pygeoapi/wiki/CommunityPlugins
+.. _`pygeoapi Community Plugins and Themes wiki page`: https://github.com/geopython/pygeoapi/wiki/CommunityPluginsThemes
 .. _`Cookiecutter`: https://github.com/audreyfeldroy/cookiecutter-pypackage
 .. _`pygeoapi-plugin-cookiecutter`: https://code.usgs.gov/wma/nhgf/pygeoapi-plugin-cookiecutter


### PR DESCRIPTION
# Overview
This PR moves the community themes list from the docs to the wiki page (similar to plugins).

# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
