### PR TITLE
Add missing parameters to BaseEDR docstring

### DIFF
--- a/pygeoapi/provider/base_edr.py
+++ b/pygeoapi/provider/base_edr.py
@@ -97,8 +97,11 @@ class BaseEDRProvider(BaseProvider):
         :param z: vertical level(s)
         :param format_: data format of output
         :param bbox: bbox geometry (for cube queries)
-        :param within: distance (for radius querires)
-        :param within_units: distance units (for radius querires)
+        :param within: distance (for radius queries)
+        :param within_units: distance units (for radius queries)
+        :param instance: instance name (for instances queries)
+        :param limit: number of records to return (for locations queries)
+        :param location_id: location identifier (for locations queries)
 
         :returns: coverage data as `dict` of CoverageJSON or native format
         """


### PR DESCRIPTION
# Overview
Adds EDR Parameters that are supported but not documented in the BaseProvider.

The arguments passed to the EDR base query is method is, this PR updates the docstring to include the additional parameters. https://github.com/geopython/pygeoapi/blob/master/pygeoapi/api/environmental_data_retrieval.py#L361-L374

# Related Issue / discussion
Closes https://github.com/geopython/pygeoapi/issues/1971
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
The Base provider for does not include an informative docstring on it's query function either. Might be worth adding a more elaborated docstring. 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
