### PR TITLE
Support EDR single item locations for Starlette

### DIFF
--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -511,12 +511,13 @@ async def get_job_result_resource(request: Request,
         api_.get_job_result_resource, request, job_id, resource)
 
 
-async def get_collection_edr_query(request: Request, collection_id=None, instance_id=None):  # noqa
+async def get_collection_edr_query(request: Request, collection_id=None, instance_id=None, location_id=None):  # noqa
     """
     OGC EDR API endpoints
 
     :param collection_id: collection identifier
     :param instance_id: instance identifier
+    :param location_id: location id of a /locations/<location_id> query
 
     :returns: HTTP response
     """
@@ -527,12 +528,11 @@ async def get_collection_edr_query(request: Request, collection_id=None, instanc
     if 'instance_id' in request.path_params:
         instance_id = request.path_params['instance_id']
 
-    query_type = request["path"].split('/')[-1]  # noqa
-    location_id = None
-
-    if request["path"].split('/')[-2] == 'locations':
-        location_id = request["path"].split('/')[-1]
+    if 'location_id' in request.path_params:
+        location_id = request.path_params['location_id']
         query_type = 'locations'
+    else:
+        query_type = request['path'].split('/')[-1]
 
     return await execute_from_starlette(
         edr_api.get_collection_edr_query, request, collection_id,

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -528,9 +528,15 @@ async def get_collection_edr_query(request: Request, collection_id=None, instanc
         instance_id = request.path_params['instance_id']
 
     query_type = request["path"].split('/')[-1]  # noqa
+    location_id = None
+
+    if request["path"].split('/')[-2] == 'locations':
+        location_id = request["path"].split('/')[-1]
+        query_type = 'locations'
+
     return await execute_from_starlette(
         edr_api.get_collection_edr_query, request, collection_id,
-        instance_id, query_type,
+        instance_id, query_type, location_id,
         skip_valid_check=True,
     )
 


### PR DESCRIPTION
# Overview
Starlette improperly parses the request path when parsing EDR queries for locations/{location_id}, this PR fixes that behavior to correctly identify when there is a single location specified. 

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
