### PR TITLE
Add outputs to pygeoapi processes in core

### DIFF
--- a/pygeoapi/process/echo.py
+++ b/pygeoapi/process/echo.py
@@ -115,7 +115,7 @@ class EchoProcessor(BaseProcessor):
 
         super().__init__(processor_def, PROCESS_METADATA)
 
-    def execute(self, data, **kwargs):
+    def execute(self, data, outputs=None):
 
         mimetype = 'application/json'
 

--- a/pygeoapi/process/hello_world.py
+++ b/pygeoapi/process/hello_world.py
@@ -119,7 +119,7 @@ class HelloWorldProcessor(BaseProcessor):
         super().__init__(processor_def, PROCESS_METADATA)
         self.supports_outputs = True
 
-    def execute(self, data, outputs=None, **kwargs):
+    def execute(self, data, outputs=None):
         mimetype = 'application/json'
         name = data.get('name')
 

--- a/pygeoapi/process/shapely_functions.py
+++ b/pygeoapi/process/shapely_functions.py
@@ -249,7 +249,7 @@ class ShapelyFunctionsProcessor(BaseProcessor):
         self.supported_formats = [fmt.value for fmt in SupportedFormats]
         super().__init__(processor_def, PROCESS_METADATA)
 
-    def execute(self, data, **kwargs) -> Tuple[str, Dict[str, Any]]:
+    def execute(self, data, outputs=None) -> Tuple[str, Dict[str, Any]]:
         mimetype = "application/json"
         operation = data.get("operation")
         output_format = data.get("output_format")


### PR DESCRIPTION
# Overview
Add output kwarg to process execute function to be able to handle pygeoapi OAProc execution request.

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/1901
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
