### PR TITLE
Use consistent get_field ref in providers

### DIFF
--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -240,15 +240,16 @@ The below template provides a minimal example (let's call the file ``mycoolraste
            super().__init__(provider_def)
            self.num_bands = 4
            self.axes = ['Lat', 'Long']
-           self.fields = self.get_fields()
+           self.get_fields()
 
        def get_fields(self):
            # generate a JSON Schema of coverage band metadata
-           return {
+           self.fields_ = {
                'b1': {
                    'type': 'number'
                }
            }
+           return self.fields_
 
        def query(self, bands=[], subsets={}, format_='json', **kwargs):
            # process bands and subsets parameters

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -244,12 +244,12 @@ The below template provides a minimal example (let's call the file ``mycoolraste
 
        def get_fields(self):
            # generate a JSON Schema of coverage band metadata
-           self.fields_ = {
+           self._fields = {
                'b1': {
                    'type': 'number'
                }
            }
-           return self.fields_
+           return self._fields
 
        def query(self, bands=[], subsets={}, format_='json', **kwargs):
            # process bands and subsets parameters

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -93,15 +93,19 @@ class BaseProvider:
         raise NotImplementedError()
 
     @property
-    def fields(self):
+    def fields(self) -> dict:
         """
         Store provider field information (names, types)
 
-        Example response: {'field1': 'string', 'field2': 'number'}}
+        Example response: {'field1': {'type': 'string'}}
 
-        :returns: dict of field names and their associated JSON Schema types
+        :returns: dict of dicts (field names and their associated JSON Schema definitions)
         """
-        return self.get_fields()
+
+        if hasattr(self, '_fields'):
+            return self._fields
+        else:
+            return self.get_fields()
 
     def get_schema(self, schema_type: SchemaType = SchemaType.item):
         """

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -99,7 +99,8 @@ class BaseProvider:
 
         Example response: {'field1': {'type': 'string'}}
 
-        :returns: dict of dicts (field names and their associated JSON Schema definitions)
+        :returns: dict of dicts (field names and their
+                  associated JSON Schema definitions)
         """
 
         if hasattr(self, '_fields'):

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -73,7 +73,7 @@ class BaseProvider:
         self.title_field = provider_def.get('title_field')
         self.properties = provider_def.get('properties', [])
         self.file_types = provider_def.get('file_types', [])
-        self.fields = {}
+        self.fields_ = {}
         self.filename = None
 
         # for coverage providers
@@ -91,6 +91,17 @@ class BaseProvider:
         """
 
         raise NotImplementedError()
+
+    @property
+    def fields(self):
+        """
+        Store provider field information (names, types)
+
+        Example response: {'field1': 'string', 'field2': 'number'}}
+
+        :returns: dict of field names and their associated JSON Schema types
+        """
+        return self.get_fields()
 
     def get_schema(self, schema_type: SchemaType = SchemaType.item):
         """

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -73,7 +73,7 @@ class BaseProvider:
         self.title_field = provider_def.get('title_field')
         self.properties = provider_def.get('properties', [])
         self.file_types = provider_def.get('file_types', [])
-        self.fields_ = {}
+        self._fields = {}
         self.filename = None
 
         # for coverage providers

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -54,7 +54,7 @@ class CSVProvider(BaseProvider):
         super().__init__(provider_def)
         self.geometry_x = provider_def['geometry']['x_field']
         self.geometry_y = provider_def['geometry']['y_field']
-        self.fields = self.get_fields()
+        self.get_fields()
 
     def get_fields(self):
         """
@@ -62,32 +62,31 @@ class CSVProvider(BaseProvider):
 
         :returns: dict of fields
         """
+        if not self.fields_:
+            LOGGER.debug('Treating all columns as string types')
+            with open(self.data) as ff:
+                LOGGER.debug('Serializing DictReader')
+                data_ = csv.DictReader(ff)
 
-        LOGGER.debug('Treating all columns as string types')
-        with open(self.data) as ff:
-            LOGGER.debug('Serializing DictReader')
-            data_ = csv.DictReader(ff)
-            fields = {}
+                row = next(data_)
 
-            row = next(data_)
+                for key, value in row.items():
+                    LOGGER.debug(f'key: {key}, value: {value}')
+                    value2 = get_typed_value(value)
+                    if key in [self.geometry_x, self.geometry_y]:
+                        continue
+                    if key == self.id_field:
+                        type_ = 'string'
+                    elif isinstance(value2, float):
+                        type_ = 'number'
+                    elif isinstance(value2, int):
+                        type_ = 'integer'
+                    else:
+                        type_ = 'string'
 
-            for key, value in row.items():
-                LOGGER.debug(f'key: {key}, value: {value}')
-                value2 = get_typed_value(value)
-                if key in [self.geometry_x, self.geometry_y]:
-                    continue
-                if key == self.id_field:
-                    type_ = 'string'
-                elif isinstance(value2, float):
-                    type_ = 'number'
-                elif isinstance(value2, int):
-                    type_ = 'integer'
-                else:
-                    type_ = 'string'
+                    self.fields_[key] = {'type': type_}
 
-                fields[key] = {'type': type_}
-
-            return fields
+        return self.fields_
 
     def _load(self, offset=0, limit=10, resulttype='results',
               identifier=None, bbox=[], datetime_=None, properties=[],

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -62,7 +62,7 @@ class CSVProvider(BaseProvider):
 
         :returns: dict of fields
         """
-        if not self.fields_:
+        if not self._fields:
             LOGGER.debug('Treating all columns as string types')
             with open(self.data) as ff:
                 LOGGER.debug('Serializing DictReader')
@@ -84,9 +84,9 @@ class CSVProvider(BaseProvider):
                     else:
                         type_ = 'string'
 
-                    self.fields_[key] = {'type': type_}
+                    self._fields[key] = {'type': type_}
 
-        return self.fields_
+        return self._fields
 
     def _load(self, offset=0, limit=10, resulttype='results',
               identifier=None, bbox=[], datetime_=None, properties=[],

--- a/pygeoapi/provider/csw_facade.py
+++ b/pygeoapi/provider/csw_facade.py
@@ -69,7 +69,7 @@ class CSWFacadeProvider(BaseProvider):
             'language': ('dc:language', 'language')
         }
 
-        self.fields = self.get_fields()
+        self.get_fields()
 
     def get_fields(self):
         """

--- a/pygeoapi/provider/csw_facade.py
+++ b/pygeoapi/provider/csw_facade.py
@@ -69,6 +69,7 @@ class CSWFacadeProvider(BaseProvider):
             'language': ('dc:language', 'language')
         }
 
+        self._fields = {}
         self.get_fields()
 
     def get_fields(self):
@@ -78,17 +79,17 @@ class CSWFacadeProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        fields = {}
-        date_fields = ['date', 'created', 'updated']
+        if not self._fields:
+            date_fields = ['date', 'created', 'updated']
 
-        for key in self.record_mappings.keys():
-            LOGGER.debug(f'key: {key}')
-            fields[key] = {'type': 'string'}
+            for key in self.record_mappings.keys():
+                LOGGER.debug(f'key: {key}')
+                self._fields[key] = {'type': 'string'}
 
-            if key in date_fields:
-                fields[key]['format'] = 'date-time'
+                if key in date_fields:
+                    self._fields[key]['format'] = 'date-time'
 
-        return fields
+        return self._fields
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -87,7 +87,7 @@ class ElasticsearchProvider(BaseProvider):
 
         LOGGER.debug('Grabbing field information')
         try:
-            self.fields = self.get_fields()
+            self.get_fields()
         except exceptions.NotFoundError as err:
             LOGGER.error(err)
             raise ProviderQueryError(err)
@@ -98,38 +98,40 @@ class ElasticsearchProvider(BaseProvider):
 
         :returns: dict of fields
         """
+        if not self.fields_:
+            ii = self.es.indices.get(index=self.index_name,
+                                     allow_no_indices=False)
 
-        fields_ = {}
-        ii = self.es.indices.get(index=self.index_name, allow_no_indices=False)
-
-        LOGGER.debug(f'Response: {ii}')
-        try:
-            if '*' not in self.index_name:
-                p = ii[self.index_name]['mappings']['properties']['properties']
-            else:
-                LOGGER.debug('Wildcard index; setting from first match')
-                index_name_ = list(ii.keys())[0]
-                p = ii[index_name_]['mappings']['properties']['properties']
-        except KeyError:
-            LOGGER.warning('Trying for alias')
-            alias_name = next(iter(ii))
-            p = ii[alias_name]['mappings']['properties']['properties']
-        except IndexError:
-            LOGGER.warning('could not get fields; returning empty set')
-            return {}
-
-        for k, v in p['properties'].items():
-            if 'type' in v:
-                if v['type'] == 'text':
-                    fields_[k] = {'type': 'string'}
-                elif v['type'] == 'date':
-                    fields_[k] = {'type': 'string', 'format': 'date'}
-                elif v['type'] in ('float', 'long'):
-                    fields_[k] = {'type': 'number', 'format': v['type']}
+            LOGGER.debug(f'Response: {ii}')
+            try:
+                if '*' not in self.index_name:
+                    mappings = ii[self.index_name]['mappings']
+                    p = mappings['properties']['properties']
                 else:
-                    fields_[k] = {'type': v['type']}
+                    LOGGER.debug('Wildcard index; setting from first match')
+                    index_name_ = list(ii.keys())[0]
+                    p = ii[index_name_]['mappings']['properties']['properties']
+            except KeyError:
+                LOGGER.warning('Trying for alias')
+                alias_name = next(iter(ii))
+                p = ii[alias_name]['mappings']['properties']['properties']
+            except IndexError:
+                LOGGER.warning('could not get fields; returning empty set')
+                return {}
 
-        return fields_
+            for k, v in p['properties'].items():
+                if 'type' in v:
+                    if v['type'] == 'text':
+                        self.fields_[k] = {'type': 'string'}
+                    elif v['type'] == 'date':
+                        self.fields_[k] = {'type': 'string', 'format': 'date'}
+                    elif v['type'] in ('float', 'long'):
+                        self.fields_[k] = {'type': 'number',
+                                           'format': v['type']}
+                    else:
+                        self.fields_[k] = {'type': v['type']}
+
+        return self.fields_
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -98,7 +98,7 @@ class ElasticsearchProvider(BaseProvider):
 
         :returns: dict of fields
         """
-        if not self.fields_:
+        if not self._fields:
             ii = self.es.indices.get(index=self.index_name,
                                      allow_no_indices=False)
 
@@ -122,16 +122,16 @@ class ElasticsearchProvider(BaseProvider):
             for k, v in p['properties'].items():
                 if 'type' in v:
                     if v['type'] == 'text':
-                        self.fields_[k] = {'type': 'string'}
+                        self._fields[k] = {'type': 'string'}
                     elif v['type'] == 'date':
-                        self.fields_[k] = {'type': 'string', 'format': 'date'}
+                        self._fields[k] = {'type': 'string', 'format': 'date'}
                     elif v['type'] in ('float', 'long'):
-                        self.fields_[k] = {'type': 'number',
+                        self._fields[k] = {'type': 'number',
                                            'format': v['type']}
                     else:
-                        self.fields_[k] = {'type': v['type']}
+                        self._fields[k] = {'type': v['type']}
 
-        return self.fields_
+        return self._fields
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/erddap.py
+++ b/pygeoapi/provider/erddap.py
@@ -65,7 +65,7 @@ class TabledapProvider(BaseProvider):
         self.get_fields()
 
     def get_fields(self):
-        if not self.fields_:
+        if not self._fields:
             LOGGER.debug('Fetching one feature for field definitions')
             properties = self.query(limit=1)['features'][0]['properties']
 
@@ -78,9 +78,9 @@ class TabledapProvider(BaseProvider):
                     data_type = 'string'
                 if data_type == 'float':
                     data_type = 'number'
-            self.fields_[key] = {'type': data_type}
+            self._fields[key] = {'type': data_type}
 
-        return self.fields_
+        return self._fields
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/erddap.py
+++ b/pygeoapi/provider/erddap.py
@@ -62,24 +62,25 @@ class TabledapProvider(BaseProvider):
 
         LOGGER.debug('Setting provider query filters')
         self.filters = self.options.get('filters')
-        self.fields = self.get_fields()
+        self.get_fields()
 
     def get_fields(self):
-        LOGGER.debug('Fetching one feature for field definitions')
-        properties = self.query(limit=1)['features'][0]['properties']
+        if not self.fields_:
+            LOGGER.debug('Fetching one feature for field definitions')
+            properties = self.query(limit=1)['features'][0]['properties']
 
-        for key, value in properties.items():
-            LOGGER.debug(f'Field: {key}={value}')
+            for key, value in properties.items():
+                LOGGER.debug(f'Field: {key}={value}')
 
-            data_type = type(value).__name__
+                data_type = type(value).__name__
 
-            if data_type == 'str':
-                data_type = 'string'
-            if data_type == 'float':
-                data_type = 'number'
-            properties[key] = {'type': data_type}
+                if data_type == 'str':
+                    data_type = 'string'
+                if data_type == 'float':
+                    data_type = 'number'
+            self.fields_[key] = {'type': data_type}
 
-        return properties
+        return self.fields_
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/esri.py
+++ b/pygeoapi/provider/esri.py
@@ -76,7 +76,7 @@ class ESRIServiceProvider(BaseProvider):
         :returns: `dict` of fields
         """
 
-        if not self.fields:
+        if not self.fields_:
             # Load fields
             params = {'f': 'pjson'}
             resp = self.get_response(self.data, params=params)
@@ -102,9 +102,9 @@ class ESRIServiceProvider(BaseProvider):
                 raise ProviderTypeError(msg)
 
             for _ in resp['fields']:
-                self.fields.update({_['name']: {'type': _['type']}})
+                self.fields_.update({_['name']: {'type': _['type']}})
 
-        return self.fields
+        return self.fields_
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/esri.py
+++ b/pygeoapi/provider/esri.py
@@ -76,7 +76,7 @@ class ESRIServiceProvider(BaseProvider):
         :returns: `dict` of fields
         """
 
-        if not self.fields_:
+        if not self._fields:
             # Load fields
             params = {'f': 'pjson'}
             resp = self.get_response(self.data, params=params)
@@ -102,9 +102,9 @@ class ESRIServiceProvider(BaseProvider):
                 raise ProviderTypeError(msg)
 
             for _ in resp['fields']:
-                self.fields_.update({_['name']: {'type': _['type']}})
+                self._fields.update({_['name']: {'type': _['type']}})
 
-        return self.fields_
+        return self._fields
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -68,7 +68,7 @@ class GeoJSONProvider(BaseProvider):
         """initializer"""
 
         super().__init__(provider_def)
-        self.fields = self.get_fields()
+        self.get_fields()
 
     def get_fields(self):
         """
@@ -77,23 +77,24 @@ class GeoJSONProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        fields = {}
-        LOGGER.debug('Treating all columns as string types')
-        if os.path.exists(self.data):
-            with open(self.data) as src:
-                data = json.loads(src.read())
-            for key, value in data['features'][0]['properties'].items():
-                if isinstance(value, float):
-                    type_ = 'number'
-                elif isinstance(value, int):
-                    type_ = 'integer'
-                else:
-                    type_ = 'string'
+        if not self.fields_:
+            LOGGER.debug('Treating all columns as string types')
+            if os.path.exists(self.data):
+                with open(self.data) as src:
+                    data = json.loads(src.read())
+                for key, value in data['features'][0]['properties'].items():
+                    if isinstance(value, float):
+                        type_ = 'number'
+                    elif isinstance(value, int):
+                        type_ = 'integer'
+                    else:
+                        type_ = 'string'
 
-                fields[key] = {'type': type_}
-        else:
-            LOGGER.warning(f'File {self.data} does not exist.')
-        return fields
+                    self.fields_[key] = {'type': type_}
+            else:
+                LOGGER.warning(f'File {self.data} does not exist.')
+
+        return self.fields_
 
     def _load(self, skip_geometry=None, properties=[], select_properties=[]):
         """Load and validate the source GeoJSON file

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -77,7 +77,7 @@ class GeoJSONProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        if not self.fields_:
+        if not self._fields:
             LOGGER.debug('Treating all columns as string types')
             if os.path.exists(self.data):
                 with open(self.data) as src:
@@ -90,11 +90,11 @@ class GeoJSONProvider(BaseProvider):
                     else:
                         type_ = 'string'
 
-                    self.fields_[key] = {'type': type_}
+                    self._fields[key] = {'type': type_}
             else:
                 LOGGER.warning(f'File {self.data} does not exist.')
 
-        return self.fields_
+        return self._fields
 
     def _load(self, skip_geometry=None, properties=[], select_properties=[]):
         """Load and validate the source GeoJSON file

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -66,7 +66,7 @@ class MongoProvider(BaseProvider):
         self.featuredb = dbclient.get_default_database()
         self.collection = provider_def['collection']
         self.featuredb[self.collection].create_index([("geometry", GEOSPHERE)])
-        self.fields = self.get_fields()
+        self.get_fields()
 
     def get_fields(self):
         """
@@ -75,25 +75,24 @@ class MongoProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        pipeline = [
-            {"$project": {"properties": 1}},
-            {"$unwind": "$properties"},
-            {"$group": {"_id": "$properties", "count": {"$sum": 1}}},
-            {"$project": {"_id": 1}}
-        ]
+        if not self.fields_:
+            pipeline = [
+                {"$project": {"properties": 1}},
+                {"$unwind": "$properties"},
+                {"$group": {"_id": "$properties", "count": {"$sum": 1}}},
+                {"$project": {"_id": 1}}
+            ]
 
-        result = list(self.featuredb[self.collection].aggregate(pipeline))
+            result = list(self.featuredb[self.collection].aggregate(pipeline))
 
-        # prepare a dictionary with fields
-        # set the field type to 'string'.
-        # by operating without a schema, mongo can query any data type.
-        fields = {}
+            # prepare a dictionary with fields
+            # set the field type to 'string'.
+            # by operating without a schema, mongo can query any data type.
+            for i in result:
+                for key in result[0]['_id'].keys():
+                    self.fields_[key] = {'type': 'string'}
 
-        for i in result:
-            for key in result[0]['_id'].keys():
-                fields[key] = {'type': 'string'}
-
-        return fields
+        return self.fields_
 
     def _get_feature_list(self, filterObj, sortList=[], skip=0, maxitems=1,
                           skip_geometry=False):

--- a/pygeoapi/provider/mongo.py
+++ b/pygeoapi/provider/mongo.py
@@ -75,7 +75,7 @@ class MongoProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        if not self.fields_:
+        if not self._fields:
             pipeline = [
                 {"$project": {"properties": 1}},
                 {"$unwind": "$properties"},
@@ -90,9 +90,9 @@ class MongoProvider(BaseProvider):
             # by operating without a schema, mongo can query any data type.
             for i in result:
                 for key in result[0]['_id'].keys():
-                    self.fields_[key] = {'type': 'string'}
+                    self._fields[key] = {'type': 'string'}
 
-        return self.fields_
+        return self._fields
 
     def _get_feature_list(self, filterObj, sortList=[], skip=0, maxitems=1,
                           skip_geometry=False):

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -285,7 +285,7 @@ class OGRProvider(BaseProvider):
                         }
 
                     # fieldWidth = layer_defn.GetFieldDefn(fld).GetWidth()
-                    # GetPrecision = layer_defn.GetFieldDefn(fld).GetPrecision()
+                    # GetPrecision = layer_defn.GetFieldDefn(fld).GetPrecision() # noqa
 
             except RuntimeError as err:
                 LOGGER.error(err)

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -188,7 +188,7 @@ class OGRProvider(BaseProvider):
         self.conn = None
 
         LOGGER.debug('Grabbing field information')
-        self.fields = self.get_fields()
+        self.get_fields()
 
     def _list_open_options(self):
         return [
@@ -260,43 +260,43 @@ class OGRProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        fields = {}
-        try:
-            layer_defn = self._get_layer().GetLayerDefn()
-            for fld in range(layer_defn.GetFieldCount()):
-                field_defn = layer_defn.GetFieldDefn(fld)
-                fieldName = field_defn.GetName()
-                fieldTypeCode = field_defn.GetType()
-                fieldType = field_defn.GetFieldTypeName(fieldTypeCode)
+        if not self.fields_:
+            try:
+                layer_defn = self._get_layer().GetLayerDefn()
+                for fld in range(layer_defn.GetFieldCount()):
+                    field_defn = layer_defn.GetFieldDefn(fld)
+                    fieldName = field_defn.GetName()
+                    fieldTypeCode = field_defn.GetType()
+                    fieldType = field_defn.GetFieldTypeName(fieldTypeCode)
 
-                fieldName2 = fieldType.lower()
+                    fieldName2 = fieldType.lower()
 
-                if fieldName2 == 'integer64':
-                    fieldName2 = 'integer'
-                elif fieldName2 == 'real':
-                    fieldName2 = 'number'
+                    if fieldName2 == 'integer64':
+                        fieldName2 = 'integer'
+                    elif fieldName2 == 'real':
+                        fieldName2 = 'number'
 
-                fields[fieldName] = {'type': fieldName2}
+                    self.fields_[fieldName] = {'type': fieldName2}
 
-                if fieldName2 == 'datetime':
-                    fields[fieldName] = {
-                        'type': 'string',
-                        'format': 'date-time'
-                    }
+                    if fieldName2 == 'datetime':
+                        self.fields_[fieldName] = {
+                            'type': 'string',
+                            'format': 'date-time'
+                        }
 
-                # fieldWidth = layer_defn.GetFieldDefn(fld).GetWidth()
-                # GetPrecision = layer_defn.GetFieldDefn(fld).GetPrecision()
+                    # fieldWidth = layer_defn.GetFieldDefn(fld).GetWidth()
+                    # GetPrecision = layer_defn.GetFieldDefn(fld).GetPrecision()
 
-        except RuntimeError as err:
-            LOGGER.error(err)
-            raise ProviderConnectionError(err)
-        except Exception as err:
-            LOGGER.error(err)
+            except RuntimeError as err:
+                LOGGER.error(err)
+                raise ProviderConnectionError(err)
+            except Exception as err:
+                LOGGER.error(err)
 
-        finally:
-            self._close()
+            finally:
+                self._close()
 
-        return fields
+        return self.fields_
 
     def query(self, offset=0, limit=10, resulttype='results',
               bbox=[], datetime_=None, properties=[], sortby=[],

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -260,7 +260,7 @@ class OGRProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        if not self.fields_:
+        if not self._fields:
             try:
                 layer_defn = self._get_layer().GetLayerDefn()
                 for fld in range(layer_defn.GetFieldCount()):
@@ -276,10 +276,10 @@ class OGRProvider(BaseProvider):
                     elif fieldName2 == 'real':
                         fieldName2 = 'number'
 
-                    self.fields_[fieldName] = {'type': fieldName2}
+                    self._fields[fieldName] = {'type': fieldName2}
 
                     if fieldName2 == 'datetime':
-                        self.fields_[fieldName] = {
+                        self._fields[fieldName] = {
                             'type': 'string',
                             'format': 'date-time'
                         }
@@ -296,7 +296,7 @@ class OGRProvider(BaseProvider):
             finally:
                 self._close()
 
-        return self.fields_
+        return self._fields
 
     def query(self, offset=0, limit=10, resulttype='results',
               bbox=[], datetime_=None, properties=[], sortby=[],

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -435,12 +435,12 @@ class OracleProvider(BaseProvider):
         """
         LOGGER.debug("Get available fields/properties")
 
-        if not self.fields_:
+        if not self._fields:
             with DatabaseConnection(
                 self.conn_dic, self.table, properties=self.properties
             ) as db:
-                self.fields_ = db.fields
-        return self.fields_
+                self._fields = db.fields
+        return self._fields
 
     def _get_where_clauses(
         self,

--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -435,12 +435,12 @@ class OracleProvider(BaseProvider):
         """
         LOGGER.debug("Get available fields/properties")
 
-        if not self.fields:
+        if not self.fields_:
             with DatabaseConnection(
                 self.conn_dic, self.table, properties=self.properties
             ) as db:
-                self.fields = db.fields
-        return self.fields
+                self.fields_ = db.fields
+        return self.fields_
 
     def _get_where_clauses(
         self,

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -246,7 +246,7 @@ class PostgreSQLProvider(BaseProvider):
                 LOGGER.debug('No string format detected')
                 return None
 
-        if not self.fields_
+        if not self.fields:
             for column in self.table_model.__table__.columns:
                 LOGGER.debug(f'Testing {column.name}')
                 if column.name == self.geom:

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -246,7 +246,7 @@ class PostgreSQLProvider(BaseProvider):
                 LOGGER.debug('No string format detected')
                 return None
 
-        if not self.fields:
+        if not self.fields_:
             for column in self.table_model.__table__.columns:
                 LOGGER.debug(f'Testing {column.name}')
                 if column.name == self.geom:

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -246,18 +246,18 @@ class PostgreSQLProvider(BaseProvider):
                 LOGGER.debug('No string format detected')
                 return None
 
-        if not self.fields_:
+        if not self._fields:
             for column in self.table_model.__table__.columns:
                 LOGGER.debug(f'Testing {column.name}')
                 if column.name == self.geom:
                     continue
 
-                self.fields_[str(column.name)] = {
+                self._fields[str(column.name)] = {
                     'type': _column_type_to_json_schema_type(column.type),
                     'format': _column_format_to_json_schema_format(column.type)
                 }
 
-        return self.fields_
+        return self._fields
 
     def get(self, identifier, crs_transform_spec=None, **kwargs):
         """

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -124,7 +124,7 @@ class PostgreSQLProvider(BaseProvider):
         )
 
         LOGGER.debug(f'DB connection: {repr(self._engine.url)}')
-        self.fields = self.get_fields()
+        self.get_fields()
 
     def query(self, offset=0, limit=10, resulttype='results',
               bbox=[], datetime_=None, properties=[], sortby=[],
@@ -204,8 +204,6 @@ class PostgreSQLProvider(BaseProvider):
 
         LOGGER.debug('Get available fields/properties')
 
-        fields = {}
-
         # sql-schema only allows these types, so we need to map from sqlalchemy
         # string, number, integer, object, array, boolean, null,
         # https://json-schema.org/understanding-json-schema/reference/type.html
@@ -248,17 +246,18 @@ class PostgreSQLProvider(BaseProvider):
                 LOGGER.debug('No string format detected')
                 return None
 
-        for column in self.table_model.__table__.columns:
-            LOGGER.debug(f'Testing {column.name}')
-            if column.name == self.geom:
-                continue
+        if not self.fields_
+            for column in self.table_model.__table__.columns:
+                LOGGER.debug(f'Testing {column.name}')
+                if column.name == self.geom:
+                    continue
 
-            fields[str(column.name)] = {
-                'type': _column_type_to_json_schema_type(column.type),
-                'format': _column_format_to_json_schema_format(column.type)
-            }
+                self.fields_[str(column.name)] = {
+                    'type': _column_type_to_json_schema_type(column.type),
+                    'format': _column_format_to_json_schema_format(column.type)
+                }
 
-        return fields
+        return self.fields_
 
     def get(self, identifier, crs_transform_spec=None, **kwargs):
         """

--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -59,38 +59,37 @@ class RasterioProvider(BaseProvider):
             self.axes = self._coverage_properties['axes']
             self.crs = self._coverage_properties['bbox_crs']
             self.num_bands = self._coverage_properties['num_bands']
-            self.fields = self.get_fields()
+            self.get_fields()
             self.native_format = provider_def['format']['name']
         except Exception as err:
             LOGGER.warning(err)
             raise ProviderConnectionError(err)
 
     def get_fields(self):
-        fields = {}
+        if not self.fields_:
+            for i, dtype in zip(self._data.indexes, self._data.dtypes):
+                LOGGER.debug(f'Adding field for band {i}')
+                i2 = str(i)
 
-        for i, dtype in zip(self._data.indexes, self._data.dtypes):
-            LOGGER.debug(f'Adding field for band {i}')
-            i2 = str(i)
+                parameter = _get_parameter_metadata(
+                    self._data.profile['driver'], self._data.tags(i))
 
-            parameter = _get_parameter_metadata(
-                self._data.profile['driver'], self._data.tags(i))
+                name = parameter['description']
+                units = parameter.get('unit_label')
 
-            name = parameter['description']
-            units = parameter.get('unit_label')
+                dtype2 = dtype
+                if dtype.startswith('float'):
+                    dtype2 = 'number'
 
-            dtype2 = dtype
-            if dtype.startswith('float'):
-                dtype2 = 'number'
+                self.fields_[i2] = {
+                    'title': name,
+                    'type': dtype2,
+                    '_meta': self._data.tags(i)
+                }
+                if units is not None:
+                    self.fields_[i2]['x-ogc-unit'] = units
 
-            fields[i2] = {
-                'title': name,
-                'type': dtype2,
-                '_meta': self._data.tags(i)
-            }
-            if units is not None:
-                fields[i2]['x-ogc-unit'] = units
-
-        return fields
+        return self.fields_
 
     def query(self, properties=[], subsets={}, bbox=None, bbox_crs=4326,
               datetime_=None, format_='json', **kwargs):

--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -66,7 +66,7 @@ class RasterioProvider(BaseProvider):
             raise ProviderConnectionError(err)
 
     def get_fields(self):
-        if not self.fields_:
+        if not self._fields:
             for i, dtype in zip(self._data.indexes, self._data.dtypes):
                 LOGGER.debug(f'Adding field for band {i}')
                 i2 = str(i)
@@ -81,15 +81,15 @@ class RasterioProvider(BaseProvider):
                 if dtype.startswith('float'):
                     dtype2 = 'number'
 
-                self.fields_[i2] = {
+                self._fields[i2] = {
                     'title': name,
                     'type': dtype2,
                     '_meta': self._data.tags(i)
                 }
                 if units is not None:
-                    self.fields_[i2]['x-ogc-unit'] = units
+                    self._fields[i2]['x-ogc-unit'] = units
 
-        return self.fields_
+        return self._fields
 
     def query(self, properties=[], subsets={}, bbox=None, bbox_crs=4326,
               datetime_=None, format_='json', **kwargs):

--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -150,7 +150,7 @@ class SensorThingsProvider(BaseProvider):
 
         :returns: dict of fields
         """
-        if not self.fields_:
+        if not self._fields:
             r = self._get_response(self._url, {'$top': 1})
             try:
                 results = r['value'][0]
@@ -161,11 +161,11 @@ class SensorThingsProvider(BaseProvider):
             for (n, v) in results.items():
                 if isinstance(v, (int, float)) or \
                    (isinstance(v, (dict, list)) and n in ENTITY):
-                    self.fields_[n] = {'type': 'number'}
+                    self._fields[n] = {'type': 'number'}
                 elif isinstance(v, str):
-                    self.fields_[n] = {'type': 'string'}
+                    self._fields[n] = {'type': 'string'}
 
-        return self.fields_
+        return self._fields
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -150,7 +150,7 @@ class SensorThingsProvider(BaseProvider):
 
         :returns: dict of fields
         """
-        if not self.fields:
+        if not self.fields_:
             r = self._get_response(self._url, {'$top': 1})
             try:
                 results = r['value'][0]
@@ -161,11 +161,11 @@ class SensorThingsProvider(BaseProvider):
             for (n, v) in results.items():
                 if isinstance(v, (int, float)) or \
                    (isinstance(v, (dict, list)) and n in ENTITY):
-                    self.fields[n] = {'type': 'number'}
+                    self.fields_[n] = {'type': 'number'}
                 elif isinstance(v, str):
-                    self.fields[n] = {'type': 'string'}
+                    self.fields_[n] = {'type': 'string'}
 
-        return self.fields
+        return self.fields_
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/socrata.py
+++ b/pygeoapi/provider/socrata.py
@@ -75,7 +75,7 @@ class SODAServiceProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        if not self.fields:
+        if not self.fields_:
 
             try:
                 [dataset] = self.client.datasets(ids=[self.resource_id])
@@ -87,9 +87,9 @@ class SODAServiceProvider(BaseProvider):
             fields = self.properties or resource[FIELD_NAME]
             for field in fields:
                 idx = resource[FIELD_NAME].index(field)
-                self.fields[field] = {'type': resource[DATA_TYPE][idx]}
+                self.fields_[field] = {'type': resource[DATA_TYPE][idx]}
 
-        return self.fields
+        return self.fields_
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/socrata.py
+++ b/pygeoapi/provider/socrata.py
@@ -75,7 +75,7 @@ class SODAServiceProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        if not self.fields_:
+        if not self._fields:
 
             try:
                 [dataset] = self.client.datasets(ids=[self.resource_id])
@@ -87,9 +87,9 @@ class SODAServiceProvider(BaseProvider):
             fields = self.properties or resource[FIELD_NAME]
             for field in fields:
                 idx = resource[FIELD_NAME].index(field)
-                self.fields_[field] = {'type': resource[DATA_TYPE][idx]}
+                self._fields[field] = {'type': resource[DATA_TYPE][idx]}
 
-        return self.fields_
+        return self._fields
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -88,7 +88,7 @@ class SQLiteGPKGProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        if not self.fields:
+        if not self.fields_:
             results = self.cursor.execute(
                 f'PRAGMA table_info({self.table})').fetchall()
             for item in results:
@@ -102,7 +102,7 @@ class SQLiteGPKGProvider(BaseProvider):
                 if json_type is not None:
                     self.fields[item['name']] = {'type': json_type}
 
-        return self.fields
+        return self.fields_
 
     def __get_where_clauses(self, properties=[], bbox=[]):
         """

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -100,7 +100,7 @@ class SQLiteGPKGProvider(BaseProvider):
                     json_type = 'string'
 
                 if json_type is not None:
-                    self.fields[item['name']] = {'type': json_type}
+                    self.fields_[item['name']] = {'type': json_type}
 
         return self.fields_
 

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -88,7 +88,7 @@ class SQLiteGPKGProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        if not self.fields_:
+        if not self._fields:
             results = self.cursor.execute(
                 f'PRAGMA table_info({self.table})').fetchall()
             for item in results:
@@ -100,9 +100,9 @@ class SQLiteGPKGProvider(BaseProvider):
                     json_type = 'string'
 
                 if json_type is not None:
-                    self.fields_[item['name']] = {'type': json_type}
+                    self._fields[item['name']] = {'type': json_type}
 
-        return self.fields_
+        return self._fields
 
     def __get_where_clauses(self, properties=[], bbox=[]):
         """

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -348,7 +348,10 @@ class TinyDBCatalogueProvider(TinyDBProvider):
     def __init__(self, provider_def):
         super().__init__(provider_def)
 
+        LOGGER.debug('Refreshing fields')
         self._excludes = ['_metadata-anytext']
+        self.fields_ = {}
+        self.get_fields()
 
     def get_fields(self):
         fields = super().get_fields()

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -83,7 +83,7 @@ class TinyDBProvider(BaseProvider):
         :returns: dict of fields
         """
 
-        if not self.fields_:
+        if not self._fields:
             try:
                 r = self.db.all()[0]
             except IndexError as err:
@@ -100,20 +100,20 @@ class TinyDBProvider(BaseProvider):
                     else:
                         typed_value_type = 'string'
 
-                    self.fields_[key] = {'type': typed_value_type}
+                    self._fields[key] = {'type': typed_value_type}
 
                     try:
                         LOGGER.debug('Attempting to detect date types')
                         _ = parse_date(value)
                         if len(value) > 11:
-                            self.fields_[key]['format'] = 'date-time'
+                            self._fields[key]['format'] = 'date-time'
                         else:
-                            self.fields_[key]['format'] = 'date'
+                            self._fields[key]['format'] = 'date'
                     except Exception:
                         LOGGER.debug('No date types detected')
                         pass
 
-        return self.fields_
+        return self._fields
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',
@@ -350,7 +350,7 @@ class TinyDBCatalogueProvider(TinyDBProvider):
 
         LOGGER.debug('Refreshing fields')
         self._excludes = ['_metadata-anytext']
-        self.fields_ = {}
+        self._fields = {}
         self.get_fields()
 
     def get_fields(self):

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -90,10 +90,6 @@ class TinyDBProvider(BaseProvider):
                 LOGGER.debug(err)
                 return {}
 
-            for p in r['properties'].keys():
-                if p not in self.excludes:
-                    self.fields_[p] = {'type': 'string'}
-
             for key, value in r['properties'].items():
                 if key not in self._excludes:
                     typed_value = get_typed_value(str(value))

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -88,28 +88,27 @@ class XarrayProvider(BaseProvider):
                          self._coverage_properties['y_axis_label'],
                          self._coverage_properties['time_axis_label']]
 
-            self.fields = self.get_fields()
+            self.get_fields()
         except Exception as err:
             LOGGER.warning(err)
             raise ProviderConnectionError(err)
 
     def get_fields(self):
-        fields = {}
+        if not self.fields_:
+            for key, value in self._data.variables.items():
+                if len(value.shape) >= 3:
+                    LOGGER.debug('Adding variable')
+                    dtype = value.dtype
+                    if dtype.name.startswith('float'):
+                        dtype = 'number'
 
-        for key, value in self._data.variables.items():
-            if len(value.shape) >= 3:
-                LOGGER.debug('Adding variable')
-                dtype = value.dtype
-                if dtype.name.startswith('float'):
-                    dtype = 'number'
+                    self.fields_[key] = {
+                        'type': dtype,
+                        'title': value.attrs['long_name'],
+                        'x-ogc-unit': value.attrs.get('units')
+                    }
 
-                fields[key] = {
-                    'type': dtype,
-                    'title': value.attrs['long_name'],
-                    'x-ogc-unit': value.attrs.get('units')
-                }
-
-        return fields
+        return self.fields_
 
     def query(self, properties=[], subsets={}, bbox=[], bbox_crs=4326,
               datetime_=None, format_='json', **kwargs):

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -94,7 +94,7 @@ class XarrayProvider(BaseProvider):
             raise ProviderConnectionError(err)
 
     def get_fields(self):
-        if not self.fields_:
+        if not self._fields:
             for key, value in self._data.variables.items():
                 if len(value.shape) >= 3:
                     LOGGER.debug('Adding variable')
@@ -102,13 +102,13 @@ class XarrayProvider(BaseProvider):
                     if dtype.name.startswith('float'):
                         dtype = 'number'
 
-                    self.fields_[key] = {
+                    self._fields[key] = {
                         'type': dtype,
                         'title': value.attrs['long_name'],
                         'x-ogc-unit': value.attrs.get('units')
                     }
 
-        return self.fields_
+        return self._fields
 
     def query(self, properties=[], subsets={}, bbox=[], bbox_crs=4326,
               datetime_=None, format_='json', **kwargs):

--- a/pygeoapi/provider/xarray_edr.py
+++ b/pygeoapi/provider/xarray_edr.py
@@ -109,7 +109,7 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
 
         try:
             if select_properties:
-                self.fields = {k: v for k, v in self.fields.items() if k in select_properties}  # noqa
+                self.fields_ = {k: v for k, v in self.fields_.items() if k in select_properties}  # noqa
                 data = self._data[[*select_properties]]
             else:
                 data = self._data
@@ -206,7 +206,7 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
         LOGGER.debug(f'query parameters: {query_params}')
         try:
             if select_properties:
-                self.fields = {k: v for k, v in self.fields.items() if k in select_properties}  # noqa
+                self.fields_ = {k: v for k, v in self.fields_.items() if k in select_properties}  # noqa
                 data = self._data[[*select_properties]]
             else:
                 data = self._data

--- a/pygeoapi/provider/xarray_edr.py
+++ b/pygeoapi/provider/xarray_edr.py
@@ -109,7 +109,7 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
 
         try:
             if select_properties:
-                self.fields_ = {k: v for k, v in self.fields_.items() if k in select_properties}  # noqa
+                self._fields = {k: v for k, v in self._fields.items() if k in select_properties}  # noqa
                 data = self._data[[*select_properties]]
             else:
                 data = self._data
@@ -206,7 +206,7 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
         LOGGER.debug(f'query parameters: {query_params}')
         try:
             if select_properties:
-                self.fields_ = {k: v for k, v in self.fields_.items() if k in select_properties}  # noqa
+                self._fields = {k: v for k, v in self._fields.items() if k in select_properties}  # noqa
                 data = self._data[[*select_properties]]
             else:
                 data = self._data


### PR DESCRIPTION
# Overview
Use consistent method to fetch fields across providers. Of note, providers fields are always queried using the `p.get_fields()` method and not the `p.fields` property


# Related Issue / discussion
As discussed in https://github.com/geopython/pygeoapi/pull/1724
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
