### PR TITLE
Fixes a rasterio query using format=json and a MemoryFile issue

### DIFF
--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -240,16 +240,15 @@ class RasterioProvider(BaseProvider):
             out_meta['units'] = _data.units
 
             LOGGER.debug('Serializing data in memory')
-            with MemoryFile() as memfile:
-                with memfile.open(**out_meta) as dest:
-                    dest.write(out_image)
+            if format_ == 'json':
+                LOGGER.debug('Creating output in CoverageJSON')
+                out_meta['bands'] = args['indexes']
+                return self.gen_covjson(out_meta, out_image)
 
-                if format_ == 'json':
-                    LOGGER.debug('Creating output in CoverageJSON')
-                    out_meta['bands'] = args['indexes']
-                    return self.gen_covjson(out_meta, out_image)
-
-                else:  # return data in native format
+            else:  # return data in native format
+                with MemoryFile() as memfile:
+                    with memfile.open(**out_meta) as dest:
+                        dest.write(out_image)
                     LOGGER.debug('Returning data in native format')
                     return memfile.read()
 


### PR DESCRIPTION
# Overview

There is an issue when writing the raster data with the MemoryFile.
The issue is present in the demo and can be tested easily with a query such as this one:
`https://demo.pygeoapi.io/master/collections/gdps-temperature/coverage?f=json&lang=en-US&bbox=-118,52,-116,54`

This fix (more an optimization) changes the code to not work with a MemoryFile at all (doesn't need to) when the queried format is json.

_Note, the MemoryFile is still being used when format isn't json._


# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
