### PR TITLE
Allow PYGEOAPI_ env variables in the docker container to be overriden

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -36,9 +36,9 @@ echo "START /entrypoint.sh"
 
 set +e
 
-export PYGEOAPI_HOME=/pygeoapi
-export PYGEOAPI_CONFIG="${PYGEOAPI_HOME}/local.config.yml"
-export PYGEOAPI_OPENAPI="${PYGEOAPI_HOME}/local.openapi.yml"
+export PYGEOAPI_HOME="${PYGEOAPI_HOME:-/pygeoapi}"
+export PYGEOAPI_CONFIG="${PYGEOAPI_CONFIG:-${PYGEOAPI_HOME}/local.config.yml}"
+export PYGEOAPI_OPENAPI="${PYGEOAPI_OPENAPI:-${PYGEOAPI_HOME}/local.openapi.yml}"
 
 # gunicorn env settings with defaults
 SCRIPT_NAME=${SCRIPT_NAME:=/}


### PR DESCRIPTION
# Overview

Hi! We have a need to be able to override the environment variables for where the pygeoapi container is writing the openapi file and reading the config file.

The following change allows opt-in changes to those environment variables.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
