### PR TITLE
Fix Flask Admin with API rules

### DIFF
--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -73,7 +73,12 @@ BLUEPRINT = Blueprint(
     static_folder=STATIC_FOLDER,
     url_prefix=API_RULES.get_url_prefix('flask')
 )
-ADMIN_BLUEPRINT = Blueprint('admin', __name__, static_folder=STATIC_FOLDER)
+ADMIN_BLUEPRINT = Blueprint(
+    'admin',
+    __name__,
+    static_folder=STATIC_FOLDER,
+    url_prefix=API_RULES.get_url_prefix('flask')
+)
 
 # CORS: optionally enable from config.
 if CONFIG['server'].get('cors', False):


### PR DESCRIPTION
# Overview
The Flask Admin blueprint is currently loaded without the API Rules prefixes. This PR adds the blueprint with the url prefixes if present.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
