### PR TITLE
Add admin key to pygeoapi configuration

### DIFF
--- a/pygeoapi-config.yml
+++ b/pygeoapi-config.yml
@@ -53,7 +53,8 @@ server:
 #        connection: /tmp/pygeoapi-process-manager.db
 #        output_dir: /tmp/
     # ogc_schemas_location: /opt/schemas.opengis.net
-    
+    admin: false # enable admin api
+
 logging:
     level: ERROR
     #logfile: /tmp/pygeoapi.log


### PR DESCRIPTION
# Overview

Currently, the example pygeoapi configuration does not contain an admin key.

This PR adds the admin key to the server section, and defaults it to False (admin api disabled)

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
