### PR TITLE
Lifted pin on sqlalchemy in order to be able to use v2+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,6 @@ jobs:
         pip3 install -r requirements-manager.txt
         pip3 install -r requirements-django.txt
         python3 setup.py install
-        pip3 install --upgrade "sqlalchemy<2"
         pip3 install --global-option=build_ext --global-option="-I/usr/include/gdal" GDAL==`gdal-config --version`
         #pip3 install --upgrade rasterio==1.1.8
     - name: setup test data ⚙️

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -62,7 +62,8 @@ import pyproj
 import shapely
 from sqlalchemy import create_engine, MetaData, PrimaryKeyConstraint, asc, desc
 from sqlalchemy.engine import URL
-from sqlalchemy.exc import InvalidRequestError, OperationalError
+from sqlalchemy.exc import ConstraintColumnNotFoundError, \
+    InvalidRequestError, OperationalError
 from sqlalchemy.ext.automap import automap_base
 from sqlalchemy.orm import Session, load_only
 from sqlalchemy.sql.expression import and_
@@ -515,7 +516,7 @@ def get_table_model(
     sqlalchemy_table_def = metadata.tables[f'{schema}.{table_name}']
     try:
         sqlalchemy_table_def.append_constraint(PrimaryKeyConstraint(id_field))
-    except KeyError:
+    except (ConstraintColumnNotFoundError, KeyError):
         raise ProviderQueryError(
             f"No such id_field column ({id_field}) on {schema}.{table_name}.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ PyYAML
 rasterio
 requests
 shapely
-SQLAlchemy<2.0.0
+SQLAlchemy
 tinydb


### PR DESCRIPTION
# Overview

This PR lifts the pin on the `sqlalchemy` dependency, removing the requirement to use a version lower than `v2`.

# Related Issue / discussion

- #1661

# Additional information

WRT RFC2, and as mentioned in my previous comment at the issue:

https://github.com/geopython/pygeoapi/issues/1661#issuecomment-2249817527

The current code base should be compatible with both sqlalchemy `v1.4` ([which is what is included in current ubuntu LTS repos](https://packages.ubuntu.com/noble/python3-sqlalchemy)) and with `v2`, which means we can continue to use v1.4 from the current ubuntu LTS repos when doing a 'bare metal' install and also means we can use the current version of sqlalchemy when installing via other methods, like pip.


# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
