### PR TITLE
raise error for collections without queryables

### DIFF
--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -134,6 +134,12 @@ def get_collection_queryables(api: API, request: Union[APIRequest, Any],
             LOGGER.debug('Loading record provider')
             p = load_plugin('provider', get_provider_by_type(
                 api.config['resources'][dataset]['providers'], 'record'))
+        finally:
+            msg = 'queryables not available for this collection'
+            return api.get_exception(
+                HTTPStatus.BAD_REQUEST, headers, request.format,
+                'NoApplicableError', msg)
+
     except ProviderGenericError as err:
         return api.get_exception(
             err.http_status_code, headers, request.format,

--- a/tests/api/test_itemtypes.py
+++ b/tests/api/test_itemtypes.py
@@ -62,6 +62,11 @@ def test_get_collection_queryables(config, api_):
         api_, req, 'notfound')
     assert code == HTTPStatus.NOT_FOUND
 
+    req = mock_api_request()
+    rsp_headers, code, response = get_collection_queryables(
+        api_, req, 'mapserver_world_map')
+    assert code == HTTPStatus.BAD_REQUEST
+
     req = mock_api_request({'f': 'html'})
     rsp_headers, code, response = get_collection_queryables(api_, req, 'obs')
     assert rsp_headers['Content-Type'] == FORMAT_TYPES[F_HTML]


### PR DESCRIPTION
# Overview
Check to return 400 if a collection has no querybles to emit.

# Related Issue / discussion
Fixes https://github.com/geopython/demo.pygeoapi.io/issues/53
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc @justb4 
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
