### PR TITLE
Update setup.py to restrict python version >= 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,7 @@ setup(
     maintainer='Tom Kralidis',
     maintainer_email='tomkralidis@gmail.com',
     url='https://pygeoapi.io',
+    python_requires='>=3.9',
     install_requires=read('requirements.txt').splitlines(),
     packages=find_packages(exclude=['pygeoapi.tests']),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(
     maintainer='Tom Kralidis',
     maintainer_email='tomkralidis@gmail.com',
     url='https://pygeoapi.io',
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     install_requires=read('requirements.txt').splitlines(),
     packages=find_packages(exclude=['pygeoapi.tests']),
     include_package_data=True,


### PR DESCRIPTION
Release 0.17.0 is incompatible with Python < 3.8

"python_requires" added to only install this version with python >= 3.9

# Overview

# Related Issue / discussion

I with python 3.8 the lastest version (0.17.0) is install but it's incompatible. Restrict this to install v0.16.1 is python < 3.9.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
