### PR TITLE
Updates for parsing with STAC browser

### DIFF
--- a/pygeoapi/provider/hateoas.py
+++ b/pygeoapi/provider/hateoas.py
@@ -120,7 +120,7 @@ class HateoasProvider(BaseProvider):
             try:
                 jsondata = _get_json_data(f'{data_path}/collection.json')
                 resource_type = 'Collection'
-                for key in ['license', 'extent']:
+                for key in ['license', 'extent', 'id']:
                     if key in jsondata:
                         content[key] = jsondata[key]
             except Exception:
@@ -151,7 +151,7 @@ class HateoasProvider(BaseProvider):
                     child_links.append({
                         'rel': 'child',
                         'href': newpath,
-                        'type': 'text/html',
+                        'type': 'application/json',
                         'created': "-",
                         'entry:type': 'Catalog'
                     })
@@ -159,7 +159,7 @@ class HateoasProvider(BaseProvider):
                     child_links.append({
                         'rel': 'child',
                         'href': newpath,
-                        'type': 'text/html',
+                        'type': 'application/json',
                         'created': "-",
                         'entry:type': 'Collection'
                     })


### PR DESCRIPTION
# Overview
This update allows the STAC created with the hateoas provider to be parsed with STAC browser: https://radiantearth.github.io/stac-browser/#/?.language=en

These are minor tweaks to change the `type` as well as to update the `id` for collections that contain additional collections within them.

# Related Issue / discussion
Started the conversation [here](https://code.usgs.gov/wma/nhgf/pygeoapi/-/issues/29) and migrated [here](https://code.usgs.gov/wma/nhgf/pygeoapi/-/issues/44) with @dblodgett-usgs



# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this update to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
