### PR TITLE
safeguard OpenAPI detection on startup (#1650)

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -903,6 +903,17 @@ def load_openapi_document() -> dict:
 
     pygeoapi_openapi = os.environ.get('PYGEOAPI_OPENAPI')
 
+    if pygeoapi_openapi is None:
+        msg = 'PYGEOAPI_OPENAPI environment not set'
+        LOGGER.error(msg)
+        raise RuntimeError(msg)
+
+    if not os.path.exists(pygeoapi_openapi):
+        msg = (f'OpenAPI document {pygeoapi_openapi} does not exist.  '
+               'Please generate before starting pygeoapi')
+        LOGGER.error(msg)
+        raise RuntimeError(msg)
+
     with open(pygeoapi_openapi, encoding='utf8') as ff:
         if pygeoapi_openapi.endswith(('.yaml', '.yml')):
             openapi_ = yaml_load(ff)


### PR DESCRIPTION
# Overview
Throws error on startup (`pygeoapi serve`) if `PYGEOAPI_OPENAPI` is not set, or does not exist.

# Related Issue / discussion
Fixes #1650 
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc @pvgenuchten 
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
