### PR TITLE
Directly render EDR JSON in HTML

### DIFF
--- a/pygeoapi/templates/collections/edr/query.html
+++ b/pygeoapi/templates/collections/edr/query.html
@@ -72,8 +72,8 @@
         }
       })
 
-
-    displayCovJSON(JSON.parse('{{ data | to_json | safe }}'), {display: true})
+    var covjson_data = {{ data | to_json | safe }};
+    displayCovJSON(covjson_data, {display: true})
 
     const truncateString = (str, maxLength) => {
       str = str.replace(/\+/g, ' ');


### PR DESCRIPTION
# Overview
Instead of turning the output to a JSON string, this PR renders the output CoverageJSON body directly to a js object consistent with other collections: https://github.com/geopython/pygeoapi/blob/f794d6721a6d2a4c2995b5a1d2fd0761ba379c04/pygeoapi/templates/collections/items/index.html#L163
https://github.com/geopython/pygeoapi/blob/f794d6721a6d2a4c2995b5a1d2fd0761ba379c04/pygeoapi/templates/collections/items/item.html#L132

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
It is is more efficient to directly render the object than rendering on the fly with JS. Furthermore, the JSON string is not parseable if there is a single quote in the response JSON.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
