### PR TITLE
Fix bullet point nesting in docs

### DIFF
--- a/docs/source/data-publishing/ogcapi-coverages.rst
+++ b/docs/source/data-publishing/ogcapi-coverages.rst
@@ -100,23 +100,41 @@ Data access examples
 --------------------
 
 * list all collections
+
   * http://localhost:5000/collections
+  
 * overview of dataset
+
   * http://localhost:5000/collections/foo
+  
 * schema of dataset
+
   * http://localhost:5000/collections/foo/schema
+  
 * coverage access via CoverageJSON (default)
+
   * http://localhost:5000/collections/foo/coverage?f=json
+  
 * coverage access via native format (as defined in ``provider.format.name``)
+
   * http://localhost:5000/collections/foo/coverage?f=GRIB
+  
 * coverage access with comma-separated properties
+
   * http://localhost:5000/collections/foo/coverage?properties=1,3
+  
 * coverage access with subsetting
+
   * http://localhost:5000/collections/foo/coverage?subset=lat(10:20)&subset=long(10:20)
+  
 * coverage with bbox
+
   * http://localhost:5000/collections/foo/coverage?bbox=10,10,20,20
+  
 * coverage with bbox and bbox CRS
+
   * http://localhost:5000/collections/foo/coverage?bbox=-8794239.772668611,5311971.846945471,-8348961.809495518,5621521.486192066&bbox=crs=3857
+  
 
 .. note::
    ``.../coverage`` queries which return an alternative representation to CoverageJSON (which prompt a download)

--- a/docs/source/data-publishing/ogcapi-records.rst
+++ b/docs/source/data-publishing/ogcapi-records.rst
@@ -100,27 +100,49 @@ Metadata search examples
 ------------------------
 
 * overview of record collection
+
   * http://localhost:5000/collections/metadata-records
+  
 * queryables
+
   * http://localhost:5000/collections/foo/queryables
+  
 * browse records
+
   * http://localhost:5000/collections/foo/items
+  
 * paging
+
   * http://localhost:5000/collections/foo/items?offset=10&limit=10
+  
 * CSV outputs
+
   * http://localhost:5000/collections/foo/items?f=csv
+  
 * query records (spatial)
+
   * http://localhost:5000/collections/foo/items?bbox=-180,-90,180,90
+  
 * query records (attribute)
+
   * http://localhost:5000/collections/foo/items?propertyname=foo
+  
 * query records (temporal)
+
   * http://localhost:5000/collections/my-metadata/items?datetime=2020-04-10T14:11:00Z
+  
 * query features (temporal) and sort ascending by a property (if no +/- indicated, + is assumed)
+
   * http://localhost:5000/collections/my-metadata/items?datetime=2020-04-10T14:11:00Z&sortby=datetime
+  
 * query features (temporal) and sort descending by a property
+
   * http://localhost:5000/collections/my-metadata/items?datetime=2020-04-10T14:11:00Z&sortby=-datetime
+  
 * fetch a specific record
+
   * http://localhost:5000/collections/my-metadata/items/123
+  
 
 .. note::
    provider `id_field` values support slashes (i.e. ``my/cool/identifier``). The client request would then

--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -162,15 +162,25 @@ Data access examples
 --------------------
 
 * list all collections
+
   * http://localhost:5000/collections
+  
 * overview of dataset
+
   * http://localhost:5000/collections/foo
+  
 * overview of dataset tiles
+
   * http://localhost:5000/collections/foo/tiles
+  
 * tile matrix metadata
+
   * http://localhost:5000/collections/lakes/tiles/WorldCRS84Quad/metadata
+  
 * tiles URI template
+
   * `http://localhost:5000/collections/lakes/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}?f=mvt <http://localhost:5000/collections/lakes/tiles/{tileMatrixSetId}/{tileMatrix}/{tileRow}/{tileCol}?f=mvt>`_
+  
 
 
 .. _`OGC API - Tiles`: https://github.com/opengeospatial/ogcapi-tiles

--- a/docs/source/data-publishing/stac.rst
+++ b/docs/source/data-publishing/stac.rst
@@ -66,6 +66,7 @@ Data access examples
 --------------------
 
 * STAC root page
+
   * http://localhost:5000/stac
 
 From here, browse the filesystem accordingly.

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -10,15 +10,19 @@ Features
 
 * out of the box modern OGC API server
 * certified OGC Compliant and Reference Implementation
+  
   * OGC API - Features
   * OGC API - Environmental Data Retrieval
   * OGC API - Tiles
+
 * additionally implements
+
   * OGC API - Coverages
   * OGC API - Maps
   * OGC API - Processes
   * OGC API - Records
   * SpatioTemporal Asset Library
+  
 * out of the box data provider plugins for rasterio, GDAL/OGR, Elasticsearch, PostgreSQL/PostGIS
 * easy to use OpenAPI / Swagger documentation for developers
 * supports JSON, GeoJSON, HTML and CSV output


### PR DESCRIPTION
# Overview

The nested lists on the [main page of the documentation site](https://docs.pygeoapi.io/en/stable/introduction.html) (and a few other pages) are not rendering properly. The rst for nested bullet points is not using proper syntax of adding an extra newline before and after the nested level. Thus, the * are rendered inline. For an example see the bottom of the attached image. This commit just adds extra lines to make the docs render properly.

I referenced the rst syntax [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html). 
> Nested lists are possible, but be aware that they must be separated from the parent list items by blank lines:

This commit is relatively trivial but helps improve a11y and styling.

# Dependency policy (RFC2) / Issues

N/A

# Updates to public demo

N/A

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute a docs fix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines

# Before
![image](https://github.com/geopython/pygeoapi/assets/70598503/e193e803-2f82-41d2-9798-aeb275805456)

# After
![image](https://github.com/geopython/pygeoapi/assets/70598503/836faaee-1b9d-4d7f-acad-776d87c36f69)
