### PR TITLE
Gracefully catch missing tiles in wmts facade

### DIFF
--- a/pygeoapi/provider/wmts_facade.py
+++ b/pygeoapi/provider/wmts_facade.py
@@ -35,8 +35,8 @@ import logging
 import requests
 from urllib.parse import urlparse, urlencode
 
-from pygeoapi.provider.tile import (
-    BaseTileProvider)
+from pygeoapi.provider.tile import (ProviderTileNotFoundError,
+                                    BaseTileProvider)
 from pygeoapi.provider.base import ProviderConnectionError
 from pygeoapi.models.provider.base import (
     TileMatrixSetEnum, TilesMetadataFormat, TileSetMetadata, LinkType)
@@ -171,7 +171,10 @@ class WMTSFacadeProvider(BaseTileProvider):
 
             with requests.Session() as session:
                 resp = session.get(request_url)
-                resp.raise_for_status()
+
+                if resp.status_code == 400:
+                    raise ProviderTileNotFoundError
+
                 return resp.content
         else:
             msg = f'Wrong data path configuration: {self.data}'


### PR DESCRIPTION
# Overview

This PR extends [this work](https://github.com/geopython/pygeoapi/pull/1937) to the WMTS facade plugin.

# Related Issue / discussion

https://github.com/geopython/pygeoapi/issues/1936

# Additional information

WMTS returns a 400, instead of 404, when it does not find a tile.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
