### PR TITLE
Xarrayedr covjson

### DIFF
--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -49,7 +49,7 @@ from pygeoapi.provider.base import (BaseProvider,
 from pygeoapi.util import get_crs_from_uri, read_data
 
 LOGGER = logging.getLogger(__name__)
-
+LOGGER.setLevel(logging.DEBUG)
 
 class XarrayProvider(BaseProvider):
     """Xarray Provider"""
@@ -269,7 +269,7 @@ class XarrayProvider(BaseProvider):
                 return fp.read()
 
     def gen_covjson(self, metadata, data, fields):
-        print("THIS IS IN THE GENCOVJSON!!!")
+        LOGGER.debug("THIS IS IN THE GENCOVJSON!!!")
         """
         Generate coverage as CoverageJSON representation
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -333,9 +333,7 @@ class XarrayProvider(BaseProvider):
         if self.time_field is not None:
             mint, maxt = metadata['time']
             cj['domain']['axes'][self.time_field] = {
-                'start': mint,
-                'stop': maxt,
-                'num': metadata['time_steps'],
+                'values': [str(v) for v in data.time.values],
             }
 
         for key, value in selected_fields.items():
@@ -368,7 +366,10 @@ class XarrayProvider(BaseProvider):
                     'shape': [metadata['height'],
                               metadata['width']]
                 }
-                cj['ranges'][key]['values'] = data[key].values.flatten().tolist()  # noqa
+                cj['ranges'][key]['values'] =[
+                    None if v is None or str(v) == 'nan' or (isinstance(v, (float, np.float32, np.float64)) and np.isnan(v)) else v
+                    for v in data[key].values.flatten()
+                ]  # noqa
 
                 if self.time_field is not None:
                     cj['ranges'][key]['axisNames'].append(

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -51,6 +51,7 @@ from pygeoapi.util import get_crs_from_uri, read_data
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 
+
 class XarrayProvider(BaseProvider):
     """Xarray Provider"""
 
@@ -367,8 +368,11 @@ class XarrayProvider(BaseProvider):
                     'shape': [metadata['height'],
                               metadata['width']]
                 }
-                cj['ranges'][key]['values'] =[
-                    None if v is None or str(v) == 'nan' or (isinstance(v, (float, np.float32, np.float64)) and np.isnan(v)) else v
+                cj['ranges'][key]['values'] = [
+                    None if (
+                        v is None or str(v) == 'nan' or 
+                        (isinstance(v, (float, np.float32, np.float64)) and np.isnan(v))
+                    ) else v
                     for v in data[key].values.flatten()
                 ]  # noqa
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -332,7 +332,7 @@ class XarrayProvider(BaseProvider):
 
         if self.time_field is not None:
             mint, maxt = metadata['time']
-            cj['domain']['axes'][self.time_field] = {
+            cj['domain']['axes']['t'] = {
                 'values': [str(v) for v in data.time.values],
             }
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -269,6 +269,7 @@ class XarrayProvider(BaseProvider):
                 return fp.read()
 
     def gen_covjson(self, metadata, data, fields):
+        print("THIS IS IN THE GENCOVJSON!!!")
         """
         Generate coverage as CoverageJSON representation
 


### PR DESCRIPTION
# Overview
 - fixes coverage json output for xarray edr
 - changing of domain axis time -> `t` instead of `time` and providing a data array of time values instead of just `start/stop/num`
 - replacing `NaN` vlaues with `None` so that they can properly be parsed by JSON as `null`
# Related Issue / discussion
Coverage Json being returned from xarray edr provider is currently invalid
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
