### PR TITLE
Check for `PYGEOAPI_OPENAPI` Env Var Before Generating `openapi.yml` in Entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,7 +36,6 @@ set +e
 
 export PYGEOAPI_HOME=/pygeoapi
 export PYGEOAPI_CONFIG="${PYGEOAPI_HOME}/local.config.yml"
-export PYGEOAPI_OPENAPI="${PYGEOAPI_HOME}/local.openapi.yml"
 
 # gunicorn env settings with defaults
 SCRIPT_NAME=${SCRIPT_NAME:=/}
@@ -52,59 +51,63 @@ entry_cmd=${1:-run}
 
 # Shorthand
 function error() {
-	echo "ERROR: $@"
-	exit -1
+    echo "ERROR: $@"
+    exit -1
 }
 
 # Workdir
 cd ${PYGEOAPI_HOME}
 
-echo "Trying to generate openapi.yml"
-pygeoapi openapi generate ${PYGEOAPI_CONFIG} --output-file ${PYGEOAPI_OPENAPI}
-
-[[ $? -ne 0 ]] && error "openapi.yml could not be generated ERROR"
-
-echo "openapi.yml generated continue to pygeoapi"
+# Check if the openapi.yml file already exists
+if [ -f "${PYGEOAPI_OPENAPI}" ]; then
+    echo "Custom openapi.yml found, skipping generation."
+else
+    echo "Generating openapi.yml"
+	export PYGEOAPI_OPENAPI="${PYGEOAPI_HOME}/local.openapi.yml"
+    pygeoapi openapi generate ${PYGEOAPI_CONFIG} --output-file ${PYGEOAPI_OPENAPI}
+    [[ $? -ne 0 ]] && error "openapi.yml could not be generated ERROR"
+    echo "openapi.yml generated successfully."
+fi
 
 case ${entry_cmd} in
-	# Run Unit tests
-	test)
-	  for test_py in $(ls tests/test_*.py)
-	  do
-	    # Skip tests requiring backend server or libs installed
-	    case ${test_py} in
-	        tests/test_elasticsearch__provider.py)
-	        ;&
-	        tests/test_sensorthings_provider.py)
-	        ;&
-	        tests/test_postgresql_provider.py)
-			    ;&
-	        tests/test_mongo_provider.py)
-	        	echo "Skipping: ${test_py}"
-	        ;;
-	        *)
-	        	python3 -m pytest ${test_py}
-	         ;;
-	    esac
-	  done
-	  ;;
+    # Run Unit tests
+    test)
+      for test_py in $(ls tests/test_*.py)
+      do
+        # Skip tests requiring backend server or libs installed
+        case ${test_py} in
+            tests/test_elasticsearch__provider.py)
+            ;&
+            tests/test_sensorthings_provider.py)
+            ;&
+            tests/test_postgresql_provider.py)
+            ;&
+            tests/test_mongo_provider.py)
+                echo "Skipping: ${test_py}"
+            ;;
+            *)
+                python3 -m pytest ${test_py}
+             ;;
+        esac
+      done
+      ;;
 
-	# Run pygeoapi server
-	run)
-		# SCRIPT_NAME should not have value '/'
-		[[ "${SCRIPT_NAME}" = '/' ]] && export SCRIPT_NAME="" && echo "make SCRIPT_NAME empty from /"
+    # Run pygeoapi server
+    run)
+        # SCRIPT_NAME should not have value '/'
+        [[ "${SCRIPT_NAME}" = '/' ]] && export SCRIPT_NAME="" && echo "make SCRIPT_NAME empty from /"
 
-		echo "Start gunicorn name=${CONTAINER_NAME} on ${CONTAINER_HOST}:${CONTAINER_PORT} with ${WSGI_WORKERS} workers and SCRIPT_NAME=${SCRIPT_NAME}"
-		exec gunicorn --workers ${WSGI_WORKERS} \
-				--worker-class=${WSGI_WORKER_CLASS} \
-				--timeout ${WSGI_WORKER_TIMEOUT} \
-				--name=${CONTAINER_NAME} \
-				--bind ${CONTAINER_HOST}:${CONTAINER_PORT} \
-				pygeoapi.flask_app:APP
-	  ;;
-	*)
-	  error "unknown command arg: must be run (default) or test"
-	  ;;
+        echo "Start gunicorn name=${CONTAINER_NAME} on ${CONTAINER_HOST}:${CONTAINER_PORT} with ${WSGI_WORKERS} workers and SCRIPT_NAME=${SCRIPT_NAME}"
+        exec gunicorn --workers ${WSGI_WORKERS} \
+                --worker-class=${WSGI_WORKER_CLASS} \
+                --timeout ${WSGI_WORKER_TIMEOUT} \
+                --name=${CONTAINER_NAME} \
+                --bind ${CONTAINER_HOST}:${CONTAINER_PORT} \
+                pygeoapi.flask_app:APP
+      ;;
+    *)
+      error "unknown command arg: must be run (default) or test"
+      ;;
 esac
 
 echo "END /entrypoint.sh"


### PR DESCRIPTION
**Overview**

This PR enhances the `entrypoint.sh` script to check for the existence of the `PYGEOAPI_OPENAPI` environment variable before generating `openapi.yml` when the `geopython/pygeoapi` Docker container starts. This update allows users to mount a custom `openapi.yml` file without it being overwritten, offering greater flexibility for customized configurations.

**Related Issue / discussion**

Addresses issue #1849.

**Additional information**

- The update maintains the original logic and flow of the `entrypoint.sh` script while adding a simple check for the `PYGEOAPI_OPENAPI` variable, ensuring user-mounted configurations are preserved.

**Dependency policy (RFC2)**

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

**Updates to public demo**

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

**Contributions and licensing**

(as per [Contributions and Licensing Guidelines](https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing))

- [x] I'd like to contribute this feature to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution.
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines.
