### PR TITLE
Fix typo in ogcapi-processes.rst

### DIFF
--- a/docs/source/data-publishing/ogcapi-processes.rst
+++ b/docs/source/data-publishing/ogcapi-processes.rst
@@ -9,7 +9,7 @@ fashion (inputs, outputs).
 pygeoapi implements OGC API - Processes functionality by providing a plugin architecture, thereby
 allowing developers to implement custom processing workflows in Python.
 
-The pygeoapi offers two processes: a default ``hello-world`` process which allows you to quickly explore the capabilities of processes, and an optional ``shapely-functions`` process with more advanced features that leverages `Shapely_` to expose various geometric processing functionality.
+The pygeoapi offers two processes: a default ``hello-world`` process which allows you to quickly explore the capabilities of processes, and an optional ``shapely-functions`` process with more advanced features that leverages `Shapely`_ to expose various geometric processing functionality.
 
 Configuration
 -------------


### PR DESCRIPTION
The docs render "Shapely_" instead of linking to the Shapely link defined in the bottom of the rst file. This commit fixes that and properly links to https://shapely.readthedocs.io/ There seems to have been a minor syntax error here.

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to docs to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
