### PR TITLE
Fix for Starlette CORS

### DIFF
--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -742,7 +742,7 @@ if API_RULES.strict_slashes:
 # CORS: optionally enable from config.
 if CONFIG['server'].get('cors', False):
     from starlette.middleware.cors import CORSMiddleware
-    APP.add_middleware(CORSMiddleware, allow_origins=['*'])
+    APP.add_middleware(CORSMiddleware, allow_origins=['*'], allow_methods=['*'])
 
 try:
     OGC_SCHEMAS_LOCATION = Path(CONFIG['server']['ogc_schemas_location'])


### PR DESCRIPTION
The Starlette app with setting cors=true enables all origins, but only permits requests with the GET method. The CORSMiddleware for Starlette requires specifying `allow_methods=['*']` to enable all common request methods.

# Overview
This PR addresses issue #1740. The [Starlette CORSMiddleware](https://www.starlette.io/middleware/#corsmiddleware) with default settings only allows GET requests. To provide access to all standard methods, the `allow_methods=['*']` kwarg must be set. The PR sets that kwarg.

# Related Issue / discussion
#1740 

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
