### PR TITLE
Fix pygeofilter reprojection tests

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -496,7 +496,7 @@ def test_prefetcher():
         None,
         pygeofilter.ast.GeometryIntersects(
             pygeofilter.ast.Attribute(name='geometry'),
-            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955418)})  # noqa
+            Geometry({'type': 'Point', 'coordinates': (2313681.808628421, 4641307.939955416), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
         ),
         id='unnested-geometry-transformed-coords-explicit-input-crs-ewkt'
     ),
@@ -507,7 +507,7 @@ def test_prefetcher():
         None,
         pygeofilter.ast.GeometryIntersects(
             pygeofilter.ast.Attribute(name='geometry'),
-            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955418)})  # noqa
+            Geometry({'type': 'Point', 'coordinates': (2313681.808628421, 4641307.939955416), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
         ),
         id='unnested-geometry-transformed-coords-explicit-input-crs-filter-crs'
     ),
@@ -518,7 +518,7 @@ def test_prefetcher():
         None,
         pygeofilter.ast.GeometryIntersects(
             pygeofilter.ast.Attribute(name='geometry'),
-            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955418)})  # noqa
+            Geometry({'type': 'Point', 'coordinates': (2313681.808628421, 4641307.939955416), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
         ),
         id='unnested-geometry-transformed-coords-ewkt-crs-overrides-filter-crs'
     ),


### PR DESCRIPTION
# Overview
Not sure what changed, but [Build](https://github.com/geopython/pygeoapi/actions/workflows/main.yml) is now failing. For some reason the output geomtery has changed ever so slightly. This PR adjusts the expected geometry in the tests to correspond with their actual values. @MTachon wonder if you might have insights into what changed and what is the best long term test case.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
