### PR TITLE
OGC API - Coverages: Propagate selected fields into covjson conversion

### DIFF
--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -237,7 +237,7 @@ class XarrayProvider(BaseProvider):
 
         :param metadata: coverage metadata
         :param data: rasterio DatasetReader object
-        :param fields: fields dict
+        :param fields: fields
 
         :returns: dict of CoverageJSON representation
         """
@@ -245,6 +245,11 @@ class XarrayProvider(BaseProvider):
         LOGGER.debug('Creating CoverageJSON domain')
         minx, miny, maxx, maxy = metadata['bbox']
         mint, maxt = metadata['time']
+        
+        selected_fields = {
+            key: value for key, value in self.fields.items()
+            if key in fields
+        }
 
         try:
             tmp_min = data.coords[self.y_field].values[0]
@@ -294,7 +299,7 @@ class XarrayProvider(BaseProvider):
             'ranges': {}
         }
 
-        for key, value in self.fields.items():
+        for key, value in selected_fields.items():
             parameter = {
                 'type': 'Parameter',
                 'description': value['title'],
@@ -315,7 +320,7 @@ class XarrayProvider(BaseProvider):
         data = _convert_float32_to_float64(data)
 
         try:
-            for key, value in self.fields.items():
+            for key, value in selected_fields.items():
                 cj['ranges'][key] = {
                     'type': 'NdArray',
                     'dataType': value['type'],

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -245,7 +245,7 @@ class XarrayProvider(BaseProvider):
         LOGGER.debug('Creating CoverageJSON domain')
         minx, miny, maxx, maxy = metadata['bbox']
         mint, maxt = metadata['time']
-        
+
         selected_fields = {
             key: value for key, value in self.fields.items()
             if key in fields


### PR DESCRIPTION
# Overview

This PR fixes a bug which causes coverage collections with an xarray provider to fail to return CoverageJSON responses when a field selection is included in a query.

# Related Issue / discussion

#1787 

# Additional information

THis issue is caused by the `fields` argument to `gen_covjson` never being used to subset the fields when building the CoverageJSON. This argument contains the fields which have been selected in the request, and therefore the only fields which exist in the resulting xarray object - so only these fields should be added to the resulting CoverageJSON.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
