### PR TITLE
do not echo query parameter values on exceptions (#1789)

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1441,7 +1441,8 @@ class API:
         # Content-Language is in the system locale (ignore language settings)
         headers = request.get_response_headers(SYSTEM_LOCALE,
                                                **self.api_headers)
-        msg = f'Invalid format: {request.format}'
+        msg = 'Invalid format requested'
+        LOGGER.error(f'{msg}: {request.format}')
         return self.get_exception(
             HTTPStatus.BAD_REQUEST, headers,
             request.format, 'InvalidParameterValue', msg)

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -451,7 +451,8 @@ def get_collection_items(
                 geometry_column_name=provider_def.get('geom_field'),
             )
         except Exception:
-            msg = f'Bad CQL string : {cql_text}'
+            msg = 'Bad CQL text'
+            LOGGER.error(f'{msg}: {cql_text}')
             return api.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'InvalidParameterValue', msg)
@@ -849,7 +850,7 @@ def post_collection_items(
     if (request_headers.get(
         'Content-Type') or request_headers.get(
             'content-type')) != 'application/query-cql-json':
-        msg = ('Invalid body content-type')
+        msg = 'Invalid body content-type'
         return api.get_exception(
             HTTPStatus.BAD_REQUEST, headers, request.format,
             'InvalidHeaderValue', msg)
@@ -885,7 +886,8 @@ def post_collection_items(
                 geometry_column_name=provider_def.get('geom_field')
             )
         except Exception:
-            msg = f'Bad CQL string : {data}'
+            msg = 'Bad CQL text'
+            LOGGER.error(f'{msg}: {data}')
             return api.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'InvalidParameterValue', msg)
@@ -894,7 +896,8 @@ def post_collection_items(
         try:
             filter_ = CQLModel.parse_raw(data)
         except Exception:
-            msg = f'Bad CQL string : {data}'
+            msg = 'Bad CQL text'
+            LOGGER.error(f'{msg}: {data}')
             return api.get_exception(
                 HTTPStatus.BAD_REQUEST, headers, request.format,
                 'InvalidParameterValue', msg)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -389,6 +389,9 @@ def test_api(config, api_, openapi):
     assert rsp_headers['Content-Language'] == 'en-US'
     assert code == HTTPStatus.BAD_REQUEST
 
+    response = json.loads(response)
+    assert response['description'] == 'Invalid format requested'
+
     assert api_.get_collections_url() == 'http://localhost:5000/collections'
 
 

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -556,7 +556,7 @@ def test_get_collection_items_postgresql_cql_bad_cql(pg_api_, bad_cql):
     assert code == HTTPStatus.BAD_REQUEST
     error_response = json.loads(response)
     assert error_response['code'] == 'InvalidParameterValue'
-    assert error_response['description'] == f'Bad CQL string : {bad_cql}'
+    assert error_response['description'] == 'Bad CQL text'
 
 
 def test_post_collection_items_postgresql_cql(pg_api_):
@@ -642,7 +642,7 @@ def test_post_collection_items_postgresql_cql_bad_cql(pg_api_, bad_cql):
     assert code == HTTPStatus.BAD_REQUEST
     error_response = json.loads(response)
     assert error_response['code'] == 'InvalidParameterValue'
-    assert error_response['description'].startswith('Bad CQL string')
+    assert error_response['description'] == 'Bad CQL text'
 
 
 def test_get_collection_items_postgresql_crs(pg_api_):


### PR DESCRIPTION
# Overview
This PR suppresses query parameter values on API error responses, redirecting to error logging.

# Related Issue / discussion
Fixes #1789 
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
