### PR TITLE
Gracefully catch tile not found

### DIFF
--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -258,7 +258,7 @@ def get_collection_tiles_data(
             HTTPStatus.BAD_REQUEST, headers, format_,
             'InvalidParameterValue', msg)
     except ProviderTileNotFoundError:
-        msg = f'Tile not found'
+        msg = 'Tile not found'
         LOGGER.info(msg)
         return headers, HTTPStatus.NOT_FOUND, msg
     except ProviderGenericError as err:

--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -49,6 +49,7 @@ from pygeoapi.models.provider.base import (TilesMetadataFormat,
 from pygeoapi.provider.base import (
     ProviderGenericError, ProviderTypeError
 )
+from pygeoapi.provider.tile import ProviderTileNotFoundError
 
 from pygeoapi.util import (
     get_provider_by_type, to_json, filter_dict_by_key_value,
@@ -256,6 +257,10 @@ def get_collection_tiles_data(
         return api.get_exception(
             HTTPStatus.BAD_REQUEST, headers, format_,
             'InvalidParameterValue', msg)
+    except ProviderTileNotFoundError:
+        msg = f'Tile not found'
+        LOGGER.info(msg)
+        return headers, HTTPStatus.NOT_FOUND, msg
     except ProviderGenericError as err:
         return api.get_exception(
             err.http_status_code, headers, request.format,

--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -35,6 +35,7 @@ from pygeoapi.provider.base_mvt import BaseMVTProvider
 from pygeoapi.provider.base import (ProviderConnectionError,
                                     ProviderGenericError,
                                     ProviderInvalidQueryError)
+from pygeoapi.provider.tile import ProviderTileNotFoundError
 from pygeoapi.models.provider.base import (
     TileSetMetadata, TileMatrixSetEnum, LinkType)
 from pygeoapi.util import is_url, url_join
@@ -176,6 +177,10 @@ class MVTElasticProvider(BaseMVTProvider):
                     data = {'fields': ['*']}
                     session.get(base_url)
                     resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}', json=data)  # noqa
+
+                    if resp.status_code == 404:
+                        raise ProviderTileNotFoundError
+
                     resp.raise_for_status()
                     return resp.content
             except requests.exceptions.RequestException as e:

--- a/pygeoapi/provider/mvt_proxy.py
+++ b/pygeoapi/provider/mvt_proxy.py
@@ -35,6 +35,7 @@ from pygeoapi.provider.base_mvt import BaseMVTProvider
 from pygeoapi.provider.base import (ProviderConnectionError,
                                     ProviderGenericError,
                                     ProviderInvalidQueryError)
+from pygeoapi.provider.tile import ProviderTileNotFoundError
 from pygeoapi.models.provider.base import (
     TileSetMetadata, LinkType)
 from pygeoapi.util import is_url, url_join
@@ -172,6 +173,9 @@ class MVTProxyProvider(BaseMVTProvider):
                         resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}.{format_}{url_query}')  # noqa
                     else:
                         resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}')  # noqa
+
+                    if resp.status_code == 404:
+                        raise ProviderTileNotFoundError
 
                     resp.raise_for_status()
                     return resp.content

--- a/pygeoapi/provider/mvt_tippecanoe.py
+++ b/pygeoapi/provider/mvt_tippecanoe.py
@@ -186,6 +186,10 @@ class MVTTippecanoeProvider(BaseMVTProvider):
             with requests.Session() as session:
                 session.get(base_url)
                 resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{extension}')  # noqa
+
+                if resp.status_code == 404:
+                    raise ProviderTileNotFoundError
+
                 resp.raise_for_status()
                 return resp.content
         except requests.exceptions.RequestException as e:


### PR DESCRIPTION
# Overview
This PR introduces graceful catching of `Not Found` errors for a Tile provider. When a Tile provider raises `ProviderTileNotFoundError` the API returns a 404 gracefully.

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/1936
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
Willing to adapt the solution - but if the expected behavior is to return a 404, I think it does make sense to not log such behavior as an error.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
