### PR TITLE
Support empty default environment variable values

### DIFF
--- a/docker/default.config.yml
+++ b/docker/default.config.yml
@@ -38,7 +38,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 80
-    url: http://localhost:5000
+    url: ${PYGEOAPI_URL:-http://localhost:5000}
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     gzip: false

--- a/docker/default.config.yml
+++ b/docker/default.config.yml
@@ -38,7 +38,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 80
-    url: ${PYGEOAPI_URL:-http://localhost:5000}
+    url: http://localhost:5000
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     gzip: false

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -168,7 +168,7 @@ def yaml_load(fh: IO) -> dict:
     # # https://stackoverflow.com/a/55301129
 
     env_matcher = re.compile(
-        r'.*?\$\{(?P<varname>\w+)(:-(?P<default>[^}]+))?\}')
+        r'.*?\$\{(?P<varname>\w+)(:-(?P<default>[^}]*))?\}')
 
     def env_constructor(loader, node):
         result = ""

--- a/tests/pygeoapi-test-config-envvars.yml
+++ b/tests/pygeoapi-test-config-envvars.yml
@@ -31,7 +31,7 @@ server:
     bind:
         host: 0.0.0.0
         port: ${PYGEOAPI_PORT}
-    url: http://localhost:5000/
+    url: ${PYGEOAPI_URL:-http://localhost:5000/}
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     language: en-US

--- a/tests/pygeoapi-test-config-envvars.yml
+++ b/tests/pygeoapi-test-config-envvars.yml
@@ -43,6 +43,8 @@ server:
     map:
         url: https://tile.openstreetmap.org/{z}/{x}/{y}.png
         attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+    api_rules:  # optional API design rules to which pygeoapi should adhere
+      url_prefix: ${PYGEOAPI_PREFIX:-}
 
 logging:
     level: DEBUG

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -54,8 +54,16 @@ def test_config_envvars():
 
     assert isinstance(config, dict)
     assert config['server']['bind']['port'] == 5001
+    assert config['server']['url'] == 'http://localhost:5000/'
     assert config['metadata']['identification']['title'] == \
         'pygeoapi default instance my title'
+
+    os.environ['PYGEOAPI_URL'] = 'https://localhost:5000'
+
+    with open(get_test_file_path('pygeoapi-test-config-envvars.yml')) as fh:
+        config = yaml_load(fh)
+
+    assert config['server']['url'] == 'https://localhost:5000'
 
     os.environ.pop('PYGEOAPI_PORT')
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,13 +57,16 @@ def test_config_envvars():
     assert config['server']['url'] == 'http://localhost:5000/'
     assert config['metadata']['identification']['title'] == \
         'pygeoapi default instance my title'
+    assert config['server']['api_rules']['url_prefix'] == ''
 
     os.environ['PYGEOAPI_URL'] = 'https://localhost:5000'
+    os.environ['PYGEOAPI_PREFIX'] = 'v1'
 
     with open(get_test_file_path('pygeoapi-test-config-envvars.yml')) as fh:
         config = yaml_load(fh)
 
     assert config['server']['url'] == 'https://localhost:5000'
+    assert config['server']['api_rules']['url_prefix'] == 'v1'
 
     os.environ.pop('PYGEOAPI_PORT')
 


### PR DESCRIPTION
# Overview
- Support empty default environment variable values. 
- Allow setting pygeoapi url in default pygeoapi image. 

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/1816
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
