### PR TITLE
Ensure STA only uses configured netloc

### DIFF
--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -213,7 +213,7 @@ class SensorThingsProvider(BaseProvider):
 
                 # Ensure we only use provided network location
                 next_ = next_.replace(urlparse(next_).netloc,
-                                        urlparse(self.data).netloc)
+                                      urlparse(self.data).netloc)
 
                 response = self._get_response(next_)
                 v.extend(response['value'])

--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -32,6 +32,7 @@
 from json.decoder import JSONDecodeError
 import logging
 from requests import Session
+from urllib.parse import urlparse
 
 from pygeoapi.config import get_config
 from pygeoapi.provider.base import (
@@ -209,6 +210,11 @@ class SensorThingsProvider(BaseProvider):
             try:
                 LOGGER.debug('Fetching next set of values')
                 next_ = response['@iot.nextLink']
+
+                # Ensure we only use provided network location
+                next_ = next_.replace(urlparse(next_).netloc,
+                                        urlparse(self.data).netloc)
+
                 response = self._get_response(next_)
                 v.extend(response['value'])
             except (ProviderConnectionError, KeyError):


### PR DESCRIPTION
# Overview
Address edgecase where SensorthingsAPI returns a network location inaccessible by pygeoapi by ensuring any backfill requests we make use the configured network location instead of the response network location

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
