### PR TITLE
Support enviornment vars in base Docker image

### DIFF
--- a/docker/default.config.yml
+++ b/docker/default.config.yml
@@ -45,7 +45,7 @@ server:
     language: en-US
     cors: true
     pretty_print: true
-    admin: ${PYGEOAPI_ADMIN_API:-false}
+    admin: ${PYGEOAPI_SERVER_ADMIN:-false}
     limit: 10
     # templates: /path/to/templates
     map:

--- a/docker/default.config.yml
+++ b/docker/default.config.yml
@@ -38,13 +38,14 @@ server:
     bind:
         host: 0.0.0.0
         port: 80
-    url: http://localhost:5000
+    url: ${PYGEOAPI_URL:-http://localhost:5000}
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     gzip: false
     language: en-US
     cors: true
     pretty_print: true
+    admin: ${PYGEOAPI_ADMIN_API:-false}
     limit: 10
     # templates: /path/to/templates
     map:

--- a/docker/default.config.yml
+++ b/docker/default.config.yml
@@ -38,7 +38,7 @@ server:
     bind:
         host: 0.0.0.0
         port: 80
-    url: ${PYGEOAPI_URL:-http://localhost:5000}
+    url: ${PYGEOAPI_SERVER_URL:-http://localhost:5000}
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     gzip: false

--- a/docs/source/running-with-docker.rst
+++ b/docs/source/running-with-docker.rst
@@ -85,12 +85,12 @@ The base Docker image supports two additional environment variables for configur
 
    This ensures the service URLs in the configuration file are automatically updated to reflect the specified URL.
 
-2. **`PYGEOAPI_ADMIN_API`**:  
+2. **`PYGEOAPI_SERVER_ADMIN`**:  
    This boolean environment variable enables or disables the `pygeoapi` Admin API. By default, the Admin API is disabled. To enable it:
 
    .. code-block:: bash
 
-      docker run -p 5000:80 -e PYGEOAPI_ADMIN_API=true -it geopython/pygeoapi
+      docker run -p 5000:80 -e PYGEOAPI_SERVER_ADMIN=true -it geopython/pygeoapi
 
    This does not enable hot reloading of the `pygoeapi` configuration. To learn more about the Admin API see :ref:`admin-api`.
 

--- a/docs/source/running-with-docker.rst
+++ b/docs/source/running-with-docker.rst
@@ -71,6 +71,30 @@ Or you can create a ``Dockerfile`` extending the base image and **copy** in your
 
 A corresponding example can be found in https://github.com/geopython/demo.pygeoapi.io/tree/master/services/pygeoapi_master
 
+Environment Variables for Configuration
+---------------------------------------
+
+The base Docker image supports two additional environment variables for configuring the `pygeoapi` server behavior:
+
+1. **`PYGEOAPI_URL`**:  
+   This variable sets the `pygeoapi` server URL in the configuration. It is useful for dynamically configuring the server URL during container deployment. For example:
+
+   .. code-block:: bash
+
+      docker run -p 2018:80 -e PYGEOAPI_URL='http://localhost:2018' -it geopython/pygeoapi
+
+   This ensures the service URLs in the configuration file are automatically updated to reflect the specified URL.
+
+2. **`PYGEOAPI_ADMIN_API`**:  
+   This boolean environment variable enables or disables the `pygeoapi` Admin API. By default, the Admin API is disabled. To enable it:
+
+   .. code-block:: bash
+
+      docker run -p 5000:80 -e PYGEOAPI_ADMIN_API=true -it geopython/pygeoapi
+
+   This does not enable hot reloading of the `pygoeapi` configuration. To learn more about the Admin API see :ref:`admin-api`.
+
+
 Deploying on a sub-path
 -----------------------
 

--- a/docs/source/running-with-docker.rst
+++ b/docs/source/running-with-docker.rst
@@ -76,12 +76,12 @@ Environment Variables for Configuration
 
 The base Docker image supports two additional environment variables for configuring the `pygeoapi` server behavior:
 
-1. **`PYGEOAPI_URL`**:  
+1. **`PYGEOAPI_SERVER_URL`**:  
    This variable sets the `pygeoapi` server URL in the configuration. It is useful for dynamically configuring the server URL during container deployment. For example:
 
    .. code-block:: bash
 
-      docker run -p 2018:80 -e PYGEOAPI_URL='http://localhost:2018' -it geopython/pygeoapi
+      docker run -p 2018:80 -e PYGEOAPI_SERVER_URL='http://localhost:2018' -it geopython/pygeoapi
 
    This ensures the service URLs in the configuration file are automatically updated to reflect the specified URL.
 

--- a/tests/pygeoapi-test-config-envvars.yml
+++ b/tests/pygeoapi-test-config-envvars.yml
@@ -31,7 +31,7 @@ server:
     bind:
         host: 0.0.0.0
         port: ${PYGEOAPI_PORT}
-    url: ${PYGEOAPI_URL:-http://localhost:5000/}
+    url: ${PYGEOAPI_SERVER_URL:-http://localhost:5000/}
     mimetype: application/json; charset=UTF-8
     encoding: utf-8
     language: en-US

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,7 +59,7 @@ def test_config_envvars():
         'pygeoapi default instance my title'
     assert config['server']['api_rules']['url_prefix'] == ''
 
-    os.environ['PYGEOAPI_URL'] = 'https://localhost:5000'
+    os.environ['PYGEOAPI_SERVER_URL'] = 'https://localhost:5000'
     os.environ['PYGEOAPI_PREFIX'] = 'v1'
 
     with open(get_test_file_path('pygeoapi-test-config-envvars.yml')) as fh:


### PR DESCRIPTION
# Overview
Support enviornment vars in base Docker image. This is primarily for demonstration purposes, as any unique deployment of the docker image would likely want to replace the entire default configuration.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
