### PR TITLE
support process output schemas in OpenAPI if exists

### DIFF
--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -743,6 +743,25 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
                 }
             }
         }
+
+        try:
+            first_key = list(p.metadata['outputs'])[0]
+            p_output = p.metadata['outputs'][first_key]
+
+            if p_output.get('schema') is not None:
+                LOGGER.debug('Adding output schema')
+                content_media_type = p_output['schema'].pop('contentMediaType', 'application/json')  # noqa
+                paths[f'{process_name_path}/execution']['post']['responses']['200'] = {  # noqa
+                    'description': 'Process output schema',
+                    'content': {
+                        content_media_type: {
+                            'schema': p_output['schema']
+                        }
+                    }
+                }
+        except (IndexError, KeyError):
+            LOGGER.debug('No output defined')
+
         if 'example' in p.metadata:
             paths[f'{process_name_path}/execution']['post']['requestBody']['content']['application/json']['example'] = p.metadata['example']  # noqa
 


### PR DESCRIPTION
# Overview
Adds process output schemas to OpenAPI output 200 objects if exists in a process definition.
# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
