### PR TITLE
EDR generic layers UI

### DIFF
--- a/pygeoapi/templates/collections/edr/query.html
+++ b/pygeoapi/templates/collections/edr/query.html
@@ -38,16 +38,18 @@
 
     var layers = L.control.layers(null, null, {collapsed: false}).addTo(map)
 
-    var layer
-    CovJSON.read(JSON.parse('{{ data | to_json | safe }}')).then(function (coverage) {
-      layer = C.dataLayer(coverage, {parameter: 'SST'})
-        .on('afterAdd', function () {
-          C.legend(layer).addTo(map)
-          map.fitBounds(layer.getBounds())
-        })
-        .addTo(map)
-      layers.addOverlay(layer, 'Temperature')
-      map.setZoom(5)
+    CovJSON.read(JSON.parse('{{ data | to_json | safe }}')).then(function (cov) {
+      cov.parameters.forEach((p) => {
+          var layer = C.dataLayer(cov, {parameter: p.key})
+            .on('afterAdd', function () {
+              C.legend(layer).addTo(map)
+              map.fitBounds(layer.getBounds())
+            })
+            .addTo(map)
+          layers.addOverlay(layer, p.observedProperty.label?.en)
+          map.setZoom(5)
+      })
+
     })
 
     map.on('click', function (e) {


### PR DESCRIPTION
default EDR template supports only SST parameter, this change allow to present any property and several at once.

# Overview
default EDR template supports only SST parameter, this change allow to present any property and several at once.


# Related Issue / discussion



# Additional information

it an be considered as fix to enable reference confirguration support not only predefined property.

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
