### PR TITLE
Fix bug when trying to get job result in binary format

### DIFF
--- a/pygeoapi/process/manager/mongodb_.py
+++ b/pygeoapi/process/manager/mongodb_.py
@@ -32,6 +32,7 @@ import traceback
 
 from pymongo import MongoClient
 
+from pygeoapi.api import FORMAT_TYPES, F_JSON, F_JSONLD
 from pygeoapi.process.base import (
     JobNotFoundError,
     JobResultNotFoundError,
@@ -148,8 +149,16 @@ class MongoDBManager(BaseManager):
             if entry["status"] != "successful":
                 LOGGER.info("JOBMANAGER - job not finished or failed")
                 return (None,)
-            with open(entry["location"], "r") as file:
-                data = json.load(file)
+            if not entry["location"]:
+                LOGGER.warning(f"job {job_id!r} -  unknown result location")
+                raise JobResultNotFoundError()
+            if entry["mimetype"] in (None, FORMAT_TYPES[F_JSON],
+                                     FORMAT_TYPES[F_JSONLD]):
+                with open(entry["location"], "r") as file:
+                    data = json.load(file)
+            else:
+                with open(entry["location"], "rb") as file:
+                    data = file.read()
             LOGGER.info("JOBMANAGER - MongoDB job result queried")
             return entry["mimetype"], data
         except Exception as err:

--- a/pygeoapi/process/manager/postgresql.py
+++ b/pygeoapi/process/manager/postgresql.py
@@ -49,6 +49,7 @@ from sqlalchemy import insert, update, delete
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import Session
 
+from pygeoapi.api import FORMAT_TYPES, F_JSON, F_JSONLD
 from pygeoapi.process.base import (
     JobNotFoundError,
     JobResultNotFoundError,
@@ -286,8 +287,13 @@ class PostgreSQLManager(BaseManager):
         else:
             try:
                 location = Path(location)
-                with location.open(encoding='utf-8') as fh:
-                    result = json.load(fh)
+                if mimetype in (None, FORMAT_TYPES[F_JSON],
+                                FORMAT_TYPES[F_JSONLD]):
+                    with location.open('r', encoding='utf-8') as fh:
+                        result = json.load(fh)
+                else:
+                    with location.open('rb') as fh:
+                        result = fh.read()
             except (TypeError, FileNotFoundError, json.JSONDecodeError):
                 raise JobResultNotFoundError()
             else:

--- a/pygeoapi/process/manager/tinydb_.py
+++ b/pygeoapi/process/manager/tinydb_.py
@@ -37,6 +37,7 @@ from typing import Any, Tuple
 import tinydb
 from filelock import FileLock
 
+from pygeoapi.api import FORMAT_TYPES, F_JSON, F_JSONLD
 from pygeoapi.process.base import (
     JobNotFoundError,
     JobResultNotFoundError,
@@ -196,8 +197,13 @@ class TinyDBManager(BaseManager):
         else:
             try:
                 location = Path(location)
-                with location.open('r', encoding='utf-8') as filehandler:
-                    result = json.load(filehandler)
+                if mimetype in (None, FORMAT_TYPES[F_JSON],
+                                FORMAT_TYPES[F_JSONLD]):
+                    with location.open('r', encoding='utf-8') as filehandler:
+                        result = json.load(filehandler)
+                else:
+                    with location.open('rb') as filehandler:
+                        result = filehandler.read()
             except (TypeError, FileNotFoundError, json.JSONDecodeError):
                 raise JobResultNotFoundError()
             else:


### PR DESCRIPTION
# Overview
Currently, none of the existing process managers (TinyDB, MongoDB, PostgreSQL) is able to return binary process outputs on a GET request to `/jobs/<job-id>/results` (`get_job_result` method of the managers). 
This is especially problematic for asynchronous processes as there seems to be no way to actually get the process outputs. For synchronous process calls, binary data can already be returned on POST requests to `/processes/<process-id>/execution` ([see](https://github.com/geopython/pygeoapi/blob/master/pygeoapi/api/processes.py#L331)).

This PR should solve the issue for all three aforementioned managers.

# Related Issue / discussion

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
