### PR TITLE
Allow storage projections other than 4326 for Postgres Provider

### DIFF
--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -108,8 +108,12 @@ class PostgreSQLProvider(BaseProvider):
         LOGGER.debug(f'ID field: {self.id_field}')
         LOGGER.debug(f'Geometry field: {self.geom}')
 
-        # conforming to the docs: https://docs.pygeoapi.io/en/latest/data-publishing/ogcapi-features.html#connection-examples
-        self.storage_crs = provider_def.get('storage_crs', 'https://www.opengis.net/def/crs/OGC/0/CRS84')
+        # conforming to the docs:
+        # https://docs.pygeoapi.io/en/latest/data-publishing/ogcapi-features.html#connection-examples # noqa
+        self.storage_crs = provider_def.get(
+            'storage_crs',
+            'https://www.opengis.net/def/crs/OGC/0/CRS84'
+        )
         LOGGER.debug(f'Configured Storage CRS: {self.storage_crs}')
 
         # Read table information from database

--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -108,6 +108,10 @@ class PostgreSQLProvider(BaseProvider):
         LOGGER.debug(f'ID field: {self.id_field}')
         LOGGER.debug(f'Geometry field: {self.geom}')
 
+        # conforming to the docs: https://docs.pygeoapi.io/en/latest/data-publishing/ogcapi-features.html#connection-examples
+        self.storage_crs = provider_def.get('storage_crs', 'https://www.opengis.net/def/crs/OGC/0/CRS84')
+        LOGGER.debug(f'Configured Storage CRS: {self.storage_crs}')
+
         # Read table information from database
         options = None
         if provider_def.get('options'):
@@ -416,7 +420,7 @@ class PostgreSQLProvider(BaseProvider):
             # NOTE: for some reason, postgis in the github action requires
             # explicit crs information. i think it's valid to assume 4326:
             # https://portal.ogc.org/files/108198#feature-crs
-            srid=4326
+            srid=pyproj.CRS.from_user_input(self.storage_crs).to_epsg()
         )
         attributes[self.id_field] = identifier
 


### PR DESCRIPTION
# Overview

# Related Issue / discussion

Having data in database in non 4326 projections and want be able to edit fails. Since 4326 is hardcoded. This small fix, allows postgres edit with storage crs as generally allowed for other providers: https://docs.pygeoapi.io/en/latest/data-publishing/ogcapi-features.html#connection-examples

It assumes that the data is submitted in the storage crs. A transformation is not happening.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this fix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
