### PR TITLE
Use returned JSON links if found in HTML

### DIFF
--- a/pygeoapi/templates/_base.html
+++ b/pygeoapi/templates/_base.html
@@ -67,22 +67,22 @@
         <a href="{{ config['server']['url'] }}">{% trans %}Home{% endtrans %}</a>
         {% endblock %}
         <span style="float: inline-end">
-          {% set links_found = namespace(json=0, jsonld=0) %}
+          {% set links_found = namespace(json='', jsonld='') %}
 
           {% for link in data['links'] %}
           {% if link['rel'] == 'alternate' and link['type'] and link['type'] in ['application/json', 'application/geo+json', 'application/prs.coverage+json'] %}
-          {% set links_found.json = 1 %}
+          {% set links_found.json = link.href | string | safe %}
           <a href="{{ link['href'] }}">{% trans %}json{% endtrans %}</a>
           {% elif link['rel'] == 'alternate' and link['type'] and link['type'] == 'application/ld+json' %}
-          {% set links_found.jsonld = 1 %}
+          {% set links_found.jsonld = link.href | string | safe %}
           <a href="{{ link['href'] }}">{% trans %}jsonld{% endtrans %}</a>
           {% endif %}
           {% endfor %}
 
-          {% if links_found.json == 0 %}
+          {% if links_found.json == '' %}
           <a href="?f=json">{% trans %}json{% endtrans %}</a>
           {% endif %}
-          {% if links_found.jsonld == 0 %}
+          {% if links_found.jsonld == '' %}
           <a href="?f=jsonld">{% trans %}jsonld{% endtrans %}</a>
           {% endif %}
 
@@ -114,7 +114,11 @@
     <script>
       // Requests and embeds JSON-LD representation of current page
       var xhr = new XMLHttpRequest();
+      {% if links_found.jsonld == '' -%}
       var path = window.location.protocol + "//" + window.location.host + window.location.pathname + "?f=jsonld";
+      {%- else -%}
+      var path = "{{ links_found.jsonld }}";
+      {%- endif %}
       xhr.open('GET', path);
       xhr.onload = function() {
         if (xhr.status === 200) {


### PR DESCRIPTION
# Overview
Use JSON-LD link if found during link creation to render JSON-LD in default HTML templates. For requests that require a parameter like EDR, pygeoapi throws an error when trying to inject the JSON-LD to the HTML template because it does not include the necessary query arguments. This PR updates the behavior such that if a JSON-LD link is found, it is then subsequently used to fetch the json-ld that is injected because it will contain the additional query arguments to fetch the appropriate url.

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/859
https://github.com/cgs-earth/RISE-EDR-Mappings/issues/16
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
