### PR TITLE
OAProc: test hello-world process evaluation of None and empty dict

### DIFF
--- a/pygeoapi/process/hello_world.py
+++ b/pygeoapi/process/hello_world.py
@@ -130,7 +130,7 @@ class HelloWorldProcessor(BaseProcessor):
         value = f'Hello {name}! {message}'.strip()
 
         produced_outputs = {}
-        if outputs is None or 'echo' in outputs:
+        if not bool(outputs) or 'echo' in outputs:
             produced_outputs = {
                 'id': 'echo',
                 'value': value


### PR DESCRIPTION
# Overview
Given an OAProc execute request can pass an empty object, and that the base process `execute` function defaults to `None`, this PR fixes the sample `hello-world` process to evaluate an output of either `{}` or `None` accordingly.

# Related Issue / discussion
In support of #1639
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
