### PR TITLE
update time querying

### DIFF
--- a/pygeoapi/provider/xarray_edr.py
+++ b/pygeoapi/provider/xarray_edr.py
@@ -115,23 +115,18 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
                 data = self._data
 
             if self.time_field in query_params:
-                remaining_query = {
-                    key: val for key, val in query_params.items()
-                    if key != self.time_field
-                }
                 if isinstance(query_params[self.time_field], slice):
+                    remaining_query = {
+                        key: val for key, val in query_params.items()
+                        if key != self.time_field
+                    }
                     time_query = {
                         self.time_field: query_params[self.time_field]
                     }
+                    data = data.sel(
+                        time_query).sel(remaining_query, method='nearest')
                 else:
-                    time_query = {
-                        self.time_field: (
-                                data[self.time_field].dt.date ==
-                                query_params[self.time_field]
-                        )
-                    }
-                data = data.sel(
-                    time_query).sel(remaining_query, method='nearest')
+                    data = data.sel(query_params, method='nearest')
             else:
                 data = data.sel(query_params, method='nearest')
         except KeyError:


### PR DESCRIPTION
# Overview
I was getting a No Data error when requesting a single datetime in EDR. 

# Related Issue / discussion
#1608

# Additional information
Note this will return the **closest** timestep. Would we want to throw a No Data error if there is not an exact match on datetime?

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this bugfix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
