### PR TITLE
Elasticsearch: relax properties query for indexes with varying mappings

### DIFF
--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -489,8 +489,8 @@ class ElasticsearchProvider(BaseProvider):
                 try:
                     feature_thinned['properties'][p] = feature_['properties'][p]  # noqa
                 except KeyError as err:
-                    LOGGER.error(err)
-                    raise ProviderQueryError()
+                    msg = f'Property missing {err}; continuing')
+                    LOGGER.warning(msg)
 
         if feature_thinned:
             return feature_thinned

--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -489,7 +489,7 @@ class ElasticsearchProvider(BaseProvider):
                 try:
                     feature_thinned['properties'][p] = feature_['properties'][p]  # noqa
                 except KeyError as err:
-                    msg = f'Property missing {err}; continuing')
+                    msg = f'Property missing {err}; continuing'
                     LOGGER.warning(msg)
 
         if feature_thinned:


### PR DESCRIPTION
# Overview
This PR relaxes ES `properties=` queries for indexes with varying mappings (aligning/consistent with other NoSQL providers [i.e. TinyDB and MongoDB]).

# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
OGC API - Features - Part 6 provides the following for this behaviour in [Permission 2A](https://github.com/opengeospatial/ogcapi-features/blob/master/extensions/property-selection/standard/clause_6_properties.adoc):

> If the parameter value includes unknown properties, the server MAY either return a 400 (Bad Request) response or ignore the unknown properties.


# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
