### PR TITLE
Fix API Tile Metadata JSON response

### DIFF
--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -327,9 +327,10 @@ def get_collection_tiles_metadata(
                                      'collections/tiles/metadata.html',
                                      tiles_metadata, request.locale)
 
-        return headers, HTTPStatus.OK, content
     else:
-        return headers, HTTPStatus.OK, tiles_metadata
+        content = to_json(tiles_metadata, api.pretty_print)
+
+    return headers, HTTPStatus.OK, content
 
 
 def tilematrixsets(api: API,

--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -262,7 +262,6 @@ def get_collection_tiles_data(
             err.ogc_exception_code, err.message)
 
 
-# TODO: no test for this function?
 def get_collection_tiles_metadata(
     api: API, request: APIRequest,
         dataset=None, matrix_id=None) -> Tuple[dict, int, str]:

--- a/tests/api/test_tiles.py
+++ b/tests/api/test_tiles.py
@@ -34,10 +34,12 @@
 
 import json
 from http import HTTPStatus
+import pytest
 
 from pygeoapi.api import FORMAT_TYPES, F_HTML
 from pygeoapi.api.tiles import (
-    get_collection_tiles, tilematrixset, tilematrixsets,
+    get_collection_tiles, tilematrixset,
+    tilematrixsets, get_collection_tiles_metadata
 )
 from pygeoapi.models.provider.base import TileMatrixSetEnum
 
@@ -81,6 +83,24 @@ def test_tilematrixsets(config, api_):
     assert rsp_headers['Content-Type'] == FORMAT_TYPES[F_HTML]
     # No language requested: should be set to default from YAML
     assert rsp_headers['Content-Language'] == 'en-US'
+
+
+@pytest.mark.parametrize('file_format', ['html', 'json', 'tilejson'])
+def test_get_collection_tiles_metadata_bad_request(api_, file_format):
+    req = mock_api_request({'f': file_format})
+    _, code, _ = get_collection_tiles_metadata(
+        api_, req, 'obs', 'WorldCRS84Quad')
+    assert code == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.parametrize('file_format', ['json', 'tilejson'])
+def test_get_collection_tiles_metadata_formats(api_, file_format):
+    req = mock_api_request({'f': file_format})
+    _, code, response = get_collection_tiles_metadata(
+        api_, req, 'naturalearth/lakes', matrix_id='WebMercatorQuad')
+    assert code == HTTPStatus.OK
+    data = json.loads(response)
+    assert data['title'] == 'Large Lakes'
 
 
 def test_tilematrixset(config, api_):

--- a/tests/api/test_tiles.py
+++ b/tests/api/test_tiles.py
@@ -99,8 +99,7 @@ def test_get_collection_tiles_metadata_formats(api_, file_format):
     _, code, response = get_collection_tiles_metadata(
         api_, req, 'naturalearth/lakes', matrix_id='WebMercatorQuad')
     assert code == HTTPStatus.OK
-    data = json.loads(response)
-    assert data['title'] == 'Large Lakes'
+    assert json.loads(response)
 
 
 def test_tilematrixset(config, api_):


### PR DESCRIPTION
# Overview
This PR adds a some testing for the `get_collection_tiles_metadata` method as well as ensuring the returned context is a serialized string. When the content is not serialized, it can run into issues downstream.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
