### PR TITLE
Render covjson or geojson in EDR HTML view

### DIFF
--- a/pygeoapi/templates/collections/edr/query.html
+++ b/pygeoapi/templates/collections/edr/query.html
@@ -14,9 +14,15 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/leaflet-coverage@0.7/leaflet-coverage.css">
     <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+    {% if data.type == "Coverage" or data.type == "CoverageCollection" %}
     <script src="https://unpkg.com/covutils@0.6/covutils.min.js"></script>
     <script src="https://unpkg.com/covjson-reader@0.16/covjson-reader.src.js"></script>
     <script src="https://unpkg.com/leaflet-coverage@0.7/leaflet-coverage.min.js"></script>
+    {% elif data.type == "Feature" or data.type == "FeatureCollection" %}
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.css"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster/dist/MarkerCluster.Default.css"/>
+    <script src="https://unpkg.com/leaflet.markercluster/dist/leaflet.markercluster-src.js"></script>
+    {% endif %}
 {% endblock %}
 
 {% block body %}
@@ -36,6 +42,7 @@
         }
     ));
 
+    {% if data.type == "Coverage" or data.type == "CoverageCollection" %}
     var layers = L.control.layers(null, null, {collapsed: false}).addTo(map)
 
     CovJSON.read(JSON.parse('{{ data | to_json | safe }}')).then(function (cov) {
@@ -57,7 +64,28 @@
         layers: [layer]
       }).setLatLng(e.latlng).openOn(map)
     })
+    {% elif data.type == "Feature" or data.type == "FeatureCollection" %}
+    var geojson_data = {{ data | to_json | safe }};
 
+    var items = new L.GeoJSON(geojson_data, {
+        onEachFeature: function (feature, layer) {
+            var html = '<span>' + {% if data['title_field'] %} feature['properties']['{{ data['title_field'] }}'] {% else %} feature.id {% endif %} + '</span>';
+            layer.bindPopup(html);
+        }
+    });
+    {% if data.type == "FeatureCollection" and data['features'][0]['geometry']['type'] == 'Point' %}
+    var markers = L.markerClusterGroup({
+        disableClusteringAtZoom: 9,
+        chunkedLoading: true,
+        chunkInterval: 500,
+    });
+    markers.clearLayers().addLayer(items);
+    map.addLayer(markers);
+    {% else %}
+    map.addLayer(items);
+    {% endif %}
+    map.fitBounds(items.getBounds(), {maxZoom: 15});
+    {% endif %}
 </script>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
# Overview
Per [B.10.1.9](https://docs.ogc.org/is/19-086r6/19-086r6.html#_74cf71ab-04dd-4e00-94d7-c9777cdc4135), geoJSON shall be returned for some EDR responses. This pull request enables an HTML view of either covJSON or geoJSON depending on the type of json returned.

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/1748
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
`/locations` is similar to `items` but instead allows parameter-first searching. i.e. 
<img width="1338" alt="image" src="https://github.com/user-attachments/assets/96f2bbc0-e140-495b-8abd-8762b34230d3">

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
