### PR TITLE
Skip resources with no providers in STA intralink process

### DIFF
--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -119,6 +119,11 @@ class SensorThingsProvider(BaseProvider):
 
             for (name, rs) in CONFIG['resources'].items():
                 pvs = rs.get('providers')
+
+                if pvs is None:
+                    LOGGER.debug(f'Skipping collection: {name}')
+                    continue
+
                 p = get_provider_default(pvs)
                 e = p.get('entity') or self._get_entity(p['data'])
                 if any([


### PR DESCRIPTION
# Overview
This adds a check for resources that are OAProc configurations, and thus can not be linked to an associated SensorThings API collection

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/1792
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
