### PR TITLE
Updated documentation about OGC API - Tiles Providers

### DIFF
--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -15,13 +15,13 @@ Providers
 pygeoapi core tile providers are listed below, along with supported features.
 
 .. csv-table::
-   :header: Provider, rendered on-the-fly, properties, WebMercatorQuad, WorldCRS84Quad
+   :header: Provider, rendered on-the-fly, properties, WebMercatorQuad, WorldCRS84Quad, raster, vector
    :align: left
 
-   `MVT-tippecanoe`_,❌,✅,✅,❌
-   `MVT-elastic`_,✅,✅,✅,❌
-   `MVT-proxy`_,❓,❓,❓,❓
-   `WMTSFacade`_,✅,❌,✅,✅
+   `MVT-tippecanoe`_,❌,✅,✅,❌,❌,✅
+   `MVT-elastic`_,✅,✅,✅,❌,❌,✅
+   `MVT-proxy`_,❓,❓,❓,❓,❓,❓
+   `WMTSFacade`_,✅,❌,✅,✅,✅,❌
 
 Below are specific connection examples based on supported providers.
 

--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -20,7 +20,7 @@ pygeoapi core tile providers are listed below, along with supported features.
 
    `MVT-tippecanoe`_,❌,✅,✅,❌,❌,✅
    `MVT-elastic`_,✅,✅,✅,❌,❌,✅
-   `MVT-proxy`_,❓,❓,❓,❓,❓,❓
+   `MVT-proxy`_,❓,❓,❓,❓,❌,✅
    `WMTSFacade`_,✅,❌,✅,✅,✅,❌
 
 Below are specific connection examples based on supported providers.


### PR DESCRIPTION
# Overview

Added two additional column properties to tell the users whether the provider supports raster or vector tiles.

![Screenshot from 2024-11-26 11-57-08](https://github.com/user-attachments/assets/c166a6a7-7717-4a7a-a38d-be8d98442781)


# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
