### PR TITLE
Implement OGC API Features Part 4 transactions for Senosorthings provider

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -31,7 +31,7 @@ parameters.
    `Parquet`_,✅/✅,results/hits,✅,✅,❌,✅,❌,❌,✅
    `PostgreSQL`_,✅/✅,results/hits,✅,✅,✅,✅,✅,✅,✅
    `SQLiteGPKG`_,✅/❌,results/hits,✅,❌,❌,✅,❌,❌,✅
-   `SensorThings API`_,✅/✅,results/hits,✅,✅,✅,✅,❌,❌,✅
+   `SensorThings API`_,✅/✅,results/hits,✅,✅,✅,✅,❌,✅,✅
    `Socrata`_,✅/✅,results/hits,✅,✅,✅,✅,❌,❌,✅
    `TinyDB`_,✅/✅,results/hits,✅,✅,✅,✅,❌,✅,✅
 

--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -264,13 +264,12 @@ class SensorThingsProvider(BaseProvider):
         v = response.get('value')
         while len(v) < limit:
             try:
-                LOGGER.debug('Fetching next set of values')
-                next_ = response['@iot.nextLink']
-
                 # Ensure we only use provided network location
-                next_ = next_.replace(urlparse(next_).netloc,
-                                      urlparse(self.data).netloc)
+                next_ = urlparse(response['@iot.nextLink'])._replace(
+                    scheme=self.parsed_url.scheme, netloc=self.parsed_url.netloc
+                ).geturl()
 
+                LOGGER.debug('Fetching next set of values')
                 response = self._get_response(next_)
                 v.extend(response['value'])
             except (ProviderConnectionError, KeyError):
@@ -572,6 +571,8 @@ class SensorThingsProvider(BaseProvider):
             self.entity = self._get_entity(self.data)
             self._url = self.data
             self.data = self._url.rstrip(f'/{self.entity}')
+
+        self.parsed_url = urlparse(self.data)
 
         # Default id
         if self.id_field:

--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -194,7 +194,7 @@ class SensorThingsProvider(BaseProvider):
         id = f"'{identifier}'" \
              if isinstance(identifier, str) else str(identifier)
         LOGGER.debug(f'Updating @iot.id: {id}')
-        response = self.http.patch(f"{self._url}({id})", json=item)
+        response = self.http.put(f"{self._url}({id})", json=item)
 
         if response.status_code == 200:
             return True

--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -3,7 +3,7 @@
 # Authors: Benjamin Webb <benjamin.miller.webb@gmail.com>
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2024 Benjamin Webb
+# Copyright (c) 2025 Benjamin Webb
 # Copyright (c) 2022 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -198,7 +198,8 @@ def test_transactions(config, post_body):
     datastream = p.get(121)
     assert datastream['properties']['name'] == 'Temperature Datastream'
 
-    result = p.update(id, {'name': 'Temperature'})
+    post_body['name'] = 'Temperature'
+    result = p.update(id, post_body)
     assert result is True
 
     datastream = p.get(121)

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -2,7 +2,7 @@
 #
 # Authors: Benjamin Webb <bwebb@lincolninst.edu>
 #
-# Copyright (c) 2024 Benjamin Webb
+# Copyright (c) 2025 Benjamin Webb
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -162,3 +162,45 @@ def test_custom_expand(config):
     assert 'Observations' in fields
     assert 'ObservedProperty' not in fields
     assert 'Sensor' not in fields
+
+POST_BODY = {
+    "@iot.id": 121,
+    "name": "Temperature Datastream",
+    "description": "Datastream for measuring temperature in Celsius.",
+    "observationType": "http://www.opengis.net/def/observationType/OGC-OM/2.0/OM_Measurement",
+    "unitOfMeasurement": {
+        "name": "Degree Celsius",
+        "symbol": "degC",
+        "definition": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#DegreeCelsius"
+    },
+    "Thing": {"@iot.id": 2},
+    "ObservedProperty": {
+        "name": "Area Temperature",
+        "description": "The degree or intensity of heat present in the area",
+        "definition": "http://www.qudt.org/qudt/owl/1.0.0/quantity/Instances.html#AreaTemperature"
+    },
+    "Sensor": {"@iot.id": 5},
+    "properties": {
+        "uri": "test"
+    }
+}
+
+def test_transactions(config):
+    p = SensorThingsProvider(config)
+    results = p.query(resulttype='hits')
+    assert results['numberMatched'] == 120
+
+    id = p.create(POST_BODY)
+    assert id == 121
+    results = p.query(resulttype='hits')
+    assert results['numberMatched'] == 121
+
+    result = p.update(id, {"name": "Temperature"})
+    assert result == True
+
+    datastream = p.get(121)
+    assert datastream['properties']['name'] == 'Temperature'
+
+    assert p.delete(id)
+    results = p.query(resulttype='hits')
+    assert results['numberMatched'] == 120


### PR DESCRIPTION
# Overview
- Introduce simple OAFeat Part 4 transactions delegating entity validation to downstream SensorThings endpoint.
- Add graceful failure to incorrectly configured STA collection

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
