### PR TITLE
Added support to tileindexing on MapScript provider

### DIFF
--- a/docs/source/data-publishing/ogcapi-maps.rst
+++ b/docs/source/data-publishing/ogcapi-maps.rst
@@ -73,9 +73,9 @@ Projections are supported through EPSG codes (`options.projection`):
 
 This parameter is optional, defaulting to WGS84 (4236).
 
-This provider also supports `tileindexing <https://mapserver.org/optimization/tileindex.html>`_,
-which let MapScript create a mosaic on the fly, piecing together a set of files. 
-In order to enable it, set `options.tileindex` to True and set the location of the index file on the `data` path.
+This provider also supports `tile indexing <https://mapserver.org/optimization/tileindex.html>`_,
+which lets MapScript create a mosaic on the fly, piecing together a set of files. 
+In order to enable it, set `options.tileindex` to `True` and set the location of the index file on the `data` path.
 
 .. code-block:: yaml
 
@@ -91,7 +91,7 @@ In order to enable it, set `options.tileindex` to True and set the location of t
                 name: png
                 mimetype: image/png
 
-The `options.tileindex` parameter is optional, defaulting to False.
+The `options.tileindex` parameter is optional, defaulting to `False`.
 
 WMSFacade
 ^^^^^^^^^

--- a/docs/source/data-publishing/ogcapi-maps.rst
+++ b/docs/source/data-publishing/ogcapi-maps.rst
@@ -73,6 +73,26 @@ Projections are supported through EPSG codes (`options.projection`):
 
 This parameter is optional, defaulting to WGS84 (4236).
 
+This provider also supports `tileindexing <https://mapserver.org/optimization/tileindex.html>`_,
+which let MapScript create a mosaic on the fly, piecing together a set of files. 
+In order to enable it, set `options.tileindex` to True and set the location of the index file on the `data` path.
+
+.. code-block:: yaml
+
+        providers:
+          - type: map
+            name: MapScript
+            data: /data/index.shp
+            options:
+                type: MS_LAYER_RASTER
+                tileindex: True
+                layer: index
+            format:
+                name: png
+                mimetype: image/png
+
+The `options.tileindex` parameter is optional, defaulting to False.
+
 WMSFacade
 ^^^^^^^^^
 

--- a/pygeoapi/provider/mapscript_.py
+++ b/pygeoapi/provider/mapscript_.py
@@ -34,7 +34,8 @@ import mapscript
 from mapscript import MapServerError
 
 from pygeoapi.provider.base import (BaseProvider, ProviderConnectionError,
-                                    ProviderGenericError, ProviderQueryError)
+                                    ProviderQueryError)
+from pygeoapi.util import (str2bool)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -74,13 +75,8 @@ class MapScriptProvider(BaseProvider):
 
             file_extension = self.data.split('.')[-1]
 
-            tileindex = False
-            if 'tileindex' in self.options:
-                if (self.options['tileindex'] is not True and self.options['tileindex'] is not False): # noqa
-                    raise ProviderGenericError('Invalid tileindex parameter')
-                tileindex = bool(self.options['tileindex'])
-
-            if tileindex is True:
+            # self._layer.tileindex = False
+            if 'tileindex' in self.options and str2bool(self.options.get('tileindex', False)): # noqa
                 self._layer.tileindex = self.data
             else:
                 if file_extension in ['shp', 'tif']:

--- a/pygeoapi/provider/mapscript_.py
+++ b/pygeoapi/provider/mapscript_.py
@@ -75,7 +75,8 @@ class MapScriptProvider(BaseProvider):
 
             file_extension = self.data.split('.')[-1]
 
-            if 'tileindex' in self.options and str2bool(self.options.get('tileindex', False)): # noqa
+            if str2bool(self.options.get('tileindex', False)):
+                LOGGER.debug('Setting tileindex')
                 self._layer.tileindex = self.data
             else:
                 if file_extension in ['shp', 'tif']:

--- a/pygeoapi/provider/mapscript_.py
+++ b/pygeoapi/provider/mapscript_.py
@@ -35,7 +35,7 @@ from mapscript import MapServerError
 
 from pygeoapi.provider.base import (BaseProvider, ProviderConnectionError,
                                     ProviderQueryError)
-from pygeoapi.util import (str2bool)
+from pygeoapi.util import str2bool
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/provider/mapscript_.py
+++ b/pygeoapi/provider/mapscript_.py
@@ -75,7 +75,6 @@ class MapScriptProvider(BaseProvider):
 
             file_extension = self.data.split('.')[-1]
 
-            # self._layer.tileindex = False
             if 'tileindex' in self.options and str2bool(self.options.get('tileindex', False)): # noqa
                 self._layer.tileindex = self.data
             else:


### PR DESCRIPTION
# Overview

This PR adds the ability to create tileindexes with the MapScript provider.  For enabling tile indexing, the provider options need to include an index file (which can be generated with gdalindex) and a `tileindex` parameter that should be set to True. This parameter is completely optional, and the default value is `False` (e.g.: no tileindex). This change is backwards compatible.

```
        providers:
          - type: map
            name: MapScript
            data: /data/orto_index_all.shp
            options:
                type: MS_LAYER_RASTER
                projection: 3763
                tileindex: True
                debug: MS_DEBUGLEVEL_VVV
                layer: sample
            format:
                name: png
                mimetype: image/png

```
# Related Issue / discussion

https://github.com/geopython/pygeoapi/issues/1930

# Additional information

Example of a raster mosaic generated in pygeoapi, based on the index file:

![Screenshot from 2025-02-07 19-43-47](https://github.com/user-attachments/assets/89bd009e-a13b-4d43-8347-82016be42b02)

![Screenshot from 2025-02-07 19-45-22](https://github.com/user-attachments/assets/34ae3fa7-6a35-459a-8c23-d0719cfbc582)

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
