### PR TITLE
fix item id breadcrumb

### DIFF
--- a/pygeoapi/templates/collections/items/item.html
+++ b/pygeoapi/templates/collections/items/item.html
@@ -1,5 +1,5 @@
 {% extends "_base.html" %}
-{% set ptitle = data['properties'][data['title_field']] or '_(Item) '.format(data['id']) %}
+{% set ptitle = data['properties'][data['title_field']] or data['id'] | string %}
 {% block desc %}{{ data.get('properties',{}).get('description', {}) | string | truncate(250) }}{% endblock %}
 {% block tags %}{{ data['properties'].get('themes', [{}])[0].get('concepts', []) | join(',') }}{% endblock %}
 {# Optionally renders an img element, otherwise standard value or link rendering #}


### PR DESCRIPTION
# Overview
This PR adjusts item template rending to not include the `_(Item)` translation and only show the item id (or title if set from the caller).  String casting is added for identifiers that are not strings (for proper Jinja2 handling).

# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
