### PR TITLE
Pre-pull docker images in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,16 @@ jobs:
       PYGEOAPI_CONFIG: "$(pwd)/pygeoapi-config.yml"
     
     steps:
+    - name: Pre-pull Docker Images
+      run: |
+        docker pull container-registry.oracle.com/database/express:21.3.0-xe &
+        docker pull appropriate/curl:latest &
+        docker pull elasticsearch:8.17.0 &
+        docker pull opensearchproject/opensearch:2.18.0 &
+        docker pull mdillon/postgis:latest &
+        docker pull mongo:8.0.4 &
+        docker pull ghcr.io/cgs-earth/sensorthings-action:0.1.0 &
+        docker pull postgis/postgis:14-3.2 &
     - name: Clear up GitHub runner diskspace
       run: |
         echo "Space before"


### PR DESCRIPTION
# Overview
Pre-pull docker images in CI to decrease the time it takes to stand up dependent services in GitHub Actions. This pulls any docker images directly invoked and those used by reusable actions. There is duplicate postgis images but the sensorthings action uses a different docker image than the postgres action.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
