### PR TITLE
add support for custom logo/icon to default HTML

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -42,6 +42,8 @@ For more information related to API design rules (the ``api_rules`` property in 
         host: 0.0.0.0  # listening address for incoming connections
         port: 5000  # listening port for incoming connections
     url: http://localhost:5000/  # url of server
+    icon: https://example.org/favicon.ico  # favicon / shortcut icon for default HTML template customization
+    logo: https://example.org/logo.png  # logo/banner for default HTML template customization
     mimetype: application/json; charset=UTF-8  # default MIME type
     encoding: utf-8  # default server encoding
     language: en-US  # default server language

--- a/docs/source/html-templating.rst
+++ b/docs/source/html-templating.rst
@@ -71,6 +71,15 @@ Featured themes
 
 Community based themes can be found on the `pygeoapi Community Plugins and Themes wiki page`_.
 
+Customizing the default HTML templates
+--------------------------------------
+
+The following aspects of the default HTML templates can be customized (within the ``server`` :ref:`configuration section <Configuration>`):
+
+- **icon**: shortcut icon (typically displays on a given web browser tab)
+- **logo**: logo/image banner (displays at the top of HTML pages)
+
+
 .. _`Jinja`: https://palletsprojects.com/p/jinja/
 .. _`Jinja documentation`: https://jinja.palletsprojects.com
 .. _`Flask`: https://palletsprojects.com/p/flask/

--- a/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
+++ b/pygeoapi/schemas/config/pygeoapi-config-0.x.yml
@@ -25,6 +25,12 @@ properties:
             url:
                 type: string
                 description: URL of server (as used by client)
+            icon:
+                type: string
+                description: URL of favicon for default HTML customization
+            logo:
+                type: string
+                description: URL of logo image for default HTML customization
             admin:
                 type: boolean
                 description: whether to enable the Admin API (default is false)

--- a/pygeoapi/templates/_base.html
+++ b/pygeoapi/templates/_base.html
@@ -1,5 +1,18 @@
 <!doctype html>
 <html lang="{{ (locale|lower)[:2] }}" dir="{% trans %}text_direction{% endtrans %}" >
+
+{% if config['server']['icon'] %}
+{% set icon = config['server']['icon'] %}
+{% else %}
+{% set icon = config['server']['url'] + '/static/img/favicon.ico' %}
+{% endif %}
+
+{% if config['server']['logo'] %}
+{% set logo = config['server']['logo'] %}
+{% else %}
+{% set logo = config['server']['url'] + '/static/img/logo.png' %}
+{% endif %}
+
   <head>
     <meta charset="{{ config['server']['encoding'] }}">
     <title>{% block title %}{% endblock %}{% if not self.title() %}{{ config['metadata']['identification']['title'] }}{% endif %}</title>
@@ -7,7 +20,7 @@
     <meta name="language" content="{{ config['server']['language'] }}">
     <meta name="description" content="{{ config['metadata']['identification']['title'] }}">
     <meta name="keywords" content="{{ config['metadata']['identification']['keywords']|join(',') }}">
-    <link rel="shortcut icon" href="{{ config['server']['url'] }}/static/img/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="{{ icon }}" type="image/x-icon">
     <link rel="stylesheet" href="https://unpkg.com/bootstrap@5.1.3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="{{ config['server']['url'] }}/static/css/default.css">
     <!--[if lt IE 9]>
@@ -40,7 +53,7 @@
       <header class="d-flex flex-wrap align-items-center py-3 justify-content-between">
         <a href="{{ config['server']['url'] }}"
           class="d-flex align-items-center mb-3 mb-md-0 text-dark text-decoration-none">
-          <img src="{{ config['server']['url'] }}/static/img/logo.png"
+          <img src="{{ logo }}"
             title="{{ config['metadata']['identification']['title'] }}" style="height:40px;vertical-align: middle;" /></a>
         <ul class="nav nav-pills">
           <li class="nav-item">


### PR DESCRIPTION
# Overview
This PR adds the ability to add a custom logo/banner or favicon to default HTML templates via configuration (existing behaviour remains if not defined).

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
