### PR TITLE
Add setuptools to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ requests
 shapely
 SQLAlchemy
 tinydb
+setuptools


### PR DESCRIPTION
# Overview

# Related Issue / discussion

No issues found containing 'setuptools'

# Additional information

While following the 'Install in 5 minutes' from https://pygeoapi.io/ I bumped into this error:

ModuleNotFoundError: No module named 'setuptools'

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
