### PR TITLE
Implement OGC API Features Part 4 transactions for the postgres provider

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -29,7 +29,7 @@ parameters.
    `OpenSearch`_,✅/✅,results/hits,✅,✅,✅,✅,✅,✅,✅
    `Oracle`_,✅/✅,results/hits,✅,❌,✅,✅,❌,❌,✅
    `Parquet`_,✅/✅,results/hits,✅,✅,❌,✅,❌,❌,✅
-   `PostgreSQL`_,✅/✅,results/hits,✅,✅,✅,✅,✅,❌,✅
+   `PostgreSQL`_,✅/✅,results/hits,✅,✅,✅,✅,✅,✅,✅
    `SQLiteGPKG`_,✅/❌,results/hits,✅,❌,❌,✅,❌,❌,✅
    `SensorThings API`_,✅/✅,results/hits,✅,✅,✅,✅,❌,❌,✅
    `Socrata`_,✅/✅,results/hits,✅,✅,✅,✅,❌,❌,✅

--- a/tests/pygeoapi-test-config-postgresql.yml
+++ b/tests/pygeoapi-test-config-postgresql.yml
@@ -134,6 +134,7 @@ resources:
                 user: postgres
                 password: postgres
                 search_path: [osm, public]
+            editable: true
             options:
                 # Maximum time to wait while connecting, in seconds.
                 connect_timeout: 10


### PR DESCRIPTION
# Overview

This PR implements `create()`, `update()` and `delete()` in the postgres provider. The behavior is analogous to implementations in other providers and as defined by the standard.

The implementation is pretty basic, i can add more advanced logic if necessary (e.g. inputs which are not in WGS 84).

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
