### PR TITLE
OAProc: fix response: document encoding for results (#1579)

### DIFF
--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -379,7 +379,7 @@ def execute_process(api: API, request: APIRequest,
     requested_outputs = data.get('outputs')
     LOGGER.debug(f'outputs: {requested_outputs}')
 
-    response_requested = data.get('response', 'raw')
+    requested_response = data.get('response', 'raw')
 
     subscriber = None
     subscriber_dict = data.get('subscriber')
@@ -409,10 +409,14 @@ def execute_process(api: API, request: APIRequest,
         result = api.manager.execute_process(
             process_id, data_dict, execution_mode=execution_mode,
             requested_outputs=requested_outputs,
-            subscriber=subscriber)
+            subscriber=subscriber,
+            requested_response=requested_response)
         job_id, mime_type, outputs, status, additional_headers = result
         headers.update(additional_headers or {})
-        headers['Location'] = f'{api.base_url}/jobs/{job_id}'
+
+        if api.manager.is_async:
+            headers['Location'] = f'{api.base_url}/jobs/{job_id}'
+
     except ProcessorExecuteError as err:
         return api.get_exception(
             err.http_status_code, headers,
@@ -422,11 +426,11 @@ def execute_process(api: API, request: APIRequest,
     if status == JobStatus.failed:
         response = outputs
 
-    if response_requested == 'raw':
+    if requested_response == 'raw':
         headers['Content-Type'] = mime_type
         response = outputs
     elif status not in (JobStatus.failed, JobStatus.accepted):
-        response['outputs'] = [outputs]
+        response = outputs
 
     if status == JobStatus.accepted:
         http_status = HTTPStatus.CREATED
@@ -435,7 +439,7 @@ def execute_process(api: API, request: APIRequest,
     else:
         http_status = HTTPStatus.OK
 
-    if mime_type == 'application/json' or response_requested == 'document':
+    if mime_type == 'application/json' or requested_response == 'document':
         response2 = to_json(response, api.pretty_print)
     else:
         response2 = response

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -597,6 +597,11 @@ class RequestedProcessExecutionMode(Enum):
     respond_async = 'respond-async'
 
 
+class RequestedResponse(Enum):
+    raw = 'raw'
+    document = 'document'
+
+
 class JobStatus(Enum):
     """
     Enum for the job status options specified in the WPS 2.0 specification

--- a/tests/api/test_processes.py
+++ b/tests/api/test_processes.py
@@ -198,6 +198,12 @@ def test_execute_process(config, api_):
             'failedUri': 'https://example.com/failed',
         }
     }
+    req_body_8 = {
+        'inputs': {
+            'name': 'Test document'
+        },
+        'response': 'document'
+    }
 
     cleanup_jobs = set()
 
@@ -345,6 +351,14 @@ def test_execute_process(config, api_):
 
     cleanup_jobs.add(tuple(['hello-world',
                             rsp_headers['Location'].split('/')[-1]]))
+
+    req = mock_api_request(data=req_body_8)
+    rsp_headers, code, response = execute_process(api_, req, 'hello-world')
+
+    response = json.loads(response)
+    assert code == HTTPStatus.OK
+    assert 'outputs' in response
+    assert isinstance(response['outputs'], list)
 
     # Cleanup
     time.sleep(2)  # Allow time for any outstanding async jobs


### PR DESCRIPTION
# Overview
This PR ensures that OGC API - Processes outputs are wrapped in `outputs` (list) when the execution request specifies `response: document`.

In addition, when pygeoapi is not configured with a process manager, execution responses suppress emitting a Location header (given there is no process manager storage by default unless configured).


# Related Issue / discussion
Fixes #1579
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc @francescoingv 
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
