### PR TITLE
Fix bbox crs for wms_face

### DIFF
--- a/tests/api/test_maps.py
+++ b/tests/api/test_maps.py
@@ -50,3 +50,42 @@ def test_get_collection_map(config, api_):
     assert code == HTTPStatus.OK
     assert isinstance(response, bytes)
     assert response[1:4] == b'PNG'
+
+def test_map_crs_transform(config, api_):
+    
+    # Florida in EPSG:4326
+    params = {
+        'bbox': '-88.374023,24.826625,-78.112793,31.015279',
+        # crs is 4326 by implicit since it is the default
+    }
+    req = mock_api_request(params)
+    _, code, floridaIn4326 = get_collection_map(
+        api_, req, 'mapserver_world_map')
+    assert code == HTTPStatus.OK
+
+    # Area that isn't florida in the ocean; used to make sure 
+    # the same coords with different crs are not the same
+    params = {
+        'bbox': '-88.374023,24.826625,-78.112793,31.015279',
+        'bbox-crs': 'http://www.opengis.net/def/crs/EPSG/0/3857',
+    }
+
+    req = mock_api_request(params)
+    _, code, florida4326InWrongCRS = get_collection_map(
+        api_, req, 'mapserver_world_map')
+    assert code == HTTPStatus.OK
+
+    assert florida4326InWrongCRS != floridaIn4326 
+
+    # Florida again, but this time in EPSG:3857
+    params = {
+        'bbox': '-9837751.2884,2854464.3843,-8695476.3377,3634733.5690',
+        'bbox-crs': 'http://www.opengis.net/def/crs/EPSG/0/3857'
+    }
+    req = mock_api_request(params)
+    _, code, floridaProjectedIn3857 = get_collection_map(
+        api_, req, 'mapserver_world_map')
+    assert code == HTTPStatus.OK
+
+
+    assert floridaIn4326 == floridaProjectedIn3857


### PR DESCRIPTION
# Overview

This PR fixes the wms_facade map provider to project the bbox properly. 

- Previously the bbox was being projected with the `crs` param and not the `bbox-crs` param. This PR allows for these to be distinct. 
- Moved the projection code to use `transform_bbox` and moved it into the map API code instead of the provider. This is since all map providers presumably should support projecting the bbox arg
- Added a bbox-crs arg for the wms_facade provider since we have to check if the crs is 4326 when checking whether or not to switch the lat/lon (unusual WMS quirk)
- Added tests for wms_facade since it previously did not have any 

# Related Issue / discussion

Fixes https://github.com/geopython/pygeoapi/issues/1995

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
