### PR TITLE
OAProc: handle binary data when response: document (#1285)

### DIFF
--- a/docs/source/data-publishing/ogcapi-processes.rst
+++ b/docs/source/data-publishing/ogcapi-processes.rst
@@ -14,6 +14,8 @@ The pygeoapi offers two processes: a default ``hello-world`` process which allow
 Configuration
 -------------
 
+The below configuration is an example of a process defined within the pygeoapi internal plugin registry:
+
 .. code-block:: yaml
 
    processes:
@@ -22,6 +24,38 @@ Configuration
        hello-world:
            processor:
                name: HelloWorld
+
+The below configuration is an example of a process defined as part of cusotm Python process:
+
+.. code-block:: yaml
+
+   processes:
+   
+    # enabled by default
+       hello-world:
+           processor:
+               # refer to a process in the standard PYTHONPATH
+               # e.g. my_package/my_module/my_file.py (class MyProcess)
+               # the MyProcess class must subclass from pygeoapi.process.base.BaseProcessor
+               name: my_package.my_module.my_file.MyProcess
+
+See :ref:`example-custom-pygeoapi-processing-plugin` for processing plugin examples
+
+Processing and response handling
+--------------------------------
+
+pygeoapi processing plugins are required to return a tuple of media type and native outputs.  Multipart
+responses are not supported at this time, and it is up to the process plugin implementor to return a single
+payload defining multiple artifacts (or references to them).
+
+By default (or via the OGC API - Processes ``response: raw`` execution parameter), pygeoapi provides
+processing responses in their native encoding and media type, as defined by a given
+plugin (which needs to set the response content type and payload accordingly).
+
+pygeoapi also supports a JSON-based response type (via the OGC API - Processes ``response: document``
+execution parameter).  When this mode is requested, the response will always be a JSON encoding embedding
+the resulting payload (which may be base64 encoded for binary data, for example).
+
 
 Asynchronous support
 --------------------
@@ -33,15 +67,27 @@ an asynchronous design pattern.  This means that when a job is submitted in asyn
 mode, the server responds immediately with a reference to the job, which allows the client
 to periodically poll the server for the processing status of a given job.
 
-pygeoapi provides asynchronous support by providing a 'manager' concept which, well,
+In keeping with the OGC API - Processes specification, asynchronous process execution
+can be requested by including the ``Prefer: respond-async`` HTTP header in the request.
+
+Job management is required for asynchronous functionality.
+
+Job management
+--------------
+
+pygeoapi provides job management by providing a 'manager' concept which, well,
 manages job execution.  The manager concept is implemented as part of the pygeoapi
 :ref:`plugins` architecture.  pygeoapi provides a default manager implementation
 based on `TinyDB`_ for simplicity.  Custom manager plugins can be developed for more
 advanced job management capabilities (e.g. Kubernetes, databases, etc.).
 
-In keeping with the OGC API - Processes specification, asynchronous process execution
-can be requested by including the ``Prefer: respond-async`` HTTP header in the request
+Job managers
+------------
 
+TinyDB
+^^^^^^
+
+TinyDB is the default job manager for pygeoapi when enabled.
 
 .. code-block:: yaml
 
@@ -52,7 +98,8 @@ can be requested by including the ``Prefer: respond-async`` HTTP header in the r
            output_dir: /tmp/
 
 MongoDB
--------
+^^^^^^^
+
 As an alternative to the default, a manager employing `MongoDB`_ can be used. 
 The connection to a `MongoDB`_ instance must be provided in the configuration.
 `MongoDB`_ uses ``localhost`` and port ``27017`` by default. Jobs are stored in a collection named
@@ -66,9 +113,9 @@ The connection to a `MongoDB`_ instance must be provided in the configuration.
            connection: mongodb://host:port
            output_dir: /tmp/
 
-
 PostgreSQL
-----------
+^^^^^^^^^^
+
 As another alternative to the default, a manager employing `PostgreSQL`_ can be used.
 The connection to a `PostgreSQL`_ database must be provided in the configuration.
 `PostgreSQL`_ uses ``localhost`` and port ``5432`` by default. Jobs are stored in a table named ``jobs``.

--- a/docs/source/data-publishing/ogcapi-processes.rst
+++ b/docs/source/data-publishing/ogcapi-processes.rst
@@ -19,19 +19,17 @@ The below configuration is an example of a process defined within the pygeoapi i
 .. code-block:: yaml
 
    processes:
-   
-    # enabled by default
+       # enabled by default
        hello-world:
            processor:
                name: HelloWorld
 
-The below configuration is an example of a process defined as part of cusotm Python process:
+The below configuration is an example of a process defined as part of a custom Python process:
 
 .. code-block:: yaml
 
    processes:
-   
-    # enabled by default
+       # enabled by default
        hello-world:
            processor:
                # refer to a process in the standard PYTHONPATH
@@ -39,12 +37,12 @@ The below configuration is an example of a process defined as part of cusotm Pyt
                # the MyProcess class must subclass from pygeoapi.process.base.BaseProcessor
                name: my_package.my_module.my_file.MyProcess
 
-See :ref:`example-custom-pygeoapi-processing-plugin` for processing plugin examples
+See :ref:`example-custom-pygeoapi-processing-plugin` for processing plugin examples.
 
 Processing and response handling
 --------------------------------
 
-pygeoapi processing plugins are required to return a tuple of media type and native outputs.  Multipart
+pygeoapi processing plugins must return a tuple of media type and native outputs.  Multipart
 responses are not supported at this time, and it is up to the process plugin implementor to return a single
 payload defining multiple artifacts (or references to them).
 
@@ -53,8 +51,8 @@ processing responses in their native encoding and media type, as defined by a gi
 plugin (which needs to set the response content type and payload accordingly).
 
 pygeoapi also supports a JSON-based response type (via the OGC API - Processes ``response: document``
-execution parameter).  When this mode is requested, the response will always be a JSON encoding embedding
-the resulting payload (which may be base64 encoded for binary data, for example).
+execution parameter).  When this mode is requested, the response will always be a JSON encoding, embedding
+the resulting payload (part of which may be Base64 encoded for binary data, for example).
 
 
 Asynchronous support

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -273,6 +273,8 @@ implementation.
 
 Each base class documents the functions, arguments and return types required for implementation.
 
+.. _example-custom-pygeoapi-processing-plugin:
+
 Example: custom pygeoapi processing plugin
 ------------------------------------------
 

--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -379,6 +379,8 @@ def execute_process(api: API, request: APIRequest,
     requested_outputs = data.get('outputs')
     LOGGER.debug(f'outputs: {requested_outputs}')
 
+    response_requested = data.get('response', 'raw')
+
     subscriber = None
     subscriber_dict = data.get('subscriber')
     if subscriber_dict:
@@ -420,7 +422,7 @@ def execute_process(api: API, request: APIRequest,
     if status == JobStatus.failed:
         response = outputs
 
-    if data.get('response', 'raw') == 'raw':
+    if response_requested == 'raw':
         headers['Content-Type'] = mime_type
         response = outputs
     elif status not in (JobStatus.failed, JobStatus.accepted):
@@ -433,7 +435,7 @@ def execute_process(api: API, request: APIRequest,
     else:
         http_status = HTTPStatus.OK
 
-    if mime_type == 'application/json':
+    if mime_type == 'application/json' or response_requested == 'document':
         response2 = to_json(response, api.pretty_print)
     else:
         response2 = response


### PR DESCRIPTION
# Overview

- handles binary data on process execution when `response: document`
- updates OAProc documentation with high level implementation details

# Related Issue / discussion
Fixes #1285 
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc @ricardogsilva @StefanBrand 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
