### PR TITLE
Checks for tile data type, before applying vector specific commands

### DIFF
--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -141,12 +141,22 @@ def get_collection_tiles(api: API, request: APIRequest,
 
     tiling_schemes = p.get_tiling_schemes()
 
+
+    dataType = None
+    if (t['format']['mimetype'] == 'application/vnd.mapbox-vector-tile'):
+        dataType = 'vector'
+    elif (t['format']['mimetype'] == 'image/png'):
+        dataType = 'map'
+    
+    if dataType == None:
+        LOGGER.error ("Could not determine tile data type")
+
     for matrix in tiling_schemes:
         tile_matrix = {
             'title': dataset,
             'tileMatrixSetURI': matrix.tileMatrixSetURI,
             'crs': matrix.crs,
-            'dataType': 'vector',
+            'dataType': dataType,
             'links': []
         }
         tile_matrix['links'].append({
@@ -230,6 +240,7 @@ def get_collection_tiles_data(
     try:
         t = get_provider_by_type(
             api.config['resources'][dataset]['providers'], 'tile')
+
         p = load_plugin('provider', t)
 
         format_ = p.format_type

--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -141,9 +141,9 @@ def get_collection_tiles(api: API, request: APIRequest,
 
     tiling_schemes = p.get_tiling_schemes()
 
-
     dataType = 'vector'
-    if t['formats']['mimetype'].startswith('image'):  datatype = 'map'
+    if t['formats']['mimetype'].startswith('image'):
+        dataType = 'map'
 
     if dataType is None:
         LOGGER.error("Could not determine tile data type")

--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -475,12 +475,20 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
             title = l10n.translate(v['title'], locale)
             description = l10n.translate(v['description'], locale)
 
+            operationId_tileSetsList = ''
+            operationId_tile = ''
+            if (tile_extension['format']['mimetype'] == 'application/vnd.mapbox-vector-tile'):
+                operationId_tileSetsList.join(f'describe{k.capitalize()}.collection.vector.getTileSetsList'),  # noqa
+                operationId_tile.join(f'get{k.capitalize()}.collection.vector.getTile'),  # noqa
+            else:
+                LOGGER.error ("operation id is currently supported only for vector tiles")
+
             paths[tiles_path] = {
                 'get': {
                     'summary': f'Fetch a {title} tiles description',
                     'description': description,
                     'tags': [k],
-                    'operationId': f'describe{k.capitalize()}.collection.vector.getTileSetsList',  # noqa
+                    'operationId': operationId_tileSetsList,  # noqa
                     'parameters': [
                         {'$ref': '#/components/parameters/f'},
                         {'$ref': '#/components/parameters/lang'}
@@ -501,7 +509,7 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
                     'summary': f'Get a {title} tile',
                     'description': description,
                     'tags': [k],
-                    'operationId': f'get{k.capitalize()}.collection.vector.getTile',  # noqa
+                    'operationId': operationId_tile,  # noqa
                     'parameters': [
                         {'$ref': f"{OPENAPI_YAML['oapit']}#/components/parameters/tileMatrixSetId"}, # noqa
                         {'$ref': f"{OPENAPI_YAML['oapit']}#/components/parameters/tileMatrix"},  # noqa

--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -141,15 +141,14 @@ def get_collection_tiles(api: API, request: APIRequest,
 
     tiling_schemes = p.get_tiling_schemes()
 
-
     dataType = None
     if (t['format']['mimetype'] == 'application/vnd.mapbox-vector-tile'):
         dataType = 'vector'
     elif (t['format']['mimetype'] == 'image/png'):
         dataType = 'map'
-    
-    if dataType == None:
-        LOGGER.error ("Could not determine tile data type")
+
+    if dataType is None:
+        LOGGER.error("Could not determine tile data type")
 
     for matrix in tiling_schemes:
         tile_matrix = {
@@ -477,11 +476,11 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
 
             operationId_tileSetsList = ''
             operationId_tile = ''
-            if (tile_extension['format']['mimetype'] == 'application/vnd.mapbox-vector-tile'):
+            if (tile_extension['format']['mimetype'] == 'application/vnd.mapbox-vector-tile'): # noqa
                 operationId_tileSetsList.join(f'describe{k.capitalize()}.collection.vector.getTileSetsList'),  # noqa
                 operationId_tile.join(f'get{k.capitalize()}.collection.vector.getTile'),  # noqa
             else:
-                LOGGER.error ("operation id is currently supported only for vector tiles")
+                LOGGER.error("operation id is currently supported only for vector tiles") # noqa
 
             paths[tiles_path] = {
                 'get': {

--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -141,11 +141,9 @@ def get_collection_tiles(api: API, request: APIRequest,
 
     tiling_schemes = p.get_tiling_schemes()
 
-    dataType = None
-    if (t['format']['mimetype'] == 'application/vnd.mapbox-vector-tile'):
-        dataType = 'vector'
-    elif (t['format']['mimetype'] == 'image/png'):
-        dataType = 'map'
+
+    dataType = 'vector'
+    if t['formats']['mimetype'].startswith('image'):  datatype = 'map'
 
     if dataType is None:
         LOGGER.error("Could not determine tile data type")


### PR DESCRIPTION
# Overview

On the tiles generic class, some vector specific operations are being applied, without checking the tile type.

* the data type is set to "vector"
* the operation ID calls vector specific functions

This PR addresses the problem by retrieving the tile type from the configuration file (format->mimetype) and making sure that these operations are restricted to vector tiles. 

In the future, more more work needs to be done around support to raster tiles.

# Related Issue / discussion

This PR was triggered by this commit: https://github.com/geopython/pygeoapi/commit/0cf470a0e205292798c5b808c6aa5f335dbf5e84

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
