### PR TITLE
Properly support int variables of any width

### DIFF
--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -80,6 +80,8 @@ class RasterioProvider(BaseProvider):
                 dtype2 = dtype
                 if dtype.startswith('float'):
                     dtype2 = 'number'
+                elif dtype.startswith('int'):
+                    dtype2 = 'integer'
 
                 self._fields[i2] = {
                     'title': name,

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -112,6 +112,8 @@ class XarrayProvider(BaseProvider):
                     dtype = value.dtype
                     if dtype.name.startswith('float'):
                         dtype = 'number'
+                    elif dtype.name.startswith('int'):
+                        dtype = 'integer'
 
                     self._fields[key] = {
                         'type': dtype,


### PR DESCRIPTION
# Overview

# Related Issue / discussion

https://github.com/geopython/pygeoapi/issues/1828

# Additional information

Found this issue while debugging https://github.com/geopython/pygeoapi/issues/1825. A quick small fix that I didn't feel fit with my other PR I am going to propose.

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
