### PR TITLE
Fix response type for tile request

### DIFF
--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -238,7 +238,7 @@ def get_collection_tiles_data(
         p = load_plugin('provider', t)
 
         format_ = p.format_type
-        headers['Content-Type'] = format_
+        headers['Content-Type'] = t['format']['mimetype']
 
         LOGGER.debug(f'Fetching tileset id {matrix_id} and tile {z_idx}/{y_idx}/{x_idx}')  # noqa
         content = p.get_tiles(layer=p.get_layer(), tileset=matrix_id,


### PR DESCRIPTION
# Overview

Set content-type to mimetype instead of format_type, so e.g. `image/png` instead of `png`.

# Related Issue / discussion

No related issue.

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

When testing a get tile request for either vector tiles or WMTS, the content-type in the response is either `pbf` or `png`. This should be replaced by the relevant mimetype, so the reponse type can be detected properly and previewed in case of png.

Example of request:

https://demo.pygeoapi.io/master/collections/lakes/tiles/WebMercatorQuad/1/1/1?f=pbf

returns response header with `content-type: pbf`.

A tile request to a WMTSFacade provider:

localhost:5000/collections/streets/tiles/WebMercatorQuad/3/2/4?f=png

returns a response header with `content-type: png`. 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
