### PR TITLE
EDR true axis y start/stop

### DIFF
--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -317,7 +317,6 @@ class XarrayProvider(BaseProvider):
                               metadata['time_steps']]
                 }
                 cj['ranges'][key]['values'] = data[key].values.flatten().tolist()  # noqa
-                #cj['ranges'][key]['values'] = data[key].transpose('lat','lon','time').values.flatten().tolist()  # noqa
         except IndexError as err:
             LOGGER.warning(err)
             raise ProviderQueryError('Invalid query parameter')

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -243,22 +243,12 @@ class XarrayProvider(BaseProvider):
         """
 
         LOGGER.debug('Creating CoverageJSON domain')
-        minx, miny, maxx, maxy = metadata['bbox']
+        minx, maxx = metadata['bbox']
         mint, maxt = metadata['time']
-
-        try:
-            tmp_min = data.coords[self.y_field].values[0]
-        except IndexError:
-            tmp_min = data.coords[self.y_field].values
-        try:
-            tmp_max = data.coords[self.y_field].values[-1]
-        except IndexError:
-            tmp_max = data.coords[self.y_field].values
-
-        if tmp_min > tmp_max:
-            LOGGER.debug(f'Reversing direction of {self.y_field}')
-            miny = tmp_max
-            maxy = tmp_min
+        
+        starty = data.coords[self.y_field].values[0]
+        stopy = data.coords[self.y_field].values[-1]
+        
 
         cj = {
             'type': 'Coverage',
@@ -272,8 +262,8 @@ class XarrayProvider(BaseProvider):
                         'num': metadata['width']
                     },
                     'y': {
-                        'start': maxy,
-                        'stop': miny,
+                        'start': starty,
+                        'stop': stopy,
                         'num': metadata['height']
                     },
                     self.time_field: {
@@ -327,6 +317,7 @@ class XarrayProvider(BaseProvider):
                               metadata['time_steps']]
                 }
                 cj['ranges'][key]['values'] = data[key].values.flatten().tolist()  # noqa
+                #cj['ranges'][key]['values'] = data[key].transpose('lat','lon','time').values.flatten().tolist()  # noqa
         except IndexError as err:
             LOGGER.warning(err)
             raise ProviderQueryError('Invalid query parameter')


### PR DESCRIPTION
Potential fix to 
https://github.com/geopython/pygeoapi/issues/1780

Reading from query bbox and reversing the order would not work anyway if not followed by reversing data (which is not cheap and would not do on default. It is visible on the sample data tests/data/coads_sst.nc where the start-stop swapping turn the data upside down.

# Overview
In the original implementation, start/stop for y axis are associated with max/min respectively read from the y data.
It looks like in case data is organised south-->north, they are reversed manually.
While it is probably correct for the only supported CRS to keep starty<stopy, the implementation probably does not work anyway as it is not followed by variables data reordering.
Test with tests/data/coads_sst.nc reference data shows the data would be turned upside down.

The proposed change does not influence behavior in case data is organized along descending lat (tested with https://psl.noaa.gov/data/gridded/data.coads.1deg.html as test/data/coads_sst.nc is anyway corrupted - values looks 0:360 and lat declared -180:180). Can cause  in case data is not organised in expected way it shall rise exception, but this change at least makes troubleshooting easier.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [X ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
