### PR TITLE
Correctly zoom to first layer on EDR HTML

### DIFF
--- a/pygeoapi/templates/collections/edr/query.html
+++ b/pygeoapi/templates/collections/edr/query.html
@@ -139,7 +139,7 @@
               if (!firstLayer) {
                 firstLayer = layer;
                 layer.on('afterAdd', () => {
-                  zoomToLayers([layers])
+                  zoomToLayers([layer])
                   if (!cov.coverages) {
                     if (isVerticalProfile(cov) || isTimeSeries(cov)) {
                       layer.openPopup();


### PR DESCRIPTION
# Overview
Fixes the layers error, allowing a zoom in on the first gridded layer with no error 

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/1818
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
