### PR TITLE
Add mock data tests for the socrata provider

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,6 +143,7 @@ jobs:
         pytest tests/test_rasterio_provider.py
         pytest tests/test_sensorthings_provider.py
         pytest tests/test_socrata_provider.py
+        # pytest tests/test_socrata_provider_live.py.py  # NOTE: these are skipped in the file but listed here for completeness
         pytest tests/test_sqlite_geopackage_provider.py
         pytest tests/test_tinydb_catalogue_provider.py
         pytest tests/test_tinydb_manager_for_parallel_requests.py

--- a/tests/test_socrata_provider.py
+++ b/tests/test_socrata_provider.py
@@ -1,6 +1,7 @@
 # =================================================================
 #
 # Authors: Benjamin Webb <bwebb@lincolninst.edu>
+# Authors: Bernhard Mallinger <bernhard.mallinger@eox.at>
 #
 # Copyright (c) 2022 Benjamin Webb
 #
@@ -27,6 +28,9 @@
 #
 # =================================================================
 
+import copy
+from unittest import mock
+
 import pytest
 
 from pygeoapi.provider.socrata import SODAServiceProvider
@@ -41,7 +45,7 @@ def config():
     return {
         'name': 'SODAServiceProvider',
         'type': 'feature',
-        'data': 'https://soda.demo.socrata.com/',
+        'data': 'https://example.com/',
         'resource_id': 'emdb-u46w',
         'id_field': 'earthquake_id',
         'time_field': 'datetime',
@@ -49,7 +53,121 @@ def config():
     }
 
 
-def test_query(config):
+@pytest.fixture
+def mock_socrata(dataset):
+
+    def fake_get(*args, **kwargs):
+        if kwargs.get('select') == 'count(*)':
+            count = 19 if kwargs.get('where') == 'region = "Nevada"' else 1006
+            return [{'count': str(count)}]
+        else:
+            # get features
+            if kwargs.get('order') == 'datetime ASC':
+                dt = '2012-09-07T23:00:42.000'
+            else:
+                dt = '2012-09-14T22:38:01.000'
+            feature = {
+                'type': 'Feature',
+                'geometry': {
+                    'type': 'Point',
+                    'coordinates': [-117.6135, 41.1085],
+                },
+                'properties': {
+                    'earthquake_id': '00388610',
+                    'datetime': dt,
+                    'magnitude': '2.7',
+                },
+            }
+            return {
+                'type': 'FeatureCollection',
+                'features': [
+                    copy.deepcopy(feature)
+                    for _ in range(kwargs.get('limit', 10))
+                ],
+                'crs': {
+                    'type': 'name',
+                    'properties': {
+                        'name': 'urn:ogc:def:crs:OGC:1.3:CRS84',
+                    }
+                }
+            }
+
+    with mock.patch(
+        'sodapy.socrata.Socrata.get', new=fake_get,
+    ) as mock_get, mock.patch(
+        'sodapy.socrata.Socrata.datasets', return_value=[dataset],
+    ):
+        yield mock_get
+
+
+@pytest.fixture()
+def dataset():
+    return {
+        'resource': {
+            'columns_datatype': ['Point',
+                                 'Text',
+                                 'Text',
+                                 'Text',
+                                 'Text',
+                                 'Number',
+                                 'Text',
+                                 'Number',
+                                 'Number',
+                                 'Calendar date'],
+            'columns_description': ['',
+                                    '',
+                                    '',
+                                    '',
+                                    '',
+                                    'This column was automatically created '
+                                    'in order to record in what polygon from '
+                                    "the dataset 'Zip Codes' (k83t-ady5) the "
+                                    "point in column 'location' is located. "
+                                    'This enables the creation of region '
+                                    'maps (choropleths) in the visualization '
+                                    'canvas and data lens.',
+                                    '',
+                                    '',
+                                    '',
+                                    ''],
+            'columns_field_name': ['location',
+                                   'earthquake_id',
+                                   'location_zip',
+                                   'location_city',
+                                   'location_address',
+                                   ':@computed_region_k83t_ady5',
+                                   'location_state',
+                                   'depth',
+                                   'magnitude',
+                                   'datetime'],
+            'columns_format': [{},
+                               {},
+                               {},
+                               {},
+                               {},
+                               {},
+                               {},
+                               {},
+                               {},
+                               {}],
+            'columns_name': ['Location',
+                             'Earthquake ID',
+                             'Location (zip)',
+                             'Location (city)',
+                             'Location (address)',
+                             'Zip Codes',
+                             'Location (state)',
+                             'Depth',
+                             'Magnitude',
+                             'Datetime'],
+            'contact_email': None,
+            'type': 'dataset',
+            'updatedAt': '2019-02-13T23:37:38.000Z'
+        }
+    }
+
+
+def test_query(config, mock_socrata):
     p = SODAServiceProvider(config)
 
     results = p.query()
@@ -72,7 +190,7 @@ def test_query(config):
     assert results['numberMatched'] == 1006
 
 
-def test_geometry(config):
+def test_geometry(config, mock_socrata):
     p = SODAServiceProvider(config)
 
     results = p.query()
@@ -82,56 +200,19 @@ def test_geometry(config):
     results = p.query(skip_geometry=True)
     assert results['features'][0]['geometry'] is None
 
-    bbox = [-109, 37, -102, 41]
-    results = p.query(bbox=bbox)
-    assert results['numberMatched'] == 0
 
-    bbox = [-178.2, 18.9, -66.9, 71.4]
-    results = p.query(bbox=bbox)
-    assert results['numberMatched'] == 817
-
-    feature = results['features'][0]
-    x, y = feature['geometry']['coordinates']
-    xmin, ymin, xmax, ymax = bbox
-    assert xmin <= x <= xmax
-    assert ymin <= y <= ymax
-
-
-def test_query_properties(config):
+def test_query_properties(config, mock_socrata):
     p = SODAServiceProvider(config)
 
     results = p.query()
-    assert len(results['features'][0]['properties']) == 11
+    assert len(results['features'][0]['properties']) == 2
 
     # Query by property
     results = p.query(properties=[('region', 'Nevada'), ])
     assert results['numberMatched'] == 19
 
-    results = p.query(properties=[('region', 'Northern California'), ])
-    assert results['numberMatched'] == 119
 
-    # Query for property
-    results = p.query(select_properties=['magnitude', ])
-    assert len(results['features'][0]['properties']) == 1
-    assert 'magnitude' in results['features'][0]['properties']
-
-    # Query with configured properties
-    config['properties'] = ['region', 'datetime', 'magnitude']
-    p = SODAServiceProvider(config)
-
-    results = p.query()
-    props = results['features'][0]['properties']
-    assert all(p in props for p in config['properties'])
-    assert len(props) == 3
-
-    results = p.query(properties=[('region', 'Central California'), ])
-    assert results['numberMatched'] == 92
-
-    results = p.query(select_properties=['region', ])
-    assert len(results['features'][0]['properties']) == 1
-
-
-def test_query_sortby_datetime(config):
+def test_query_sortby_datetime(config, mock_socrata):
     p = SODAServiceProvider(config)
 
     results = p.query(sortby=[{'property': 'datetime', 'order': '+'}])
@@ -142,18 +223,8 @@ def test_query_sortby_datetime(config):
     dt = results['features'][0]['properties']['datetime']
     assert dt == '2012-09-14T22:38:01.000'
 
-    results = p.query(datetime_='../2012-09-10T00:00:00.00Z',
-                      sortby=[{'property': 'datetime', 'order': '-'}])
-    dt = results['features'][0]['properties']['datetime']
-    assert dt == '2012-09-09T23:57:50.000'
 
-    results = p.query(datetime_='2012-09-10T00:00:00.00Z/..',
-                      sortby=[{'property': 'datetime', 'order': '+'}])
-    dt = results['features'][0]['properties']['datetime']
-    assert dt == '2012-09-10T00:04:44.000'
-
-
-def test_get(config):
+def test_get(config, mock_socrata):
     p = SODAServiceProvider(config)
 
     result = p.get('00388610')

--- a/tests/test_socrata_provider_live.py
+++ b/tests/test_socrata_provider_live.py
@@ -1,0 +1,165 @@
+# =================================================================
+#
+# Authors: Benjamin Webb <bwebb@lincolninst.edu>
+#
+# Copyright (c) 2022 Benjamin Webb
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+import pytest
+
+from pygeoapi.provider.socrata import SODAServiceProvider
+
+# we don't run these tests by default because they depend on
+# external servers which is slow and sometimes fails
+pytest.skip("skipping live tests", allow_module_level=True)
+
+
+@pytest.fixture()
+def config():
+    # USGS Earthquakes
+    # source: [USGS](http://usgs.gov)
+    # URL: https://soda.demo.socrata.com/dataset/emdb-u46w
+    # License: CC0 3.0 https://creativecommons.org/licenses/by-sa/3.0/
+    return {
+        'name': 'SODAServiceProvider',
+        'type': 'feature',
+        'data': 'https://soda.demo.socrata.com/',
+        'resource_id': 'emdb-u46w',
+        'id_field': 'earthquake_id',
+        'time_field': 'datetime',
+        'geom_field': 'location'
+    }
+
+
+def test_query(config):
+    p = SODAServiceProvider(config)
+
+    results = p.query()
+    assert results['features'][0]['id'] == '00388610'
+    assert results['numberReturned'] == 10
+
+    results = p.query(limit=50)
+    assert results['numberReturned'] == 50
+    feature_10 = results['features'][10]
+
+    results = p.query(offset=10)
+    assert results['features'][0] == feature_10
+    assert results['numberReturned'] == 10
+
+    results = p.query(limit=10)
+    assert len(results['features']) == 10
+    assert results['numberMatched'] == 1006
+
+    results = p.query(limit=10001, resulttype='hits')
+    assert results['numberMatched'] == 1006
+
+
+def test_geometry(config):
+    p = SODAServiceProvider(config)
+
+    results = p.query()
+    geometry = results['features'][0]['geometry']
+    assert geometry['coordinates'] == [-117.6135, 41.1085]
+
+    results = p.query(skip_geometry=True)
+    assert results['features'][0]['geometry'] is None
+
+    bbox = [-109, 37, -102, 41]
+    results = p.query(bbox=bbox)
+    assert results['numberMatched'] == 0
+
+    bbox = [-178.2, 18.9, -66.9, 71.4]
+    results = p.query(bbox=bbox)
+    assert results['numberMatched'] == 817
+
+    feature = results['features'][0]
+    x, y = feature['geometry']['coordinates']
+    xmin, ymin, xmax, ymax = bbox
+    assert xmin <= x <= xmax
+    assert ymin <= y <= ymax
+
+
+def test_query_properties(config):
+    p = SODAServiceProvider(config)
+
+    results = p.query()
+    assert len(results['features'][0]['properties']) == 11
+
+    # Query by property
+    results = p.query(properties=[('region', 'Nevada'), ])
+    assert results['numberMatched'] == 19
+
+    results = p.query(properties=[('region', 'Northern California'), ])
+    assert results['numberMatched'] == 119
+
+    # Query for property
+    results = p.query(select_properties=['magnitude', ])
+    assert len(results['features'][0]['properties']) == 1
+    assert 'magnitude' in results['features'][0]['properties']
+
+    # Query with configured properties
+    config['properties'] = ['region', 'datetime', 'magnitude']
+    p = SODAServiceProvider(config)
+
+    results = p.query()
+    props = results['features'][0]['properties']
+    assert all(p in props for p in config['properties'])
+    assert len(props) == 3
+
+    results = p.query(properties=[('region', 'Central California'), ])
+    assert results['numberMatched'] == 92
+
+    results = p.query(select_properties=['region', ])
+    assert len(results['features'][0]['properties']) == 1
+
+
+def test_query_sortby_datetime(config):
+    p = SODAServiceProvider(config)
+
+    results = p.query(sortby=[{'property': 'datetime', 'order': '+'}])
+    dt = results['features'][0]['properties']['datetime']
+    assert dt == '2012-09-07T23:00:42.000'
+
+    results = p.query(sortby=[{'property': 'datetime', 'order': '-'}])
+    dt = results['features'][0]['properties']['datetime']
+    assert dt == '2012-09-14T22:38:01.000'
+
+    results = p.query(datetime_='../2012-09-10T00:00:00.00Z',
+                      sortby=[{'property': 'datetime', 'order': '-'}])
+    dt = results['features'][0]['properties']['datetime']
+    assert dt == '2012-09-09T23:57:50.000'
+
+    results = p.query(datetime_='2012-09-10T00:00:00.00Z/..',
+                      sortby=[{'property': 'datetime', 'order': '+'}])
+    dt = results['features'][0]['properties']['datetime']
+    assert dt == '2012-09-10T00:04:44.000'
+
+
+def test_get(config):
+    p = SODAServiceProvider(config)
+
+    result = p.get('00388610')
+    assert result['id'] == '00388610'
+    assert result['properties']['magnitude'] == '2.7'


### PR DESCRIPTION
# Overview

The socrata sever under https://soda.demo.socrata.com/ is not completely reliable, which frequently leads to CI failures, see e.g.:  [1](https://github.com/geopython/pygeoapi/actions/runs/12344100688/job/34446167944#step:22:716) [2](https://github.com/geopython/pygeoapi/actions/runs/12340554140/job/34438145035#step:22:716) [3](https://github.com/totycro/pygeoapi/actions/runs/12253568265/job/34182570517)

This PR introduces basic tests for the `SODAServiceProvider` and moves existing test to a separate live tests file which is skipped by default (but can be run manually any time). This is analogous to the OGR WFS tests.


# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
