### PR TITLE
Clean feature properties regarding resource setting for OGR provider

### DIFF
--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -30,12 +30,12 @@
 #
 # =================================================================
 
+from copy import deepcopy
 import functools
 import importlib
 import logging
 import os
 from typing import Any
-from copy import deepcopy
 
 from osgeo import gdal as osgeo_gdal
 from osgeo import ogr as osgeo_ogr

--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -35,6 +35,7 @@ import importlib
 import logging
 import os
 from typing import Any
+from copy import deepcopy
 
 from osgeo import gdal as osgeo_gdal
 from osgeo import ogr as osgeo_ogr
@@ -527,6 +528,14 @@ class OGRProvider(BaseProvider):
 
         if skip_geometry:
             json_feature['geometry'] = None
+
+        # Drop non-defined properties
+        if self.properties:
+            props = json_feature['properties']
+            dropping_keys = deepcopy(props).keys()
+            for item in dropping_keys:
+                if item not in self.properties:
+                    props.pop(item)
 
         try:
             json_feature['id'] = json_feature['properties'].pop(


### PR DESCRIPTION
# Overview

Adds a clean out of properties on returned features for the OGR provider similar to the approach from Postgres provider. This way the configured properties as they can be defined in the [docs](https://docs.pygeoapi.io/en/0.19.0/data-publishing/ogcapi-features.html#controlling-the-order-of-properties) are respected.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
- [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this PR to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
