### PR TITLE
fix `KeyError: 'updated'`  when jobs are started but haven't been updated yet

### DIFF
--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -434,6 +434,7 @@ class BaseManager:
             'process_id': process_id,
             'created': get_current_datetime(),
             'started': get_current_datetime(),
+            'updated': get_current_datetime(),
             'finished': None,
             'status': current_status.value,
             'location': None,


### PR DESCRIPTION
# Overview
When requesting the jobs from `/jobs` and said job hasn't been updated yet following error appears since `updated` key hasn't been set yet:

```
[2025-02-28T12:42:14Z] {/usr/local/lib/python3.10/dist-packages/flask/app.py:875} ERROR - Exception on /jobs [GET]  Traceback (most recent call last):                                                                                 
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 1511, in wsgi_app                              
    response = self.full_dispatch_request()                                                                        
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 919, in full_dispatch_request                  
    rv = self.handle_user_exception(e)                                                                             
  File "/usr/local/lib/python3.10/dist-packages/flask_cors/extension.py", line 194, in wrapped_function            
    return cors_after_request(app.make_response(f(*args, **kwargs)))                                               
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 917, in full_dispatch_request                  
    rv = self.dispatch_request()                                                                                   
  File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 902, in dispatch_request                       
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]        
  File "/pygeoapi/pygeoapi/flask_app.py", line 425, in get_jobs                                                    
    return execute_from_flask(processes_api.get_jobs, request)                                                     
  File "/pygeoapi/pygeoapi/flask_app.py", line 148, in execute_from_flask                                          
    headers, status, content = api_function(actual_api, api_request, *args)                                        
  File "/pygeoapi/pygeoapi/api/processes.py", line 314, in get_jobs                                                
    'updated': job_['updated']                                                                                     
KeyError: 'updated'
```


proposed solution:
setting `updated` key when adding jobs (not just when updating)

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
