### PR TITLE
use identification.url as about link on landing page

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -714,6 +714,13 @@ class API:
         LOGGER.debug('Creating links')
         # TODO: put title text in config or translatable files?
         fcm['links'] = [{
+            'rel': 'about',
+            'type': 'text/html',
+            'title': l10n.translate(
+                self.config['metadata']['identification']['title'],
+                request.locale),
+            'href': self.config['metadata']['identification']['url']
+        }, {
             'rel': request.get_linkrel(F_JSON),
             'type': FORMAT_TYPES[F_JSON],
             'title': l10n.translate('This document as JSON', request.locale),

--- a/pygeoapi/templates/landing_page.html
+++ b/pygeoapi/templates/landing_page.html
@@ -40,6 +40,15 @@
               </div>
           </div>
         {% endif %}
+          <div class="row">
+              <div class="col-sm-4">
+                {% trans %}URL{% endtrans %}
+              </div>
+              <div class="col-sm-8">
+                  <a href="{{ config['metadata']['identification']['url'] }}">
+                    {{ config['metadata']['identification']['url'] | truncate( 70 ) }}</a>
+              </div>
+          </div>
       </div>
     </div>
   </section>

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -271,8 +271,9 @@ def test_apirules_active(config_with_rules, rules_api):
         assert response.status_code == 200
         assert response.is_json
         links = response.json['links']
+        assert links[0]['rel'] == 'about'
         assert all(
-            href.startswith(base_url) for href in (rel['href'] for rel in links)  # noqa
+            href.startswith(base_url) for href in (rel['href'] for rel in links[1:])  # noqa
         )
 
     # Test Starlette
@@ -303,8 +304,9 @@ def test_apirules_active(config_with_rules, rules_api):
         response = starlette_client.get(starlette_prefix, follow_redirects=True)  # noqa
         assert response.status_code == 200
         links = response.json()['links']
+        assert links[0]['rel'] == 'about'
         assert all(
-            href.startswith(base_url) for href in (rel['href'] for rel in links)  # noqa
+            href.startswith(base_url) for href in (rel['href'] for rel in links[1:])  # noqa
         )
 
 
@@ -510,14 +512,17 @@ def test_root(config, api_):
 
     assert isinstance(root, dict)
     assert 'links' in root
-    assert root['links'][0]['rel'] == 'self'
-    assert root['links'][0]['type'] == FORMAT_TYPES[F_JSON]
-    assert root['links'][0]['href'].endswith('?f=json')
+    assert root['links'][0]['rel'] == 'about'
+    assert root['links'][0]['type'] == 'text/html'
+    assert root['links'][0]['href'] == 'http://example.org'
+    assert root['links'][1]['rel'] == 'self'
+    assert root['links'][1]['type'] == FORMAT_TYPES[F_JSON]
+    assert root['links'][1]['href'].endswith('?f=json')
     assert any(link['href'].endswith('f=jsonld') and link['rel'] == 'alternate'
                for link in root['links'])
     assert any(link['href'].endswith('f=html') and link['rel'] == 'alternate'
                for link in root['links'])
-    assert len(root['links']) == 11
+    assert len(root['links']) == 12
     assert 'title' in root
     assert root['title'] == 'pygeoapi default instance'
     assert 'description' in root


### PR DESCRIPTION
# Overview
Use configuration directive `metadata.identification.url` as an `about` link on the landing page and add to UI.
# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
