### PR TITLE
Fix starlette get_config route in Admin API

### DIFF
--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -557,7 +557,7 @@ async def admin_config(request: Request):
     """
 
     if request.method == 'GET':
-        return await execute_from_starlette(admin_api.get_config, request,
+        return await execute_from_starlette(admin_api.get_config_, request,
                                             alternative_api=ADMIN)
     elif request.method == 'PUT':
         return await execute_from_starlette(admin_api.put_config, request,


### PR DESCRIPTION
# Overview
Starlette incorrectly invokes the `get_config` function instead of [get_config_](https://github.com/geopython/pygeoapi/blob/107f776ea2df89c4aee7851fe62d1ba4c53ccf7f/pygeoapi/admin.py#L161). 

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
