### PR TITLE
feat: add version parameter to WMSFacade provider

### DIFF
--- a/docs/source/data-publishing/ogcapi-maps.rst
+++ b/docs/source/data-publishing/ogcapi-maps.rst
@@ -51,7 +51,7 @@ Currently supported style files (`options.style`):
 .. code-block:: yaml
 
    providers:
-       - type: map 
+       - type: map
          name: MapScript
          data: /path/to/data.shp
          options:
@@ -59,7 +59,7 @@ Currently supported style files (`options.style`):
              layer: foo_name
              style: ./foo.sld
          format:
-            name: png 
+            name: png
             mimetype: image/png
 
 WMSFacade
@@ -71,14 +71,15 @@ required.  An optional style name can be defined via `options.style`.
 .. code-block:: yaml
 
    providers:
-       - type: map 
+       - type: map
          name: WMSFacade
          data: https://demo.mapserver.org/cgi-bin/msautotest
          options:
              layer: world_latlong
              style: default
+             version: 1.3.0
          format:
-               name: png 
+               name: png
                mimetype: image/png
 
 

--- a/pygeoapi/provider/wms_facade.py
+++ b/pygeoapi/provider/wms_facade.py
@@ -84,7 +84,9 @@ class WMSFacadeProvider(BaseProvider):
 
         self._transparent = 'TRUE'
 
-        if crs in [4326, 'CRS;84']:
+        version = self.options.get('version', '1.3.0')
+
+        if crs in [4326, 'CRS;84'] and version == '1.3.0':
             LOGGER.debug('Swapping 4326 axis order to WMS 1.3 mode (yx)')
             bbox2 = ','.join(str(c) for c in
                              [bbox[1], bbox[0], bbox[3], bbox[2]])
@@ -106,12 +108,14 @@ class WMSFacadeProvider(BaseProvider):
         if not transparent:
             self._transparent = 'FALSE'
 
+        crs_param = 'crs' if version == '1.3.0' else 'srs'
+
         params = {
-            'version': '1.3.0',
+            'version': version,
             'service': 'WMS',
             'request': 'GetMap',
             'bbox': bbox2,
-            'crs': CRS_CODES[crs],
+            crs_param: CRS_CODES[crs],
             'layers': self.options['layer'],
             'styles': self.options.get('style', 'default'),
             'width': width,
@@ -128,7 +132,7 @@ class WMSFacadeProvider(BaseProvider):
         else:
             request_url = '?'.join([self.data, urlencode(params)])
 
-        LOGGER.debug(f'WMS 1.3.0 request url: {request_url}')
+        LOGGER.debug(f'WMS {version} request url: {request_url}')
 
         response = requests.get(request_url)
 


### PR DESCRIPTION
# Overview

# Related Issue / discussion

The WMSFacade data provider does not support other WMS versions then 1.3.0. This PR adds the ability to use another version.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
