### PR TITLE
refactor: replace list with set for field name lookup

### DIFF
--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -217,10 +217,10 @@ def get_collection_items(
                                            **api.api_headers)
 
     properties = []
-    reserved_fieldnames = ['bbox', 'bbox-crs', 'crs', 'f', 'lang', 'limit',
+    reserved_fieldnames = {'bbox', 'bbox-crs', 'crs', 'f', 'lang', 'limit',
                            'offset', 'resulttype', 'datetime', 'sortby',
                            'properties', 'skipGeometry', 'q',
-                           'filter', 'filter-lang', 'filter-crs']
+                           'filter', 'filter-lang', 'filter-crs'}
 
     collections = filter_dict_by_key_value(api.config['resources'],
                                            'type', 'collection')
@@ -379,7 +379,7 @@ def get_collection_items(
     LOGGER.debug('processing property parameters')
     for k, v in request.params.items():
         if k not in reserved_fieldnames:
-            if k in list(p.fields.keys()):
+            if k in p.fields.keys():
                 LOGGER.debug(f'Adding property filter {k}={v}')
             else:
                 LOGGER.debug(f'Adding additional property filter {k}={v}')


### PR DESCRIPTION
# Overview
This PR improves the efficiency of field name lookups by replacing a list with a set.  

## Changes  
- Converted `reserved_fieldnames` from a list to a set to optimize membership checks.  Now its O(1).
- Removed unnecessary `list()` conversion in `if k in p.fields.keys()`.  Now its O(1).

## Why?  
Sets provide O(1) average-time complexity for lookups, making the code more efficient.  

## Impact  
No breaking changes; this improves performance without altering functionality. 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute a performace refactor to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
