### PR TITLE
Correct MVT tile indices when fetching tiles from providers + fix tile indices in MVT UI preview

### DIFF
--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -176,7 +176,7 @@ class MVTElasticProvider(BaseMVTProvider):
                 with requests.Session() as session:
                     data = {'fields': ['*']}
                     session.get(base_url)
-                    resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}', json=data)  # noqa
+                    resp = session.get(f'{base_url}/{layer}/{z}/{x}/{y}{url_query}', json=data)  # noqa
 
                     if resp.status_code == 404:
                         if (self.is_in_limits(TileMatrixSetEnum.WEBMERCATORQUAD.value, z, x, y)): # noqa

--- a/pygeoapi/provider/mvt_proxy.py
+++ b/pygeoapi/provider/mvt_proxy.py
@@ -170,9 +170,9 @@ class MVTProxyProvider(BaseMVTProvider):
                 with requests.Session() as session:
                     session.get(base_url)
                     if '.' in url.path:
-                        resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}.{format_}{url_query}')  # noqa
+                        resp = session.get(f'{base_url}/{layer}/{z}/{x}/{y}.{format_}{url_query}')  # noqa
                     else:
-                        resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{url_query}')  # noqa
+                        resp = session.get(f'{base_url}/{layer}/{z}/{x}/{y}{url_query}')  # noqa
 
                     if resp.status_code == 404:
                         if (self.is_in_limits(self.get_tilematrixset(tileset), z, x, y)): # noqa

--- a/pygeoapi/provider/mvt_tippecanoe.py
+++ b/pygeoapi/provider/mvt_tippecanoe.py
@@ -184,7 +184,7 @@ class MVTTippecanoeProvider(BaseMVTProvider):
         try:
             with requests.Session() as session:
                 session.get(base_url)
-                resp = session.get(f'{base_url}/{layer}/{z}/{y}/{x}{extension}')  # noqa
+                resp = session.get(f'{base_url}/{layer}/{z}/{x}/{y}{extension}')  # noqa
 
                 if resp.status_code == 404:
                     if (self.is_in_limits(TileMatrixSetEnum.WEBMERCATORQUAD.value, z, x, y)): # noqa
@@ -215,7 +215,7 @@ class MVTTippecanoeProvider(BaseMVTProvider):
         """
 
         try:
-            service_url_path = self.service_url.joinpath(f'{z}/{y}/{x}.{format_}')  # noqa
+            service_url_path = self.service_url.joinpath(f'{z}/{x}/{y}.{format_}')  # noqa
             with open(service_url_path, mode='rb') as tile:
                 return tile.read()
         except FileNotFoundError as err:

--- a/pygeoapi/templates/collections/tiles/index.html
+++ b/pygeoapi/templates/collections/tiles/index.html
@@ -100,8 +100,8 @@
         ));
     {% elif data['tile_type'] == 'vector' %}
         url = url
-            .replace("tileRow", "x")
-            .replace("tileCol", "y");
+            .replace("tileRow", "y")
+            .replace("tileCol", "x");
         var VectorTileOptions = {
             interactive: true,
             rendererFactory: L.canvas.tile,


### PR DESCRIPTION
# Overview

This PR fixes the tile indices in the Elastic, Proxy and Tippecanoe MVT providers, and corrects the tile indices in the MVT tiles pygeoapi UI. All providers now use `/{z}/{x}/{y}` to fetch tiles from their original sources. 

A combination of the switched-around indices in the preview and the switched-around indices in the providers allowed tiles to be visible on the preview, but external clients needed to use `/{z}/{x}/{y}` in their tile URL to serve tiles - this is contrary to the OGC Tiles specification which is `/{z}/{y}/{x}`.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

This PR is related to #1985 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
