### PR TITLE
Update HTML templates to new limits structure

### DIFF
--- a/pygeoapi/templates/collections/items/index.html
+++ b/pygeoapi/templates/collections/items/index.html
@@ -43,7 +43,7 @@
                 <div class="col-sm-12">
                   {% trans %}Limit{% endtrans %}:
                   <select id="limits">
-                    <option value="{{ config['server']['limit'] }}">{{ config['server']['limit'] }} ({% trans %}default{% endtrans %})</option>
+                    <option value="{{ config['server']['limits']['default_items'] }}">{{ config['server']['limits']['default_items'] }} ({% trans %}default{% endtrans %})</option>
                     <option value="100">100</option>
                     <option value="1000">1,000</option>
                     <option value="2000">2,000</option>

--- a/pygeoapi/templates/jobs/index.html
+++ b/pygeoapi/templates/jobs/index.html
@@ -52,7 +52,7 @@
         <div class="col-sm-12">
           {% trans %}Limit{% endtrans %}:
           <select id="limits">
-            <option value="{{ config['server']['limit'] }}">{{ config['server']['limit'] }} ({% trans %}default{% endtrans %})</option>
+            <option value="{{ config['server']['limits']['default_items'] }}">{{ config['server']['limits']['default_items'] }} ({% trans %}default{% endtrans %})</option>
             <option value="100">100</option>
             <option value="1000">1,000</option>
             <option value="2000">2,000</option>


### PR DESCRIPTION
# Overview

This fixes an issue where the HTML templates weren't updated to use the new limits syntax.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
