### PR TITLE
Added information about projection of mapscript provider

### DIFF
--- a/docs/source/data-publishing/ogcapi-maps.rst
+++ b/docs/source/data-publishing/ogcapi-maps.rst
@@ -62,6 +62,17 @@ Currently supported style files (`options.style`):
             name: png
             mimetype: image/png
 
+Projections are supported through EPSG codes (`options.projection`):        
+
+.. code-block:: yaml
+
+           options:
+             type: MS_LAYER_POINT
+             layer: foo_name
+             projection: 32631
+
+This parameter is optional, defaulting to WGS84 (4236).
+
 WMSFacade
 ^^^^^^^^^
 


### PR DESCRIPTION
# Overview

Updated docs with information about how to pass projections to the mapscript provider.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
