### PR TITLE
TinyDB: fix query data type casting

### DIFF
--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -181,7 +181,11 @@ class TinyDBProvider(BaseProvider):
         if properties:
             LOGGER.debug('processing properties')
             for prop in properties:
-                QUERY.append(f"(Q.properties['{prop[0]}']=={prop[1]})")
+                if isinstance(prop[1], str):
+                    value = f"'{prop[1]}'"
+                else:
+                    value = prop[1]
+                QUERY.append(f"(Q.properties['{prop[0]}']=={value})")
 
         QUERY = self._add_search_query(QUERY, q)
 

--- a/tests/test_tinydb_provider.py
+++ b/tests/test_tinydb_provider.py
@@ -111,6 +111,16 @@ def test_query(config):
     assert results['numberMatched'] == 1
     assert results['numberReturned'] == 1
 
+    results = p.query(properties=[('STATION_NAME', 'HUMBER RIVER AT WESTON')])
+    assert len(results['features']) == 10
+    assert results['numberMatched'] == 50
+    assert results['numberReturned'] == 10
+
+    results = p.query(properties=[('IDENTIFIER', '02HC003.1975-10-03')])
+    assert len(results['features']) == 1
+    assert results['numberMatched'] == 1
+    assert results['numberReturned'] == 1
+
     results = p.query(limit=1)
     assert len(results['features']) == 1
     assert results['features'][0]['id'] == '02HC003.1975-10-03'


### PR DESCRIPTION
# Overview
This PR fixes TinyDB casting of data types to ensure proper quoting when querying a backend.
# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->
None
# Additional information
This PR is in support of the OGC API - Records presentation to OGC TC on 2025-01-22.
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
