### PR TITLE
Add processing directive for raster layers on mapscript/OAMaps

### DIFF
--- a/pygeoapi/provider/mapscript_.py
+++ b/pygeoapi/provider/mapscript_.py
@@ -111,6 +111,9 @@ class MapScriptProvider(BaseProvider):
                     cls.updateFromString(cls_def)
                     self._layer.insertClass(cls)
 
+            if self.options['type'] == 'MS_LAYER_RASTER':
+                self._layer.addProcessing('SCALE=AUTO')
+
         except MapServerError as err:
             LOGGER.warning(err)
             raise ProviderConnectionError('Cannot connect to map service')


### PR DESCRIPTION
# Overview

# Related Issue / discussion

https://github.com/geopython/pygeoapi/issues/1919

# Additional information

This PR adds a processing directive to the generated mapfile:

```
  LAYER
    DATA "/pygeoapi/sample-wgs84.tif"
    PROCESSING "SCALE=AUTO"
    PROJECTION
      "proj=longlat"
      "datum=WGS84"
      "no_defs"
    END # PROJECTION
    STATUS ON
    TILEITEM "location"
    TYPE RASTER
    UNITS METERS
  END # LAYER

```
Like this, MapScript is able to display the map correctly

![Screenshot from 2025-02-03 17-54-33](https://github.com/user-attachments/assets/d612c1bc-39d4-41db-a48b-a07976f4642d)

Reference to this issue on Stack Overflow:
https://gis.stackexchange.com/questions/132060/mapserver-map-file-shows-raster-image-as-white

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
