### PR TITLE
Fix indentation in yaml example

### DIFF
--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -106,8 +106,8 @@ Following block shows how to configure pygeoapi to read Mapbox vector tiles from
               zoom:
                 min: 0
                 max: 15
-             schemes:
-                 - WebMercatorQuad # this option is needed in the MVT-proxy provider
+              schemes:
+                - WebMercatorQuad # this option is needed in the MVT-proxy provider
          format:
              name: pbf
              mimetype: application/vnd.mapbox-vector-tile
@@ -124,8 +124,8 @@ Following code block shows how to configure pygeoapi to read Mapbox vector tiles
               zoom:
                 min: 0
                 max: 15
-             schemes:
-                 - WebMercatorQuad
+              schemes:
+                - WebMercatorQuad
          format:
              name: pbf
              mimetype: application/vnd.mapbox-vector-tile


### PR DESCRIPTION
# Overview

Copying and pasting from the example in the documentation results in a broken YAML. A small triviality that can cost time :crying_cat_face: 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute docs to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
