### PR TITLE
Fix 'type' member of the rel=http://www.opengis.net/def/rel/ogc/1.0/schema link

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1085,7 +1085,7 @@ def describe_collections(api: API, request: APIRequest,
 
         if collection_data_type in ['feature', 'coverage', 'record']:
             collection['links'].append({
-                'type': FORMAT_TYPES[F_JSON],
+                'type': 'application/schema+json',
                 'rel': f'{OGC_RELTYPES_BASE}/schema',
                 'title': l10n.translate('Schema of collection in JSON', request.locale),  # noqa
                 'href': f'{api.get_collections_url()}/{k}/schema?f={F_JSON}'  # noqa


### PR DESCRIPTION
According to Requirement 17 /req/returnables-and-receivables/op of OGC API Features Part 5, the media type shall be application/schema+json.

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
