### PR TITLE
fix collection breadcrumbs on queryables and schemas HTML Jinja2 templates

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1382,6 +1382,7 @@ class API:
                 self.config['resources'][dataset]['title'], request.locale)
 
             schema['collections_path'] = self.get_collections_url()
+            schema['dataset_path'] = f'{self.get_collections_url()}/{dataset}'
 
             content = render_j2_template(self.tpl_config,
                                          'collections/schema.html',

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -188,6 +188,7 @@ def get_collection_queryables(api: API, request: Union[APIRequest, Any],
             api.config['resources'][dataset]['title'], request.locale)
 
         queryables['collections_path'] = api.get_collections_url()
+        queryables['dataset_path'] = f'{api.get_collections_url()}/{dataset}'
 
         content = render_j2_template(api.tpl_config,
                                      'collections/queryables.html',

--- a/pygeoapi/templates/collections/queryables.html
+++ b/pygeoapi/templates/collections/queryables.html
@@ -2,7 +2,7 @@
 {% block title %}{{ super() }} {{ data['title'] }} {% endblock %}
 {% block crumbs %}{{ super() }}
 / <a href="{{ data['collections_path'] }}">{% trans %}Collections{% endtrans %}</a>
-/ <a href="./{{ data['id'] }}">{{ data['title'] | truncate( 25 ) }}</a>
+/ <a href="{{ data['dataset_path'] }}">{{ data['title'] | truncate( 25 ) }}</a>
 / <a href="./{{ data['id'] }}queryables">{% trans %}Queryables{% endtrans %}</a>
 {% endblock %}
 {% block body %}

--- a/pygeoapi/templates/collections/schema.html
+++ b/pygeoapi/templates/collections/schema.html
@@ -2,7 +2,7 @@
 {% block title %}{{ super() }} {{ data['title'] }} {% endblock %}
 {% block crumbs %}{{ super() }}
 / <a href="{{ data['collections_path'] }}">{% trans %}Collections{% endtrans %}</a>
-/ <a href="./{{ data['id'] }}">{{ data['title'] | truncate( 25 ) }}</a>
+/ <a href="{{ data['dataset_path'] }}">{{ data['title'] | truncate( 25 ) }}</a>
 / <a href="./{{ data['id'] }}schema">{% trans %}Schema{% endtrans %}</a>
 {% endblock %}
 {% block body %}


### PR DESCRIPTION
# Overview
Safeguards collection breadcrumb `href`'s in Jinja2 collection schema/queryables templates

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
