### PR TITLE
OACov: add support for UAD, override temporal extents from provider 

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1161,6 +1161,16 @@ def describe_collections(api: API, request: APIRequest,
                         'cellsCount': p._coverage_properties['height'],
                         'resolution': p._coverage_properties['resy']
                     }]
+                    if 'time_range' in p._coverage_properties:
+                        collection['extent']['temporal'] = {
+                            'interval': [p._coverage_properties['time_range']]
+                        }
+                        if 'restime' in p._coverage_properties:
+                            collection['extent']['temporal']['grid'] = {
+                                'resolution': p._coverage_properties['restime']  # noqa
+                            }
+                    if 'uad' in p._coverage_properties:
+                        collection['extent'].update(p._coverage_properties['uad'])  # noqa
 
         try:
             tile = get_provider_by_type(v['providers'], 'tile')

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -128,10 +128,10 @@ def dategetter(date_property: str, collection: dict) -> str:
 
     value = collection.get(date_property)
 
-    if value is None:
-        return None
-
-    return value.isoformat()
+    if value is None or isinstance(value, str):
+        return value
+    else:
+        return value.isoformat()
 
 
 def get_typed_value(value: str) -> Union[bool, float, int, str]:


### PR DESCRIPTION
# Overview

This PR adds the following updates in support of OACov enhancements:

- override collection temporal information if exists in coverage provider
- add unified additional extents to collection extents if exists in coverage provider
- add an option to `pygeoapi.util.dategetter` to return raw input (existing behaviour preserved) once date is validated

# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
