### PR TITLE
Include JSON-LD documents in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include README.md LICENSE.md requirements.txt
-recursive-include pygeoapi *.html *.json *.yml
+recursive-include pygeoapi *.html *.json *.jsonld *.yml
 recursive-include pygeoapi/static *


### PR DESCRIPTION
# Overview
https://github.com/geopython/pygeoapi/pull/1927 introduced GeoJSON-LD templating as default behavior. However seems that the jsonld templates are not in a remote install of pygeoapi because they are excluded from the manifest.

# Related Issue / discussion
https://github.com/geopython/pygeoapi/pull/1927
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
Could theoretically rename the documents to have a `.json` suffix but that may be confusing seeing as they are not producing the JSON output from pygeoapi. 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
