### PR TITLE
Improvements for xarray provider

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1122,19 +1122,6 @@ class API:
                         'title': title_,
                         'href': f"{self.get_collections_url()}/{k}/coverage?f={collection_data_format['name']}"  # noqa
                     })
-
-                # Hardcode netcdf format for xarray provider
-                if (collection_data['name'] == 'xarray' and
-                   collection_data_format['name'] == 'zarr'):
-                    title_ = l10n.translate('Coverage data as', request.locale)
-                    title_ = f"{title_} {F_NETCDF}"
-                    collection['links'].append({
-                        'type': FORMAT_TYPES[F_NETCDF],
-                        'rel': f'{OGC_RELTYPES_BASE}/coverage',
-                        'title': title_,
-                        'href': f"{self.get_collections_url()}/{k}/coverage?f={F_NETCDF}"  # noqa
-                    })
-
                 if dataset is not None:
                     LOGGER.debug('Creating extended coverage metadata')
                     try:

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1122,6 +1122,19 @@ class API:
                         'title': title_,
                         'href': f"{self.get_collections_url()}/{k}/coverage?f={collection_data_format['name']}"  # noqa
                     })
+
+                # Hardcode netcdf format for xarray provider
+                if (collection_data['name'] == 'xarray' and
+                   collection_data_format['name'] == 'zarr'):
+                    title_ = l10n.translate('Coverage data as', request.locale)
+                    title_ = f"{title_} {F_NETCDF}"
+                    collection['links'].append({
+                        'type': FORMAT_TYPES[F_NETCDF],
+                        'rel': f'{OGC_RELTYPES_BASE}/coverage',
+                        'title': title_,
+                        'href': f"{self.get_collections_url()}/{k}/coverage?f={F_NETCDF}"  # noqa
+                    })
+
                 if dataset is not None:
                     LOGGER.debug('Creating extended coverage metadata')
                     try:

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -88,6 +88,7 @@ F_PNG = 'png'
 F_JPEG = 'jpeg'
 F_MVT = 'mvt'
 F_NETCDF = 'NetCDF'
+F_ZARR = 'zarr'
 
 #: Formats allowed for ?f= requests (order matters for complex MIME types)
 FORMAT_TYPES = OrderedDict((
@@ -98,6 +99,7 @@ FORMAT_TYPES = OrderedDict((
     (F_JPEG, 'image/jpeg'),
     (F_MVT, 'application/vnd.mapbox-vector-tile'),
     (F_NETCDF, 'application/x-netcdf'),
+    (F_ZARR, 'application/zip+zarr'),
 ))
 
 #: Locale used for system responses (e.g. exceptions)
@@ -1113,27 +1115,28 @@ class API:
                     'title': l10n.translate('Coverage data', request.locale),
                     'href': f'{self.get_collections_url()}/{k}/coverage?f={F_JSON}'  # noqa
                 })
-                if collection_data_format is not None:
-                    title_ = l10n.translate('Coverage data as', request.locale)  # noqa
-                    title_ = f"{title_} {collection_data_format['name']}"
-                    collection['links'].append({
-                        'type': collection_data_format['mimetype'],
-                        'rel': f'{OGC_RELTYPES_BASE}/coverage',
-                        'title': title_,
-                        'href': f"{self.get_collections_url()}/{k}/coverage?f={collection_data_format['name']}"  # noqa
-                    })
-
                 # Hardcode netcdf format for xarray provider
-                if (collection_data['name'] == 'xarray' and
-                   collection_data_format['name'] == 'zarr'):
-                    title_ = l10n.translate('Coverage data as', request.locale)
-                    title_ = f"{title_} {F_NETCDF}"
-                    collection['links'].append({
-                        'type': FORMAT_TYPES[F_NETCDF],
-                        'rel': f'{OGC_RELTYPES_BASE}/coverage',
-                        'title': title_,
-                        'href': f"{self.get_collections_url()}/{k}/coverage?f={F_NETCDF}"  # noqa
-                    })
+                if collection_data['name'] == 'xarray':
+                    data_formats = [
+                        {'name': F_NETCDF, 'mimetype': FORMAT_TYPES[F_NETCDF]},
+                        {'name': F_ZARR, 'mimetype': FORMAT_TYPES[F_ZARR]}
+                    ]
+                elif collection_data_format is not None:
+                    data_formats = [collection_data_format]
+                else:
+                    data_formats = []
+
+                for data_format in data_formats:
+                    title_ = l10n.translate('Coverage data as', request.locale)  # noqa
+                    title_ = f"{title_} {data_format['name']}"
+                    collection['links'].append(
+                        {
+                            'type': data_format['mimetype'],
+                            'rel': f'{OGC_RELTYPES_BASE}/coverage',
+                            'title': title_,
+                            'href': f"{self.get_collections_url()}/{k}/coverage?f={data_format['name']}",  # noqa
+                        }
+                    )
 
                 if dataset is not None:
                     LOGGER.debug('Creating extended coverage metadata')

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -221,6 +221,10 @@ class XarrayProvider(BaseProvider):
             LOGGER.warning(msg)
             raise ProviderNoDataError(msg)
 
+        if format_ == 'json':
+            # json does not support float32
+            data = _convert_float32_to_float64(data)
+
         out_meta = {
             'bbox': [
                 data.coords[self.x_field].values[0],
@@ -344,7 +348,6 @@ class XarrayProvider(BaseProvider):
             cj['parameters'][key] = parameter
 
         data = data.fillna(None)
-        data = _convert_float32_to_float64(data)
 
         try:
             for key, value in selected_fields.items():

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -85,7 +85,15 @@ class XarrayProvider(BaseProvider):
             else:
                 data_to_open = self.data
 
-            self._data = open_func(data_to_open)
+            try:
+                self._data = open_func(data_to_open)
+            except ValueError as err:
+                # Manage non-cf-compliant time dimensions
+                if 'time' in str(err):
+                    self._data = open_func(self.data, decode_times=False)
+                else:
+                    raise err
+
             self.storage_crs = self._parse_storage_crs(provider_def)
             self._coverage_properties = self._get_coverage_properties()
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -172,10 +172,20 @@ class XarrayProvider(BaseProvider):
                     LOGGER.error(msg)
                     raise ProviderQueryError(msg)
                 else:
-                    query_params[self._coverage_properties['x_axis_label']] = \
-                        slice(bbox[0], bbox[2])
-                    query_params[self._coverage_properties['y_axis_label']] = \
-                        slice(bbox[1], bbox[3])
+                    x_axis_label = self._coverage_properties['x_axis_label']
+                    x_coords = data.coords[x_axis_label]
+                    if x_coords.values[0] > x_coords.values[-1]:
+                        LOGGER.debug('Reversing slicing of x axis from high to low')
+                        query_params[x_axis_label] = slice(bbox[2], bbox[0])
+                    else:
+                        query_params[x_axis_label] = slice(bbox[0], bbox[2])
+                    y_axis_label = self._coverage_properties['y_axis_label']
+                    y_coords = data.coords[y_axis_label]
+                    if y_coords.values[0] > y_coords.values[-1]:
+                        LOGGER.debug('Reversing slicing of y axis from high to low')
+                        query_params[y_axis_label] = slice(bbox[3], bbox[1])
+                    else:
+                        query_params[y_axis_label] = slice(bbox[1], bbox[3])
 
                 LOGGER.debug('bbox_crs is not currently handled')
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -673,7 +673,7 @@ def _convert_float32_to_float64(data):
     for var_name in data.variables:
         if data[var_name].dtype == 'float32':
             og_attrs = data[var_name].attrs
-            data[var_name] = data[var_name].astype('float64')
+            data[var_name] = data[var_name].astype('float64', copy=False)
             data[var_name].attrs = og_attrs
 
     return data

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -115,7 +115,7 @@ class XarrayProvider(BaseProvider):
 
                     self._fields[key] = {
                         'type': dtype,
-                        'title': value.attrs['long_name'],
+                        'title': value.attrs.get('long_name'),
                         'x-ogc-unit': value.attrs.get('units')
                     }
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -282,7 +282,6 @@ class XarrayProvider(BaseProvider):
 
         LOGGER.debug('Creating CoverageJSON domain')
         minx, miny, maxx, maxy = metadata['bbox']
-        mint, maxt = metadata['time']
 
         selected_fields = {
             key: value for key, value in self.fields.items()
@@ -333,6 +332,7 @@ class XarrayProvider(BaseProvider):
         }
 
         if self.time_field is not None:
+            mint, maxt = metadata['time']
             cj['domain']['axes'][self.time_field] = {
                 'start': mint,
                 'stop': maxt,

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -257,9 +257,6 @@ class XarrayProvider(BaseProvider):
         elif format_ == 'zarr':
             LOGGER.debug('Returning data in native zarr format')
             return _get_zarr_data(data)
-        elif format_ == 'netcdf':
-            LOGGER.debug('Returning data in netcdf format')
-            return _get_netcdf_data(data)
         else:  # return data in native format
             with tempfile.NamedTemporaryFile() as fp:
                 LOGGER.debug('Returning data in native NetCDF format')
@@ -672,22 +669,6 @@ def _get_zarr_data(data):
 
     with open(zarr_zip_filename, 'rb') as fh:
         return fh.read()
-
-
-def _get_netcdf_data(data: xarray.Dataset):
-    """
-    Returns bytes to read from netcdf file
-    :param data: Xarray dataset of coverage data
-
-    :returns: byte array of netcdf data
-    """
-
-    with tempfile.NamedTemporaryFile() as fp:
-        data.to_netcdf(
-            fp.name
-        )  # we need to pass a string to be able to use the "netcdf4" engine
-        fp.seek(0)
-        return fp.read()
 
 
 def _convert_float32_to_float64(data):

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -63,13 +63,10 @@ class XarrayProvider(BaseProvider):
 
         super().__init__(provider_def)
 
-        self.native_format = None
         try:
             if provider_def['data'].endswith('.zarr'):
-                self.native_format = 'zarr'
                 open_func = xarray.open_zarr
             else:
-                self.native_format = 'netcdf'
                 if '*' in self.data:
                     LOGGER.debug('Detected multi file dataset')
                     open_func = xarray.open_mfdataset
@@ -258,15 +255,19 @@ class XarrayProvider(BaseProvider):
             LOGGER.debug('Creating output in CoverageJSON')
             return self.gen_covjson(out_meta, data, properties)
         elif format_ == 'zarr':
-            LOGGER.debug('Returning data in zarr format')
+            LOGGER.debug('Returning data in native zarr format')
             return _get_zarr_data(data)
         elif format_ == 'netcdf':
             LOGGER.debug('Returning data in netcdf format')
             return _get_netcdf_data(data)
-        else:
-            msg = f'Unsupported format: {format_}'
-            LOGGER.error(msg)
-            raise ProviderQueryError(msg)
+        else:  # return data in native format
+            with tempfile.NamedTemporaryFile() as fp:
+                LOGGER.debug('Returning data in native NetCDF format')
+                data.to_netcdf(
+                    fp.name
+                )  # we need to pass a string to be able to use the "netcdf4" engine  # noqa
+                fp.seek(0)
+                return fp.read()
 
     def gen_covjson(self, metadata, data, fields):
         """

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -254,9 +254,11 @@ class XarrayProvider(BaseProvider):
             LOGGER.debug('Returning data in native zarr format')
             return _get_zarr_data(data)
         else:  # return data in native format
-            with tempfile.TemporaryFile() as fp:
+            with tempfile.NamedTemporaryFile() as fp:
                 LOGGER.debug('Returning data in native NetCDF format')
-                fp.write(data.to_netcdf())
+                data.to_netcdf(
+                    fp.name
+                )  # we need to pass a string to be able to use the "netcdf4" engine  # noqa
                 fp.seek(0)
                 return fp.read()
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -175,14 +175,18 @@ class XarrayProvider(BaseProvider):
                     x_axis_label = self._coverage_properties['x_axis_label']
                     x_coords = data.coords[x_axis_label]
                     if x_coords.values[0] > x_coords.values[-1]:
-                        LOGGER.debug('Reversing slicing of x axis from high to low')
+                        LOGGER.debug(
+                            'Reversing slicing of x axis from high to low'
+                            )
                         query_params[x_axis_label] = slice(bbox[2], bbox[0])
                     else:
                         query_params[x_axis_label] = slice(bbox[0], bbox[2])
                     y_axis_label = self._coverage_properties['y_axis_label']
                     y_coords = data.coords[y_axis_label]
                     if y_coords.values[0] > y_coords.values[-1]:
-                        LOGGER.debug('Reversing slicing of y axis from high to low')
+                        LOGGER.debug(
+                            'Reversing slicing of y axis from high to low'
+                            )
                         query_params[y_axis_label] = slice(bbox[3], bbox[1])
                     else:
                         query_params[y_axis_label] = slice(bbox[1], bbox[3])
@@ -437,8 +441,12 @@ class XarrayProvider(BaseProvider):
         if self.time_field is not None:
             properties['time_axis_label'] = self.time_field
             properties['time_range'] = [
-                _to_datetime_string(self._data.coords[self.time_field].values[0]),
-                _to_datetime_string(self._data.coords[self.time_field].values[-1]),
+                _to_datetime_string(
+                    self._data.coords[self.time_field].values[0]
+                    ),
+                _to_datetime_string(
+                    self._data.coords[self.time_field].values[-1]
+                    ),
             ]
             properties['time'] = self._data.dims[self.time_field]
             properties['time_duration'] = self.get_time_coverage_duration()
@@ -494,7 +502,8 @@ class XarrayProvider(BaseProvider):
         :returns: time resolution string
         """
 
-        if self.time_field is not None and self._data[self.time_field].size > 1:
+        if self.time_field is not None \
+           and self._data[self.time_field].size > 1:
             time_diff = (self._data[self.time_field][1] -
                          self._data[self.time_field][0])
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -248,7 +248,7 @@ class XarrayProvider(BaseProvider):
                 _to_datetime_string(data.coords[self.time_field].values[0]),
                 _to_datetime_string(data.coords[self.time_field].values[-1]),
             ]
-            out_meta["time_steps"] = data.dims[self.time_field]
+            out_meta["time_steps"] = data.sizes[self.time_field]
 
         LOGGER.debug('Serializing data in memory')
         if format_ == 'json':
@@ -448,7 +448,7 @@ class XarrayProvider(BaseProvider):
                     self._data.coords[self.time_field].values[-1]
                     ),
             ]
-            properties['time'] = self._data.dims[self.time_field]
+            properties['time'] = self._data.sizes[self.time_field]
             properties['time_duration'] = self.get_time_coverage_duration()
             properties['restime'] = self.get_time_resolution()
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -253,6 +253,9 @@ class XarrayProvider(BaseProvider):
         elif format_ == 'zarr':
             LOGGER.debug('Returning data in native zarr format')
             return _get_zarr_data(data)
+        elif format_ == 'netcdf':
+            LOGGER.debug('Returning data in netcdf format')
+            return _get_netcdf_data(data)
         else:  # return data in native format
             with tempfile.NamedTemporaryFile() as fp:
                 LOGGER.debug('Returning data in native NetCDF format')
@@ -660,6 +663,22 @@ def _get_zarr_data(data):
 
     with open(zarr_zip_filename, 'rb') as fh:
         return fh.read()
+
+
+def _get_netcdf_data(data: xarray.Dataset):
+    """
+    Returns bytes to read from netcdf file
+    :param data: Xarray dataset of coverage data
+
+    :returns: byte array of netcdf data
+    """
+
+    with tempfile.NamedTemporaryFile() as fp:
+        data.to_netcdf(
+            fp.name
+        )  # we need to pass a string to be able to use the "netcdf4" engine
+        fp.seek(0)
+        return fp.read()
 
 
 def _convert_float32_to_float64(data):


### PR DESCRIPTION
# Overview

Using the xarray provider to manage Zarr data extensively, I have noticed and fixed a few bugs and added a couple of features that could be useful, so I would like to contribute these changes.

# Additional information

Summary of changes:
- Avoid crashes when the time dimension is not cf-compliant by trying to reload the data with `decode_times=False`
- Allow managing data without a time dimension at all
- The provider was already automatically managing subsets on coordinates sorted in reverse order, now it can do so also when applying a bounding box
- Fixed bug where some values where not converted to float64 before generating json output
- Used a named temporary file to generate netcdf output to allow use of netcdf4 engine  
- A couple of minor changes
- Allow requesting for netcdf or zarr output format regardless of the data format

This last change is the trickiest. I had to patch the APIRequest class to advertise the capability of producing more than one kind of output format for coverage data. At the moment I have hardcoded the two formats supported by the xarray provider, but eventually it would be nice to allow each provider to advertise an arbitrary list of output formats; I'm proposing this change as an initial implementation and a future PR could be able to expand on it and make this available to all providers. Please let me know what you think about this.


# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
