### PR TITLE
Serialize string to bool

### DIFF
--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -134,7 +134,7 @@ def dategetter(date_property: str, collection: dict) -> str:
     return value.isoformat()
 
 
-def get_typed_value(value: str) -> Union[float, int, str]:
+def get_typed_value(value: str) -> Union[bool, float, int, str]:
     """
     Derive true type from data value
 
@@ -148,6 +148,8 @@ def get_typed_value(value: str) -> Union[float, int, str]:
             value2 = float(value)
         elif len(value) > 1 and value.startswith('0'):
             value2 = value
+        elif value.lower() in ['true', 'false']:
+            value2 = value.lower() == 'true'
         else:  # int?
             value2 = int(value)
     except ValueError:  # string (default)?

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -149,7 +149,7 @@ def get_typed_value(value: str) -> Union[bool, float, int, str]:
         elif len(value) > 1 and value.startswith('0'):
             value2 = value
         elif value.lower() in ['true', 'false']:
-            value2 = value.lower() == 'true'
+            value2 = str2bool(value)
         else:  # int?
             value2 = int(value)
     except ValueError:  # string (default)?

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -72,6 +72,12 @@ def test_get_typed_value():
     value = util.get_typed_value('1.c2')
     assert isinstance(value, str)
 
+    value = util.get_typed_value('true')
+    assert isinstance(value, bool)
+
+    value = util.get_typed_value('false')
+    assert isinstance(value, bool)
+
 
 def test_yaml_load(config):
     assert isinstance(config, dict)


### PR DESCRIPTION
# Overview
Serialize strings to boolean values. This becomes an issue when using environment variable `PYGEOAPI_SERVER_ADMIN` to enable to Admin API. The value is not serialized as a boolean, meaning any addition to the configuration will fail against an invalid JSON schema. 

# Related Issue / discussion
Addresses https://github.com/geopython/pygeoapi/issues/1875
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
