### PR TITLE
Only show TMS endpoints in the landing page, when the server publishes tiles

### DIFF
--- a/pygeoapi/templates/landing_page.html
+++ b/pygeoapi/templates/landing_page.html
@@ -60,7 +60,7 @@
     </p>
   </section>
  {% endif %}
- {% if data['stac'] %}
+ {% if data['stac-collection'] %}
   <section id="collections">
     <h2>{% trans %}SpatioTemporal Assets{% endtrans %}</h2>
     <p>
@@ -68,7 +68,7 @@
     </p>
   </section>
  {% endif %}
- {% if data['processes'] %}
+ {% if data['process'] %}
   <section id="processes">
       <h2>{% trans %}Processes{% endtrans %}</h2>
       <p>
@@ -97,12 +97,14 @@
         <a href="{{ config['server']['url'] }}/conformance?f=html">{% trans %}View the conformance classes of this service{% endtrans %}</a>
       </p>
   </section>
+  {% if data['tile'] %}
   <section id="tilematrixsets">
       <h2>{% trans %}Tile Matrix Sets{% endtrans %}</h2>
       <p>
         <a href="{{ config['server']['url'] }}/TileMatrixSets?f=html">{% trans %}View the Tile Matrix Sets available on this service{% endtrans %}</a>
       </p>
   </section>
+  {% endif %}
   </div>
   <div class="col-md-4 col-sm-12">
     <div class="card mb-3">


### PR DESCRIPTION
# Overview

This PR removes the TMS endpoints in the landing page, when there are no tile collections.
To guess if a collection is tile, it filters the collections by provider in  __init__.py and then this information is passed to the Jinja renderer.


# Related Issue / discussion

https://github.com/geopython/pygeoapi/issues/1916

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
