### PR TITLE
Fix SensorThings URI field retention

### DIFF
--- a/pygeoapi/provider/sensorthings.py
+++ b/pygeoapi/provider/sensorthings.py
@@ -484,8 +484,13 @@ class SensorThingsProvider(BaseProvider):
             self._expand_location(feature['Thing'])
 
         # Retain URI if present
-        if feature.get('properties') and self.uri_field:
-            uri = feature['properties']
+        try:
+            if self.uri_field is not None:
+                uri = feature['properties'][self.uri_field]
+        except KeyError:
+            msg = f'Unable to find uri field: {self.uri_field}'
+            LOGGER.error(msg)
+            raise ProviderInvalidDataError(msg)
 
         # Create intra links
         for k, v in feature.items():
@@ -506,7 +511,7 @@ class SensorThingsProvider(BaseProvider):
             ret = {k: feature.pop(k) for k in keys}
             feature = ret
 
-        if self.uri_field is not None and uri != '':
+        if self.uri_field is not None:
             feature[self.uri_field] = uri
 
         return feature

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -29,6 +29,7 @@
 
 import pytest
 
+from pygeoapi.provider.base import ProviderInvalidDataError
 from pygeoapi.provider.sensorthings import SensorThingsProvider
 
 
@@ -196,6 +197,12 @@ def test_custom_uri_field(config):
     assert result['properties']['uri'] == \
         'https://geoconnex.us/iow/sta-demo/timeseries/9'
     assert len(result['properties']) == 2
+
+    config['uri_field'] = 'bad_uri'
+    p = SensorThingsProvider(config)
+    with pytest.raises(ProviderInvalidDataError,
+                       match=".*Unable to find uri field: bad_uri"):
+        result = p.get('9')
 
 
 def test_transactions(config, post_body):

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -185,6 +185,19 @@ def test_custom_expand(config):
     assert 'Sensor' not in fields
 
 
+def test_custom_uri_field(config):
+    config['uri_field'] = 'urai'
+    config['properties'] = ['name']
+    p = SensorThingsProvider(config)
+
+    result = p.get('9')
+    assert result['id'] == '9'
+    assert result['properties']['name'] == 'Depth Below Surface'
+    assert result['properties']['uri'] == \
+        'https://geoconnex.us/iow/sta-demo/timeseries/9'
+    assert len(result['properties']) == 2
+
+
 def test_transactions(config, post_body):
     p = SensorThingsProvider(config)
     results = p.query(resulttype='hits')

--- a/tests/test_sensorthings_provider.py
+++ b/tests/test_sensorthings_provider.py
@@ -186,7 +186,7 @@ def test_custom_expand(config):
 
 
 def test_custom_uri_field(config):
-    config['uri_field'] = 'urai'
+    config['uri_field'] = 'uri'
     config['properties'] = ['name']
     p = SensorThingsProvider(config)
 


### PR DESCRIPTION
# Overview
This PR fixes the retention and setting of the `uri_field` for the Sensorthings Provider. This is to ensure that the uri field is present in the response if configured. This also fixes an issue with STA incorrectly setting the URI field. 

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
