### PR TITLE
Add job before returning the response

### DIFF
--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -238,25 +238,6 @@ class BaseManager:
 
         :returns: tuple of MIME type, response payload and status
         """
-
-        process_id = p.metadata['id']
-        current_status = JobStatus.accepted
-
-        job_metadata = {
-            'type': 'process',
-            'identifier': job_id,
-            'process_id': process_id,
-            'job_start_datetime': datetime.utcnow().strftime(
-                DATETIME_FORMAT),
-            'job_end_datetime': None,
-            'status': current_status.value,
-            'location': None,
-            'mimetype': 'application/octet-stream',
-            'message': 'Job accepted and ready for execution',
-            'progress': 5
-        }
-
-        self.add_job(job_metadata)
         self._send_in_progress_notification(subscriber)
 
         try:
@@ -406,6 +387,23 @@ class BaseManager:
             LOGGER.debug('Synchronous execution')
             handler = self._execute_handler_sync
             response_headers = None
+
+        # Add Job before returning any response.
+        current_status = JobStatus.accepted
+        job_metadata = {
+            'type': 'process',
+            'identifier': job_id,
+            'process_id': process_id,
+            'job_start_datetime': datetime.utcnow().strftime(DATETIME_FORMAT),
+            'job_end_datetime': None,
+            'status': current_status.value,
+            'location': None,
+            'mimetype': 'application/octet-stream',
+            'message': 'Job accepted and ready for execution',
+            'progress': 5
+        }
+        self.add_job(job_metadata)
+
         # TODO: handler's response could also be allowed to include more HTTP
         # headers
         mime_type, outputs, status = handler(


### PR DESCRIPTION
Hi!

# Overview
This makes the base process manager add the job to it's database _before_ returning any response to the client.

# Related Issue / discussion
In my testing, I send many async jobs requests at the same time. Once the response header comes back, I ping the server every second to see if the job succeeded. 

On my slow VM, with more than 10 simultaneous requests, the first ping fails because the job doesn't exist. I receive the following response from the server : `{'code': 'InvalidParameterValue', 'type': 'InvalidParameterValue', 'description': '<job id>'}`.

Diving in the code, I see that the first `add_job` call of the manager, that registers the job to the db, happens within the execution function. In the async case, this means that the Process creation and start happens between the initial response and the `add_job` . In the case of (relatively) large loads like in my example, this takes more than 1 sec. 

In any case, it feels better if the response sent with the `accepted` status only happens once the job is registered to the database.

# Additional information

I just started playing with pygeoapi, I might have missed something that justified the previous behaviour!

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this bugfix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
