### PR TITLE
update starlette documentation

### DIFF
--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -100,7 +100,7 @@ To integrate pygeoapi as part of another Starlette application:
    from starlette.applications import Starlette
    from starlette.responses import PlainTextResponse
    from starlette.routing import Route
-   from pygeoapi.starlette_app import app as pygeoapi_app
+   from pygeoapi.starlette_app import APP as pygeoapi_app
 
 
    async def homepage(request):


### PR DESCRIPTION
# Overview

# Related Issue / discussion

The [Starlette documentation](https://dive.pygeoapi.io/advanced/downstream-applications/#starlette-and-fastapi) gives this example:

```python
from pygeoapi.starlette_app import app as pygeoapi_app
```

but it doesn't work since "app" has been renamed "APP" in #1152. This PR fixes the documentation.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [docs] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
