### PR TITLE
Always use MarkerCluster to display FeatureCollection items

### DIFF
--- a/pygeoapi/templates/collections/edr/query.html
+++ b/pygeoapi/templates/collections/edr/query.html
@@ -274,7 +274,6 @@
             layer.bindPopup(html);
         }
     });
-    {% if data.type == "FeatureCollection" and data.features and data.features[0]['geometry']['type'] == 'Point' %}
     var markers = L.markerClusterGroup({
         disableClusteringAtZoom: 9,
         chunkedLoading: true,
@@ -282,7 +281,6 @@
     });
     markers.clearLayers().addLayer(items);
     map.addLayer(markers);
-    {% endif %}
     map.fitBounds(items.getBounds(), {maxZoom: 15});
     {% endif %}
 </script>

--- a/pygeoapi/templates/collections/items/index.html
+++ b/pygeoapi/templates/collections/items/index.html
@@ -169,7 +169,6 @@
             layer.bindPopup(html);
         }
     });
-    {% if data['features'][0]['geometry']['type'] == 'Point' %}
     var markers = L.markerClusterGroup({
         disableClusteringAtZoom: 9,
         chunkedLoading: true,
@@ -177,9 +176,6 @@
     });
     markers.clearLayers().addLayer(items);
     map.addLayer(markers);
-    {% else %}
-    map.addLayer(items);
-    {% endif %}
 
     map.fitBounds(items.getBounds());
     </script>


### PR DESCRIPTION
# Overview
For a FeatureCollection of mixed geometry types Marker Cluster is able to put all features on the map and make clusters for all Point features

# Related Issue / discussion
There is no need for the logic to check if the first feature in the collection is a point because MarkerCluster is able to only cluster Points. We noticed this when returning a mixed FeatureCollection and the first feature returned was a Polygon. 
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
