### PR TITLE
EDR Inheritance 

### DIFF
--- a/pygeoapi/provider/base_edr.py
+++ b/pygeoapi/provider/base_edr.py
@@ -52,7 +52,7 @@ class BaseEDRProvider(BaseProvider):
         :returns: pygeoapi.provider.base_edr.BaseEDRProvider
         """
 
-        super().__init__(provider_def)
+        BaseProvider.__init__(self, provider_def)
 
 #        self.instances = []
 


### PR DESCRIPTION
# Overview

Loading the collections with many EDR datasets was very slow. I realized that the `XarrayEDRProvider` was initializing `XarrayProvider` twice- once through the `BaseEDRProvider` due to MRO and once explicitly. This made loading the collections page really slow, because for each dataset, the `XarrayProvider` was called twice, which caused all the zarr datasets to be lazy loaded twice. 

# Related Issue / discussion
https://code.usgs.gov/wma/nhgf/pygeoapi/-/issues/43

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->


# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute this bug fix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
