### PR TITLE
Fix typo in Docker documentation

### DIFF
--- a/docs/source/running-with-docker.rst
+++ b/docs/source/running-with-docker.rst
@@ -92,7 +92,7 @@ The base Docker image supports two additional environment variables for configur
 
       docker run -p 5000:80 -e PYGEOAPI_SERVER_ADMIN=true -it geopython/pygeoapi
 
-   This does not enable hot reloading of the `pygoeapi` configuration. To learn more about the Admin API see :ref:`admin-api`.
+   This does not enable hot reloading of the `pygeoapi` configuration. To learn more about the Admin API see :ref:`admin-api`.
 
 
 Deploying on a sub-path


### PR DESCRIPTION
# Overview

This tiny PR fixes a letter swap in the Docker docs page.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
