### PR TITLE
Only show TMS endpoints in the landing page, when the server publishes tiles

### DIFF
--- a/pygeoapi/templates/landing_page.html
+++ b/pygeoapi/templates/landing_page.html
@@ -97,12 +97,14 @@
         <a href="{{ config['server']['url'] }}/conformance?f=html">{% trans %}View the conformance classes of this service{% endtrans %}</a>
       </p>
   </section>
+{% if data['tiles'] %}
   <section id="tilematrixsets">
       <h2>{% trans %}Tile Matrix Sets{% endtrans %}</h2>
       <p>
         <a href="{{ config['server']['url'] }}/TileMatrixSets?f=html">{% trans %}View the Tile Matrix Sets available on this service{% endtrans %}</a>
       </p>
   </section>
+  {% endif %}
   </div>
   <div class="col-md-4 col-sm-12">
     <div class="card mb-3">


### PR DESCRIPTION
# Overview

This PR harmonizes the behavior of the TMS endpoints section of the landing page with the sections that regard other Standards (e.g.: STAC, OAP), by showing it only when the server publishes data on that Standard.

# Related Issue / discussion

https://github.com/geopython/pygeoapi/issues/1916

# Additional information

If there are not tiles in the server, it should not show the TMS endpoints.

![Screenshot from 2025-02-28 17-31-03](https://github.com/user-attachments/assets/728af70c-9773-49b2-821a-1bdc462542ca)

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
