### PR TITLE
OAProc: add Prefer header to OpenAPI document

### DIFF
--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -725,6 +725,16 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
                 'description': md_desc,
                 'tags': [name],
                 'operationId': f'execute{name.capitalize()}Job',
+                'parameters': [{
+                    'in': 'header',
+                    'name': 'Prefer',
+                    'required': False,
+                    'description': 'Indicates client preferences, including whether the client is capable of asynchronous processing.',  # noqa
+                    'schema': {
+                        'type': 'string',
+                        'enum': ['respond-async']
+                    }
+                }],
                 'responses': {
                     '200': {'$ref': '#/components/responses/200'},
                     '201': {'$ref': f"{OPENAPI_YAML['oapip']}/responses/ExecuteAsync.yaml"},  # noqa

--- a/tests/api/test_itemtypes.py
+++ b/tests/api/test_itemtypes.py
@@ -637,7 +637,7 @@ def test_get_collection_item_json_ld(config, api_):
     expanded = jsonld.expand(feature)[0]
     assert expanded['http://www.opengis.net/ont/geosparql#hasGeometry'][0][
             'http://www.opengis.net/ont/geosparql#asWKT'][0][
-            '@value'] == 'MULTIPOINT (10 40, 40 30, 20 20, 30 10)'
+            '@value'] == 'MULTIPOINT ((10 40), (40 30), (20 20), (30 10))'
     assert expanded['https://schema.org/geo'][0][
             'https://schema.org/polygon'][0][
             '@value'] == "10.0,40.0 40.0,30.0 20.0,20.0 30.0,10.0 10.0,40.0"


### PR DESCRIPTION
# Overview

Adds HTTP Prefer header information to OpenAPI generation.

![Screenshot 2025-04-08 at 08 57 23](https://github.com/user-attachments/assets/e1cd4d12-3827-4a40-aec4-737d361cbd9a)

# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc/thanks @securedimensions
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
