### PR TITLE
Don't generate paging links if provider created them

### DIFF
--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -545,34 +545,40 @@ def get_collection_items(
         'href': f'{uri}?f={F_HTML}{serialized_query_params}'
     }])
 
-    if 'next' not in [link['rel'] for link in content['links']]:
-        if offset > 0:
-            prev = max(0, offset - limit)
-            content['links'].append(
-                {
-                    'type': 'application/geo+json',
-                    'rel': 'prev',
-                    'title': l10n.translate('Items (prev)', request.locale),
-                    'href': f'{uri}?offset={prev}{serialized_query_params}'
-                })
+    next_link = False
+    prev_link = False
 
-        next_link = False
-
+    if 'next' in [link['rel'] for link in content['links']]:
+        LOGGER.debug('Using next link from provider')
+    else:
         if content.get('numberMatched', -1) > (limit + offset):
             next_link = True
         elif len(content['features']) == limit:
             next_link = True
 
-        if next_link:
-            next_ = offset + limit
-            next_href = f'{uri}?offset={next_}{serialized_query_params}'
-            content['links'].append(
-                {
-                    'type': 'application/geo+json',
-                    'rel': 'next',
-                    'title': l10n.translate('Items (next)', request.locale),
-                    'href': next_href
-                })
+        if offset > 0:
+            prev_link = True
+
+    if prev_link:
+        prev = max(0, offset - limit)
+        content['links'].append(
+            {
+                'type': 'application/geo+json',
+                'rel': 'prev',
+                'title': l10n.translate('Items (prev)', request.locale),
+                'href': f'{uri}?offset={prev}{serialized_query_params}'
+            })
+
+    if next_link:
+        next_ = offset + limit
+        next_href = f'{uri}?offset={next_}{serialized_query_params}'
+        content['links'].append(
+            {
+                'type': 'application/geo+json',
+                'rel': 'next',
+                'title': l10n.translate('Items (next)', request.locale),
+                'href': next_href
+            })
 
     content['links'].append(
         {

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -545,33 +545,34 @@ def get_collection_items(
         'href': f'{uri}?f={F_HTML}{serialized_query_params}'
     }])
 
-    if offset > 0:
-        prev = max(0, offset - limit)
-        content['links'].append(
-            {
-                'type': 'application/geo+json',
-                'rel': 'prev',
-                'title': l10n.translate('Items (prev)', request.locale),
-                'href': f'{uri}?offset={prev}{serialized_query_params}'
-            })
+    if 'next' not in [link['rel'] for link in content['links']]:
+        if offset > 0:
+            prev = max(0, offset - limit)
+            content['links'].append(
+                {
+                    'type': 'application/geo+json',
+                    'rel': 'prev',
+                    'title': l10n.translate('Items (prev)', request.locale),
+                    'href': f'{uri}?offset={prev}{serialized_query_params}'
+                })
 
-    next_link = False
+        next_link = False
 
-    if content.get('numberMatched', -1) > (limit + offset):
-        next_link = True
-    elif len(content['features']) == limit:
-        next_link = True
+        if content.get('numberMatched', -1) > (limit + offset):
+            next_link = True
+        elif len(content['features']) == limit:
+            next_link = True
 
-    if next_link:
-        next_ = offset + limit
-        next_href = f'{uri}?offset={next_}{serialized_query_params}'
-        content['links'].append(
-            {
-                'type': 'application/geo+json',
-                'rel': 'next',
-                'title': l10n.translate('Items (next)', request.locale),
-                'href': next_href
-            })
+        if next_link:
+            next_ = offset + limit
+            next_href = f'{uri}?offset={next_}{serialized_query_params}'
+            content['links'].append(
+                {
+                    'type': 'application/geo+json',
+                    'rel': 'next',
+                    'title': l10n.translate('Items (next)', request.locale),
+                    'href': next_href
+                })
 
     content['links'].append(
         {


### PR DESCRIPTION
# Overview

This PR changes itemtypes.py to allow providers to generate their own `'next'` links, which then disable the limit-offset paging built into pygeoapi. As discussed in #1981, we want to move away from limit-offset paging for the data we're serving from Postgres and move towards keyset paging instead, and I believe this change would let us handle that from within our provider.

We just check for a next link in the response before disabling the generation of both prev and next links, as the Features standard mentions that prev links may be skipped based on implementation. As such, if the provider has generated a `next` link but not a `prev` link, we assume that was intentional.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

Closes #1981 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
