### PR TITLE
Allow setting docker repository via repository secret

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -12,7 +12,7 @@ on:
     branches: [master]
     
 env:
-  DOCKER_REPOSITORY: geopython/pygeoapi
+  DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY || 'geopython/pygeoapi' }}
 #  DOCKER_TEST_IMAGE: geopython/pygeoapi:test
 
 jobs:


### PR DESCRIPTION
# Overview
Allows setting the docker repository location via repository secret during GitHub Actions build of containers. Pretty confident we have disabled this workflow and it is now staged on Dockerhub. By doing so we are no longer publishing multi-arch images

# Related Issue / discussion
Addresses https://github.com/geopython/pygeoapi/issues/1320
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
