### PR TITLE
fix operationId values for Tiles requirements (#1728)

### DIFF
--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -469,7 +469,7 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
                     'summary': f'Fetch a {title} tiles description',
                     'description': description,
                     'tags': [k],
-                    'operationId': f'describe{k.capitalize()}Tiles',
+                    'operationId': f'describe{k.capitalize()}.collection.vector.getTileSetsList',  # noqa
                     'parameters': [
                         {'$ref': '#/components/parameters/f'},
                         {'$ref': '#/components/parameters/lang'}
@@ -490,7 +490,7 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
                     'summary': f'Get a {title} tile',
                     'description': description,
                     'tags': [k],
-                    'operationId': f'get{k.capitalize()}Tiles',
+                    'operationId': f'get{k.capitalize()}.collection.vector.getTile',  # noqa
                     'parameters': [
                         {'$ref': f"{OPENAPI_YAML['oapit']}#/components/parameters/tileMatrixSetId"}, # noqa
                         {'$ref': f"{OPENAPI_YAML['oapit']}#/components/parameters/tileMatrix"},  # noqa


### PR DESCRIPTION
# Overview
Fix operationId values for Tiles requirements.  Note that this is specific to vector tiles, so we would need to update accordingly if/once we progress to other tile types.
# Related Issue / discussion
#1728 
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
