### PR TITLE
update Elasticsearch and MongoDB in CI to match pygeoapi-examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Install and run Elasticsearch 📦
       uses: getong/elasticsearch-action@v1.2
       with:
-        elasticsearch version: '8.3.1'
+        elasticsearch version: '8.17.0'
         host port: 9200
         container port: 9200
         host node port: 9300
@@ -71,7 +71,7 @@ jobs:
     - name: Install and run MongoDB
       uses: supercharge/mongodb-github-action@1.12.0
       with:
-        mongodb-version: 4.4
+        mongodb-version: '8.0.4'
     - name: Install and run SensorThingsAPI
       uses: cgs-earth/sensorthings-action@v0.1.0
     - name: Install sqlite and gpkg dependencies


### PR DESCRIPTION
# Overview
Bumps Elasticsearch and MongoDB versions in CI to match official examples in [pygeoapi-examples](https://github.com/geopython/pygeoapi-examples).

# Related Issue / discussion
https://github.com/geopython/pygeoapi-examples/pull/22
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
