### PR TITLE
Admin: coerce resource temporal extents into datetime objects

### DIFF
--- a/pygeoapi/admin.py
+++ b/pygeoapi/admin.py
@@ -371,7 +371,8 @@ class Admin(API):
 
         try:
             data = json.loads(data)
-            temporal_extents_str2datetime(data.get('extents', {}))
+            res = list(data.keys())[0]
+            temporal_extents_str2datetime(data[res].get('extents', {}))
         except (json.decoder.JSONDecodeError, TypeError) as err:
             # Input is not valid JSON
             LOGGER.error(err)

--- a/pygeoapi/admin.py
+++ b/pygeoapi/admin.py
@@ -221,8 +221,8 @@ class Admin(API):
 
         try:
             data = json.loads(data)
-            for resource in data['resources']:
-                temporal_extents_str2datetime(resource.get('extents', {}))
+            for key, value in data.get('resources', {}).items():
+                temporal_extents_str2datetime(value.get('extents', {}))
         except (json.decoder.JSONDecodeError, TypeError) as err:
             # Input is not valid JSON
             LOGGER.error(err)
@@ -279,8 +279,8 @@ class Admin(API):
 
         try:
             data = json.loads(data)
-            for resource in data['resources']:
-                temporal_extents_str2datetime(resource.get('extents', {}))
+            for key, value in data.get('resources', {}).items():
+                temporal_extents_str2datetime(value.get('extents', {}))
         except (json.decoder.JSONDecodeError, TypeError) as err:
             # Input is not valid JSON
             LOGGER.error(err)

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -3,7 +3,7 @@
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 # Authors: Benjamin Webb <benjamin.miller.webb@gmail.com>
 #
-# Copyright (c) 2023 Tom Kralidis
+# Copyright (c) 2024 Tom Kralidis
 # Copyright (c) 2023 Benjamin Webb
 #
 # Permission is hereby granted, free of charge, to any person
@@ -29,6 +29,7 @@
 #
 # =================================================================
 
+from datetime import datetime
 import time
 
 from pathlib import Path
@@ -110,12 +111,14 @@ class APITest(unittest.TestCase):
         content = self.http.get(url).json()
         self.assertEqual(len(content.keys()), 2)
 
+        dt = content['data2']['extents']['temporal']['begin']
+        self.assertIsInstance(dt, datetime)
+
         # PUT an existing resource
         url = f'{self.admin_endpoint}/resources/data2'
         with get_abspath('resource-put.json').open() as fh:
             post_data = fh.read()
-        print(url)
-        print(get_abspath('resource-put.json'))
+
         response = self.http.put(url, data=post_data)
         self.assertEqual(response.status_code, 204)
 

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -112,7 +112,7 @@ class APITest(unittest.TestCase):
         content = self.http.get(url).json()
         self.assertEqual(len(content.keys()), 2)
 
-        with get_abspath('../../tests/pygeoapi-test-config-admin.yml').open() as fh:  # noqa
+        with get_abspath('../../pygeoapi-test-config-admin.yml').open() as fh:
             d = yaml_load(fh)
             temporal_extent_begin = d['data2']['extents']['temporal']['begin']
             self.assertIsInstance(temporal_extent_begin, datetime)

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -114,7 +114,7 @@ class APITest(unittest.TestCase):
 
         with get_abspath('../../pygeoapi-test-config-admin.yml').open() as fh:
             d = yaml_load(fh)
-            temporal_extent_begin = d['data2']['extents']['temporal']['begin']
+            temporal_extent_begin = d['resources']['data2']['extents']['temporal']['begin']  # noqa
             self.assertIsInstance(temporal_extent_begin, datetime)
 
         # PUT an existing resource

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -31,11 +31,12 @@
 
 from datetime import datetime
 import time
-
-from pathlib import Path
 import unittest
 
+from pathlib import Path
 from requests import Session
+
+from pygeoapi.util import yaml_load
 
 THISDIR = Path(__file__).resolve().parent
 
@@ -111,8 +112,10 @@ class APITest(unittest.TestCase):
         content = self.http.get(url).json()
         self.assertEqual(len(content.keys()), 2)
 
-        dt = content['data2']['extents']['temporal']['begin']
-        self.assertIsInstance(dt, datetime)
+        with get_abspath('../../tests/pygeoapi-test-config-admin.yml') as fh:
+            d = yaml_load(fh)
+            temporal_extent_begin = d['data2']['extents']['temporal']['begin']
+            self.assertIsInstance(temporal_extent_begin, datetime)
 
         # PUT an existing resource
         url = f'{self.admin_endpoint}/resources/data2'

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -112,7 +112,7 @@ class APITest(unittest.TestCase):
         content = self.http.get(url).json()
         self.assertEqual(len(content.keys()), 2)
 
-        with get_abspath('../../tests/pygeoapi-test-config-admin.yml') as fh:
+        with get_abspath('../../tests/pygeoapi-test-config-admin.yml').open() as fh:  # noqa
             d = yaml_load(fh)
             temporal_extent_begin = d['data2']['extents']['temporal']['begin']
             self.assertIsInstance(temporal_extent_begin, datetime)


### PR DESCRIPTION
# Overview
Coerces config temporal extent objects into datetime types for admin API workflow.
# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
This PR should be merged after #1876, and then tested against #1874
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
