### PR TITLE
Oracle Connection Pooling implementation of issues/1655 

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -388,15 +388,17 @@ Extra properties is a list of strings which are added as fields for data retriev
 can be used to return expressions computed by the database.
 
 Session Pooling
-""""""""""""""""""""
+""""""""""""""""
+
 Configured using environment variables.
 
+.. code-block:: bash
 
    export ORACLE_POOL_MIN=2
-   
    export ORACLE_POOL_MAX=10
 
-The ORACLE_POOL_MIN and ORACLE_POOL_MAX environment variables are used to trigger Session Pool creation in the Oracle Provider and the DatabaseConnection class. See https://python-oracledb.readthedocs.io/en/latest/api_manual/module.html#oracledb.create_pool for Documentation of the create_pool function.
+
+The ``ORACLE_POOL_MIN`` and ``ORACLE_POOL_MAX`` environment variables are used to trigger session pool creation in the Oracle Provider and the ``DatabaseConnection`` class. See https://python-oracledb.readthedocs.io/en/latest/api_manual/module.html#oracledb.create_pool for documentation of the ``create_pool`` function.
 
 If none or only one of the environment variables is set, session pooling will not be activated and standalone connections are established at every request.
 

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -387,6 +387,19 @@ Extra properties
 Extra properties is a list of strings which are added as fields for data retrieval in the SELECT clauses. They
 can be used to return expressions computed by the database.
 
+Session Pooling
+""""""""""""""""""""
+Configured using environment variables.
+
+
+   export ORACLE_POOL_MIN=2
+   
+   export ORACLE_POOL_MAX=10
+
+The ORACLE_POOL_MIN and ORACLE_POOL_MAX environment variables are used to trigger Session Pool creation in the Oracle Provider and the DatabaseConnection class. See https://python-oracledb.readthedocs.io/en/latest/api_manual/module.html#oracledb.create_pool for Documentation of the create_pool function.
+
+If none or only one of the environment variables is set, session pooling will not be activated and standalone connections are established at every request.
+
 
 Custom SQL Manipulator Plugin
 """""""""""""""""""""""""""""

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -1182,7 +1182,6 @@ def get_collection_item(api: API, request: APIRequest,
     return headers, HTTPStatus.OK, to_json(content, api.pretty_print)
 
 
-@staticmethod
 def create_crs_transform_spec(
         config: dict, query_crs_uri: Optional[str] = None) -> Union[None, CrsTransformSpec]:  # noqa
     """
@@ -1245,7 +1244,6 @@ def create_crs_transform_spec(
         return None
 
 
-@staticmethod
 def set_content_crs_header(
         headers: dict, config: dict, query_crs_uri: Optional[str] = None):
     """

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -188,6 +188,7 @@ class DatabaseConnection:
         # Initialize the connection pool if it hasn't been initialized
         if DatabaseConnection.pool is None:
             DatabaseConnection.initialize_pool(conn_dic)
+            LOGGER.debug(f"Initialized conneciton pool with {DatabaseConnection.pool.max}connections ")
 
     def __enter__(self):
 

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -243,7 +243,7 @@ class DatabaseConnection:
         """
         try:
             if self.conn:
-                self.conn.close()
+                DatabaseConnection.pool.release(self.conn)
                 LOGGER.debug("Connection released back to pool.")
         except oracledb.DatabaseError as e:
             LOGGER.error("Error closing the connection.")

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -85,7 +85,6 @@ class DatabaseConnection:
 
         return DatabaseConnection.pool
 
-
     def __init__(self, conn_dic, table, properties=[], context="query"):
         """
         OracleProvider Class constructor
@@ -122,7 +121,7 @@ class DatabaseConnection:
 
         # Initialize the connection pool if it hasn't been initialized
         if os.environ.get('ORACLE_POOL_MIN') and os.environ.get('ORACLE_POOL_MAX'):  # noqa
-            LOGGER.debug(f"Found environment variables for session pooling:")
+            LOGGER.debug("Found environment variables for session pooling:")
             LOGGER.debug(f"ORACLE_POOL_MIN: {os.environ.get('ORACLE_POOL_MIN')}")  # noqa
             LOGGER.debug(f"ORACLE_POOL_MAX: {os.environ.get('ORACLE_POOL_MAX')}")  # noqa
             if DatabaseConnection.pool is None:
@@ -130,7 +129,6 @@ class DatabaseConnection:
                     LOGGER.debug(f"self.conn_dict contains {self.conn_dict}")
                     DatabaseConnection.initialize_pool(self.conn_dict)
                     LOGGER.debug(f"Initialized conneciton pool with {DatabaseConnection.pool.max} connections ")  # noqa
-
 
     @staticmethod
     def _make_dsn(conn_dict):
@@ -202,9 +200,7 @@ class DatabaseConnection:
 
         return dsn
 
-
     def __enter__(self):
-
         """Acquires a connection from the pool."""
         try:
             if DatabaseConnection.pool:
@@ -297,7 +293,6 @@ class DatabaseConnection:
         except oracledb.DatabaseError as e:
             LOGGER.error("Error closing the connection.")
             LOGGER.error(e)
-
 
     def _get_table_columns(self, schema, table):
         """

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -67,8 +67,8 @@ class DatabaseConnection:
         # Get env var values for Oracle Pool config
         # This has to be done with global vars instead of YAML File
         # Because pool should constant and not for every layer
-        oracle_pool_min = os.environ.get('ORACLE_POOL_MIN')
-        oracle_pool_max = os.environ.get('ORACLE_POOL_MAX')
+        oracle_pool_min = int(os.environ.get('ORACLE_POOL_MIN'))
+        oracle_pool_max = int(os.environ.get('ORACLE_POOL_MAX'))
 
         dsn = cls._make_dsn(conn_dict)
         # Create the pool

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -54,6 +54,27 @@ class DatabaseConnection:
     """Database connection class to be used as 'with' statement.
     The class returns a connection object.
     """
+    pool = None  # Class-level connection pool
+    @classmethod
+    def initialize_pool(cls, conn_dict):
+        """Initialize the connection pool if not already initialized."""
+        if cls.pool is None:
+            dsn = oracledb.makedsn(
+                conn_dict["host"],
+                conn_dict.get("port", 1521),
+                service_name=conn_dict["service_name"]
+            )
+            cls.pool = oracledb.create_pool(
+                user=conn_dict["user"],
+                password=conn_dict["password"],
+                dsn=dsn,
+                min=2,  # Minimum number of connections in the pool
+                max=10,  # Maximum number of connections in the pool
+                increment=1,  # Number of connections to add if pool is empty
+            )
+            LOGGER.debug("Connection pool created successfully.")
+
+
 
     def __init__(self, conn_dic, table, properties=[], context="query"):
         """
@@ -88,107 +109,24 @@ class DatabaseConnection:
         )
         self.properties = [item.lower() for item in properties]
         self.fields = {}  # Dict of columns. Key is col name, value is type
-        self.conn = None
+
+        # Initialize the connection pool if it hasn't been initialized
+        if DatabaseConnection.pool is None:
+            DatabaseConnection.initialize_pool(conn_dic)
 
     def __enter__(self):
+
+        """Acquires a connection from the pool."""
         try:
-            if self.conn_dict.get("init_oracle_client", False):
-                oracledb.init_oracle_client()
-
-            # Connect with tnsnames.ora entry and Login with Oracle Wallet
-            if self.conn_dict.get("external_auth") == "wallet":
-                LOGGER.debug(
-                    "Oracle connect with tnsnames.ora entry \
-                    and login with Oracle Wallet"
-                )
-
-                if "tns_name" not in self.conn_dict:
-                    raise ProviderConnectionError(
-                        "tns_name must be set for external authentication!"
-                    )
-
-                dsn = self.conn_dict["tns_name"]
-
-            # Connect with SERVICE_NAME
-            if "service_name" in self.conn_dict:
-                LOGGER.debug(
-                    f"Oracle connect with service_name: \
-                        {self.conn_dict['service_name']}"
-                )
-
-                if "host" not in self.conn_dict:
-                    raise ProviderConnectionError(
-                        "Host must be set for connection with service_name!"
-                    )
-
-                dsn = oracledb.makedsn(
-                    self.conn_dict["host"],
-                    self.conn_dict.get("port", 1521),
-                    service_name=self.conn_dict["service_name"],
-                )
-
-            # Connect with SID
-            elif "sid" in self.conn_dict:
-                LOGGER.debug(
-                    f"Oracle connect with sid: {self.conn_dict['sid']}"
-                )
-
-                if "host" not in self.conn_dict:
-                    raise ProviderConnectionError(
-                        "Host must be set for connection with sid!"
-                    )
-
-                dsn = oracledb.makedsn(
-                    self.conn_dict["host"],
-                    self.conn_dict.get("port", 1521),
-                    sid=self.conn_dict["sid"],
-                )
-
-            # Connect with tnsnames.ora entry
-            elif "tns_name" in self.conn_dict:
-                LOGGER.debug(
-                    f"Oracle connect with tns_name: \
-                        {self.conn_dict['tns_name']}"
-                )
-                dsn = self.conn_dict["tns_name"]
-
-            else:
-                raise ProviderConnectionError(
-                    "One of service_name, sid or tns_name must be specified!"
-                )
-
-            LOGGER.debug(f"Oracle DSN string: {dsn}")
-
-            # Connect with tnsnames.ora entry and Login with Oracle Wallet
-            if self.conn_dict.get("external_auth") == "wallet":
-                self.conn = oracledb.connect(externalauth=True, dsn=dsn)
-
-            # Connect with tnsnames.ora entry,
-            # TNS_ADMIN is set via configuration
-            if "tns_admin" in self.conn_dict:
-                self.conn = oracledb.connect(
-                    user=self.conn_dict["user"],
-                    password=self.conn_dict["password"],
-                    dsn=dsn,
-                    config_dir=self.conn_dict["tns_admin"],
-                )
-
-            # Connect with user / password via dsn string
-            # When dsn is a TNS name, the environment variable TNS_ADMIN must
-            # be set (Path to tnsnames.ora file)
-            else:
-                self.conn = oracledb.connect(
-                    user=self.conn_dict["user"],
-                    password=self.conn_dict["password"],
-                    dsn=dsn,
-                )
+            self.conn = DatabaseConnection.pool.acquire()
+            LOGGER.debug("Connection acquired from pool.")
+            LOGGER.debug(f"Connection {self.conn}.")
 
         except oracledb.DatabaseError as e:
-            LOGGER.error(
-                f"Couldn't connect to Oracle using:{str(self.conn_dict)}"
-            )
+            LOGGER.error("Couldn't acquire a connection from the pool.")
             LOGGER.error(e)
             raise ProviderConnectionError(e)
+
 
         # Check if table name has schema/owner inside
         # If not, current user is set
@@ -225,8 +163,18 @@ class DatabaseConnection:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        # some logic to commit/rollback
-        self.conn.close()
+        """
+        Releases the connection back to the pool.
+        """
+        try:
+            if self.conn:
+                self.conn.close()
+                LOGGER.debug("Connection released back to pool.")
+        except oracledb.DatabaseError as e:
+            LOGGER.error("Error closing the connection.")
+            LOGGER.error(e)
+
+
 
     def _get_table_columns(self, schema, table):
         """

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -4,7 +4,7 @@
 # Authors: Moritz Langer <moritz.b.langer@gmail.com>
 #
 # Copyright (c) 2023 Andreas Kosubek
-#
+# Copyright (c) 2024 Moritz Langer
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
 # files (the "Software"), to deal in the Software without
@@ -31,11 +31,12 @@
 import importlib
 import json
 import logging
+import os
+import threading
+from typing import Optional
+
 import oracledb
 import pyproj
-from typing import Optional
-import threading
-import os
 
 from pygeoapi.api import DEFAULT_STORAGE_CRS
 

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -1,6 +1,7 @@
 # =================================================================
 #
 # Authors: Andreas Kosubek <andreas.kosubek@ama.gv.at>
+# Authors: Moritz Langer <moritz.b.langer@gmail.com>
 #
 # Copyright (c) 2023 Andreas Kosubek
 #

--- a/tests/test_oracle_provider.py
+++ b/tests/test_oracle_provider.py
@@ -667,6 +667,6 @@ def test_query_pool(config):
 
     if 'ORACLE_POOL_MIN' in os.environ:
         del os.environ["ORACLE_POOL_MIN"]
-    
+
     if 'ORACLE_POOL_MAx' in os.environ:
         del os.environ["ORACLE_POOL_MAX"]

--- a/tests/test_oracle_provider.py
+++ b/tests/test_oracle_provider.py
@@ -147,6 +147,7 @@ def config():
         "editable": True,
     }
 
+
 @pytest.fixture()
 def config_db_conn():
     return {
@@ -630,18 +631,19 @@ def test_query_mandatory_properties_must_be_specified(config):
     with pytest.raises(ProviderInvalidQueryError):
         p.query(properties=[("id", "123")])
 
+
 def test_oracle_pool(config_db_conn):
     """
     Test whether an oracle session pool is created when there are
     the required env variables.
     """
     os.environ["ORACLE_POOL_MIN"] = "2"
-    os.environ["ORACLE_POOL_MAx"] = "10"
     oracle_pool_min = os.environ.get('ORACLE_POOL_MIN', 2)
+    os.environ["ORACLE_POOL_MAx"] = "10"
     oracle_pool_max = os.environ.get('ORACLE_POOL_MAX', 10)
     db_conn = DatabaseConnection(**config_db_conn)
-    assert db_conn.pool != None
-    
+    assert db_conn.pool is not None
+
     if 'ORACLE_POOL_MIN' in os.environ:
         del os.environ["ORACLE_POOL_MIN"]
     
@@ -650,28 +652,20 @@ def test_oracle_pool(config_db_conn):
 
 
 def test_query_pool(config):
-    """Test query using a DB Session Pool for a valid JSON object with geometry"""
+    """Test query using a DB Session Pool for a valid JSON object with geometry"""   # noqa
     # Set ENV Var for creating a session pool
     os.environ["ORACLE_POOL_MIN"] = "2"
+    oracle_pool_min = os.environ.get('ORACLE_POOL_MIN', 2)
     os.environ["ORACLE_POOL_MAx"] = "10"
+    oracle_pool_max = os.environ.get('ORACLE_POOL_MAX', 10)
     # Create DatabaseConnection config from standard config
     keys = ['data', 'table']
     config_db_conn = {x:config[x] for x in keys}
     config_db_conn['conn_dic'] = config_db_conn.pop('data')
     # Create Connection class and check against pool
     db_conn = DatabaseConnection(**config_db_conn)
-    assert db_conn.pool != None
-    # Run query tests
-    # p = OracleProvider(config)
-    # feature_collection = p.query()
-    # assert feature_collection.get("type") == "FeatureCollection"
-    # features = feature_collection.get("features")
-    # assert features is not None
-    # feature = features[0]
-    # properties = feature.get("properties")
-    # assert properties is not None
-    # geometry = feature.get("geometry")
-    # assert geometry is not None
+    assert db_conn.pool is not None
+    # Run query test again with session pool
     test_query(config)
 
     if 'ORACLE_POOL_MIN' in os.environ:

--- a/tests/test_oracle_provider.py
+++ b/tests/test_oracle_provider.py
@@ -638,10 +638,10 @@ def test_oracle_pool(config_db_conn):
     the required env variables.
     """
     os.environ["ORACLE_POOL_MIN"] = "2"     # noqa
-    os.environ["ORACLE_POOL_MAx"] = "10"    # noqa
+    os.environ["ORACLE_POOL_MAX"] = "10"    # noqa
     db_conn = DatabaseConnection(**config_db_conn)
-    assert db_conn.pool is not None
-
+    assert db_conn.pool.max == int(os.environ.get("ORACLE_POOL_MAX"))
+    assert db_conn.pool
     if 'ORACLE_POOL_MIN' in os.environ:
         del os.environ["ORACLE_POOL_MIN"]
 
@@ -653,14 +653,15 @@ def test_query_pool(config):
     """Test query using a DB Session Pool for a valid JSON object with geometry"""   # noqa
     # Set ENV Var for creating a session pool
     os.environ["ORACLE_POOL_MIN"] = "2"     # noqa
-    os.environ["ORACLE_POOL_MAx"] = "10"    # noqa
+    os.environ["ORACLE_POOL_MAX"] = "10"    # noqa
     # Create DatabaseConnection config from standard config
     keys = ['data', 'table']
     config_db_conn = {x: config[x] for x in keys}
     config_db_conn['conn_dic'] = config_db_conn.pop('data')
     # Create Connection class and check against pool
     db_conn = DatabaseConnection(**config_db_conn)
-    assert db_conn.pool is not None
+    assert db_conn.pool.max == int(os.environ.get("ORACLE_POOL_MAX"))
+    assert db_conn.pool
     # Run query test again with session pool
     test_query(config)
 

--- a/tests/test_oracle_provider.py
+++ b/tests/test_oracle_provider.py
@@ -646,7 +646,7 @@ def test_oracle_pool(config_db_conn):
         del os.environ["ORACLE_POOL_MIN"]
 
     if 'ORACLE_POOL_MAx' in os.environ:
-        del os.environ["ORACLE_POOL_MAx"]
+        del os.environ["ORACLE_POOL_MAX"]
 
 
 def test_query_pool(config):
@@ -669,4 +669,4 @@ def test_query_pool(config):
         del os.environ["ORACLE_POOL_MIN"]
     
     if 'ORACLE_POOL_MAx' in os.environ:
-        del os.environ["ORACLE_POOL_MAx"]
+        del os.environ["ORACLE_POOL_MAX"]

--- a/tests/test_oracle_provider.py
+++ b/tests/test_oracle_provider.py
@@ -632,41 +632,28 @@ def test_query_mandatory_properties_must_be_specified(config):
         p.query(properties=[("id", "123")])
 
 
-def test_oracle_pool(config_db_conn):
+@pytest.fixture()
+def database_connection_pool(config_db_conn):
+    os.environ["ORACLE_POOL_MIN"] = "2"  # noqa: F841
+    os.environ["ORACLE_POOL_MAX"] = "10"  # noqa: F841
+    yield
+    if 'ORACLE_POOL_MIN' in os.environ:
+        del os.environ["ORACLE_POOL_MIN"]
+    if 'ORACLE_POOL_MAX' in os.environ:
+        del os.environ["ORACLE_POOL_MAX"]
+
+
+def test_oracle_pool(config_db_conn, database_connection_pool):
     """
     Test whether an oracle session pool is created when there are
     the required env variables.
     """
-    os.environ["ORACLE_POOL_MIN"] = "2"     # noqa: F841
-    os.environ["ORACLE_POOL_MAX"] = "10"    # noqa: F841
     db_conn = DatabaseConnection(**config_db_conn)
-    assert db_conn.pool.max == int(os.environ.get("ORACLE_POOL_MAX"))
     assert db_conn.pool
-    if 'ORACLE_POOL_MIN' in os.environ:
-        del os.environ["ORACLE_POOL_MIN"]
-
-    if 'ORACLE_POOL_MAx' in os.environ:
-        del os.environ["ORACLE_POOL_MAX"]
+    assert db_conn.pool.max == int(os.environ.get("ORACLE_POOL_MAX"))
 
 
-def test_query_pool(config):
+def test_query_pool(config, database_connection_pool):
     """Test query using a DB Session Pool for a valid JSON object with geometry"""   # noqa
-    # Set ENV Var for creating a session pool
-    os.environ["ORACLE_POOL_MIN"] = "2"     # noqa: F841
-    os.environ["ORACLE_POOL_MAX"] = "10"    # noqa: F841
-    # Create DatabaseConnection config from standard config
-    keys = ['data', 'table']
-    config_db_conn = {x: config[x] for x in keys}
-    config_db_conn['conn_dic'] = config_db_conn.pop('data')
-    # Create Connection class and check against pool
-    db_conn = DatabaseConnection(**config_db_conn)
-    assert db_conn.pool.max == int(os.environ.get("ORACLE_POOL_MAX"))
-    assert db_conn.pool
     # Run query test again with session pool
     test_query(config)
-
-    if 'ORACLE_POOL_MIN' in os.environ:
-        del os.environ["ORACLE_POOL_MIN"]
-
-    if 'ORACLE_POOL_MAx' in os.environ:
-        del os.environ["ORACLE_POOL_MAX"]

--- a/tests/test_oracle_provider.py
+++ b/tests/test_oracle_provider.py
@@ -637,8 +637,8 @@ def test_oracle_pool(config_db_conn):
     Test whether an oracle session pool is created when there are
     the required env variables.
     """
-    os.environ["ORACLE_POOL_MIN"] = "2"     # noqa
-    os.environ["ORACLE_POOL_MAX"] = "10"    # noqa
+    os.environ["ORACLE_POOL_MIN"] = "2"     # noqa: F841
+    os.environ["ORACLE_POOL_MAX"] = "10"    # noqa: F841
     db_conn = DatabaseConnection(**config_db_conn)
     assert db_conn.pool.max == int(os.environ.get("ORACLE_POOL_MAX"))
     assert db_conn.pool
@@ -652,8 +652,8 @@ def test_oracle_pool(config_db_conn):
 def test_query_pool(config):
     """Test query using a DB Session Pool for a valid JSON object with geometry"""   # noqa
     # Set ENV Var for creating a session pool
-    os.environ["ORACLE_POOL_MIN"] = "2"     # noqa
-    os.environ["ORACLE_POOL_MAX"] = "10"    # noqa
+    os.environ["ORACLE_POOL_MIN"] = "2"     # noqa: F841
+    os.environ["ORACLE_POOL_MAX"] = "10"    # noqa: F841
     # Create DatabaseConnection config from standard config
     keys = ['data', 'table']
     config_db_conn = {x: config[x] for x in keys}

--- a/tests/test_oracle_provider.py
+++ b/tests/test_oracle_provider.py
@@ -637,16 +637,14 @@ def test_oracle_pool(config_db_conn):
     Test whether an oracle session pool is created when there are
     the required env variables.
     """
-    os.environ["ORACLE_POOL_MIN"] = "2"
-    oracle_pool_min = os.environ.get('ORACLE_POOL_MIN', 2)
-    os.environ["ORACLE_POOL_MAx"] = "10"
-    oracle_pool_max = os.environ.get('ORACLE_POOL_MAX', 10)
+    os.environ["ORACLE_POOL_MIN"] = "2"     # noqa
+    os.environ["ORACLE_POOL_MAx"] = "10"    # noqa
     db_conn = DatabaseConnection(**config_db_conn)
     assert db_conn.pool is not None
 
     if 'ORACLE_POOL_MIN' in os.environ:
         del os.environ["ORACLE_POOL_MIN"]
-    
+
     if 'ORACLE_POOL_MAx' in os.environ:
         del os.environ["ORACLE_POOL_MAx"]
 
@@ -654,13 +652,11 @@ def test_oracle_pool(config_db_conn):
 def test_query_pool(config):
     """Test query using a DB Session Pool for a valid JSON object with geometry"""   # noqa
     # Set ENV Var for creating a session pool
-    os.environ["ORACLE_POOL_MIN"] = "2"
-    oracle_pool_min = os.environ.get('ORACLE_POOL_MIN', 2)
-    os.environ["ORACLE_POOL_MAx"] = "10"
-    oracle_pool_max = os.environ.get('ORACLE_POOL_MAX', 10)
+    os.environ["ORACLE_POOL_MIN"] = "2"     # noqa
+    os.environ["ORACLE_POOL_MAx"] = "10"    # noqa
     # Create DatabaseConnection config from standard config
     keys = ['data', 'table']
-    config_db_conn = {x:config[x] for x in keys}
+    config_db_conn = {x: config[x] for x in keys}
     config_db_conn['conn_dic'] = config_db_conn.pop('data')
     # Create Connection class and check against pool
     db_conn = DatabaseConnection(**config_db_conn)


### PR DESCRIPTION
# Overview
This is an implementation of connection pooling in oracle. It leaves the decision up to the environment, if the variables 
`ORACLE_POOL_MIN` and `ORACLE_POOL_MAX` are found in the environment, a Pool is created with min and max connections according to the variable values. If they are not set, than single connections are used, just like before. 
This should lead to no breaks for current users and is easy to set up. 

Tests and Documentation are added as well.

# Related Issue / discussion
Related to https://github.com/geopython/pygeoapi/issues/1655  
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?
Related to https://github.com/geopython/pygeoapi/issues/1655 

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
