### PR TITLE
Support UUID serialization

### DIFF
--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -38,6 +38,7 @@ import mimetypes
 import os
 import re
 import functools
+import uuid
 from functools import partial
 from dataclasses import dataclass
 from datetime import date, datetime, time
@@ -383,6 +384,8 @@ def json_serial(obj: Any) -> str:
 
     if isinstance(obj, (datetime, date, time)):
         return obj.isoformat()
+    elif isinstance(obj, uuid.UUID):
+        return str(obj)
     elif isinstance(obj, bytes):
         try:
             LOGGER.debug('Returning as UTF-8 decoded bytes')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -33,6 +33,7 @@ from contextlib import nullcontext as does_not_raise
 from copy import deepcopy
 from io import StringIO
 from unittest import mock
+import uuid
 
 import pytest
 from pyproj.exceptions import CRSError
@@ -141,6 +142,9 @@ def test_json_serial():
 
     d = Decimal(1.0)
     assert util.json_serial(d) == 1.0
+
+    d = uuid.UUID('12345678-1234-5678-1234-567812345678')
+    assert util.json_serial(d) == '12345678-1234-5678-1234-567812345678'
 
     with pytest.raises(TypeError):
         util.json_serial('foo')


### PR DESCRIPTION
# Overview

Implements support for UUID in JSON serialization to support Postgres databases with UUID as ID column.

# Related Issue / discussion

No related issue

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
