### PR TITLE
fix: adds requested_outputs to execute function

### DIFF
--- a/pygeoapi/process/manager/dummy.py
+++ b/pygeoapi/process/manager/dummy.py
@@ -116,7 +116,7 @@ class DummyManager(BaseManager):
         self._send_in_progress_notification(subscriber)
         processor = self.get_processor(process_id)
         try:
-            jfmt, outputs = processor.execute(data_dict)
+            jfmt, outputs = processor.execute(data_dict, outputs=requested_outputs)
             current_status = JobStatus.successful
             self._send_success_notification(subscriber, outputs)
         except Exception as err:


### PR DESCRIPTION
# Overview
The execute_process function in `dummy.py` includes an unused parameter, `requested_outputs`. As a result, the output specification in a job request is ignored.
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [Y] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
