### PR TITLE
Use existing key for Admin OAS Patch

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -721,6 +721,14 @@ def get_admin(cfg: dict) -> dict:
     res_eg = {
         res_eg_key: cfg['resources'][res_eg_key]
     }
+    if 'extents' in res_eg[res_eg_key]:
+        res_eg_eg_key = 'extents'
+    elif 'type' in res_eg[res_eg_key]:
+        res_eg_eg_key = 'type'
+
+    res_eg[res_eg_key]['patch_example'] = {
+        res_eg_eg_key: res_eg[res_eg_key][res_eg_eg_key]
+    }
 
     paths['/admin/config'] = {
         'get': {
@@ -887,7 +895,7 @@ def get_admin(cfg: dict) -> dict:
                 'description': 'Updates admin configuration resource',
                 'content': {
                     'application/json': {
-                        'example': {'type': res_eg[res_eg_key]['type']},
+                        'example': res_eg[res_eg_key]['patch_example'],
                         'schema': schema_dict['properties']['resources']['patternProperties']['^.*$']  # noqa
                     }
                 },

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -719,7 +719,7 @@ def get_admin(cfg: dict) -> dict:
 
     res_eg_key = next(iter(cfg['resources']))
     res_eg = {
-        res_eg_key: deepcopy(cfg['resources'][res_eg_key])
+        res_eg_key: cfg['resources'][res_eg_key]
     }
 
     paths['/admin/config'] = {

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -719,7 +719,7 @@ def get_admin(cfg: dict) -> dict:
 
     res_eg_key = next(iter(cfg['resources']))
     res_eg = {
-        res_eg_key: cfg['resources'][res_eg_key]
+        res_eg_key: deepcopy(cfg['resources'][res_eg_key])
     }
 
     paths['/admin/config'] = {
@@ -887,7 +887,7 @@ def get_admin(cfg: dict) -> dict:
                 'description': 'Updates admin configuration resource',
                 'content': {
                     'application/json': {
-                        'example': {'extents': res_eg[res_eg_key]['extents']},
+                        'example': {'type': res_eg[res_eg_key]['type']},
                         'schema': schema_dict['properties']['resources']['patternProperties']['^.*$']  # noqa
                     }
                 },


### PR DESCRIPTION
# Overview
Updates the Admin OpenAPI document to use the only key common across all pygeoapi resource types

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/1912
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
