### PR TITLE
Remove duplicated/unused 'get_manager' function

### DIFF
--- a/pygeoapi/process/manager/__init__.py
+++ b/pygeoapi/process/manager/__init__.py
@@ -29,35 +29,4 @@
 #
 # =================================================================
 
-import logging
-from typing import Dict
-
-from pygeoapi.plugin import load_plugin
-from pygeoapi.process.manager.base import BaseManager
-
-LOGGER = logging.getLogger(__name__)
-
-
-def get_manager(config: Dict) -> BaseManager:
-    """Instantiate process manager from the supplied configuration.
-
-    :param config: pygeoapi configuration
-
-    :returns: The pygeoapi process manager object
-    """
-    manager_conf = config.get('server', {}).get(
-        'manager',
-        {
-            'name': 'Dummy',
-            'connection': None,
-            'output_dir': None
-        }
-    )
-    processes_conf = {}
-    for id_, resource_conf in config.get('resources', {}).items():
-        if resource_conf.get('type') == 'process':
-            processes_conf[id_] = resource_conf
-    manager_conf['processes'] = processes_conf
-    if manager_conf.get('name') == 'Dummy':
-        LOGGER.info('Starting dummy manager')
-    return load_plugin('process_manager', manager_conf)
+"""OGC process manager package"""


### PR DESCRIPTION
# Overview

# Related Issue / discussion

Remove duplicated/unused `get_manager` function, first introduced in `__init__.py`, then copied to `base.py`, but the original function remained and became dead code.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
