### PR TITLE
Add some Python types to the base provider

### DIFF
--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -51,12 +51,14 @@ class SchemaType(Enum):
     update = 'update'
     replace = 'replace'
 
+
 # All the potential properties on a field
 # as defined by the OGC API features spec
 FieldProperties = TypedDict(
     "FieldProperties",
     {
-        "type": Literal["string", "number", "integer", "boolean", "object", "array"],
+        "type": Literal["string", "number", "integer",
+                        "boolean", "object", "array"],
         "title": str,
         "description": str,
         "format": NotRequired[str],
@@ -66,9 +68,11 @@ FieldProperties = TypedDict(
     },
 )
 
+
 # Dict type representing a mapping of the field
 # to its associated data type
 FieldMapping = dict[str, FieldProperties]
+
 
 class BaseProvider:
     """generic Provider ABC"""
@@ -148,7 +152,7 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def get_data_path(self, baseurl: str , urlpath: str, dirpath: str) -> dict:
+    def get_data_path(self, baseurl: str, urlpath: str, dirpath: str) -> dict:
         """
         Gets directory listing or file description or raw file dump
 
@@ -239,7 +243,8 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def _load_and_prepare_item(self, item: str, identifier: Optional[str]=None,
+    def _load_and_prepare_item(self, item: str,
+                               identifier: Optional[str] = None,
                                accept_missing_identifier=False,
                                raise_if_exists=True):
         """

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -44,10 +44,10 @@ class SchemaType(Enum):
     update = 'update'
     replace = 'replace'
 
-# Dict type representing a mapping of the field
-# to its associated data type
-FieldMapping = TypedDict(
-    "FieldMapping",
+# All the potential properties on a field
+# as defined by the OGC API features spec
+FieldProperties = TypedDict(
+    "FieldProperties",
     {
         "type": Literal["string", "number", "integer", "boolean", "object", "array"],
         "title": str,
@@ -58,6 +58,10 @@ FieldMapping = TypedDict(
         "enum": NotRequired[list[str]],
     },
 )
+
+# Dict type representing a mapping of the field
+# to its associated data type
+FieldMapping = dict[str, FieldProperties]
 
 class BaseProvider:
     """generic Provider ABC"""

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -31,6 +31,7 @@ import json
 import logging
 from enum import Enum
 from http import HTTPStatus
+from typing import Literal, Optional, TypedDict
 
 from pygeoapi.error import GenericError
 
@@ -43,11 +44,16 @@ class SchemaType(Enum):
     update = 'update'
     replace = 'replace'
 
+# Dict type representing a mapping of the field 
+# to its associated data type
+FieldMapping = dict[
+    str, dict[Literal["type"], Literal["number", "string", "integer"]]
+]
 
 class BaseProvider:
     """generic Provider ABC"""
 
-    def __init__(self, provider_def):
+    def __init__(self, provider_def: dict):
         """
         Initialize object
 
@@ -73,7 +79,7 @@ class BaseProvider:
         self.title_field = provider_def.get('title_field')
         self.properties = provider_def.get('properties', [])
         self.file_types = provider_def.get('file_types', [])
-        self._fields = {}
+        self._fields: FieldMapping = {}
         self.filename = None
 
         # for coverage providers
@@ -81,7 +87,7 @@ class BaseProvider:
         self.crs = None
         self.num_bands = None
 
-    def get_fields(self):
+    def get_fields(self) -> FieldMapping:
         """
         Get provider field information (names, types)
 
@@ -94,7 +100,7 @@ class BaseProvider:
         raise NotImplementedError()
 
     @property
-    def fields(self) -> dict:
+    def fields(self) -> FieldMapping:
         """
         Store provider field information (names, types)
 
@@ -110,7 +116,7 @@ class BaseProvider:
         else:
             return self.get_fields()
 
-    def get_schema(self, schema_type: SchemaType = SchemaType.item):
+    def get_schema(self, schema_type: SchemaType = SchemaType.item) -> tuple:
         """
         Get provider schema model
 
@@ -122,7 +128,7 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def get_data_path(self, baseurl, urlpath, dirpath):
+    def get_data_path(self, baseurl: str , urlpath: str, dirpath: str) -> dict:
         """
         Gets directory listing or file description or raw file dump
 
@@ -145,7 +151,7 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def get_domains(self, properties=[], current=False):
+    def get_domains(self, properties: list[str] = [], current=False):
         """
         Get domains from dataset
 
@@ -168,7 +174,7 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def get(self, identifier, **kwargs):
+    def get(self, identifier: str, **kwargs):
         """
         query the provider by id
 
@@ -179,7 +185,7 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def create(self, item):
+    def create(self, item: dict) -> str:
         """
         Create a new item
 
@@ -190,7 +196,7 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def update(self, identifier, item):
+    def update(self, identifier: str, item: dict) -> bool:
         """
         Updates an existing item
 
@@ -202,7 +208,7 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def delete(self, identifier):
+    def delete(self, identifier: str) -> bool:
         """
         Deletes an existing item
 
@@ -213,7 +219,7 @@ class BaseProvider:
 
         raise NotImplementedError()
 
-    def _load_and_prepare_item(self, item, identifier=None,
+    def _load_and_prepare_item(self, item: str, identifier: Optional[str]=None,
                                accept_missing_identifier=False,
                                raise_if_exists=True):
         """

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -31,7 +31,7 @@ import json
 import logging
 from enum import Enum
 from http import HTTPStatus
-from typing import Literal, Optional, TypedDict
+from typing import Literal, NotRequired, Optional, TypedDict
 
 from pygeoapi.error import GenericError
 
@@ -46,9 +46,18 @@ class SchemaType(Enum):
 
 # Dict type representing a mapping of the field
 # to its associated data type
-FieldMapping = dict[
-    str, dict[Literal["type"], Literal["number", "string", "integer"]]
-]
+FieldMapping = TypedDict(
+    "FieldMapping",
+    {
+        "type": Literal["string", "number", "integer", "boolean", "object", "array"],
+        "title": str,
+        "description": str,
+        "format": NotRequired[str],
+        "x-ogc-unit": NotRequired[str],
+        "x-ogc-role": NotRequired[str],
+        "enum": NotRequired[list[str]],
+    },
+)
 
 class BaseProvider:
     """generic Provider ABC"""

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -31,7 +31,14 @@ import json
 import logging
 from enum import Enum
 from http import HTTPStatus
-from typing import Literal, NotRequired, Optional, TypedDict
+from typing import Literal, Optional, TypedDict
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import NotRequired
+else:
+    from typing_extensions import NotRequired
+
 
 from pygeoapi.error import GenericError
 

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -44,7 +44,7 @@ class SchemaType(Enum):
     update = 'update'
     replace = 'replace'
 
-# Dict type representing a mapping of the field 
+# Dict type representing a mapping of the field
 # to its associated data type
 FieldMapping = dict[
     str, dict[Literal["type"], Literal["number", "string", "integer"]]


### PR DESCRIPTION
# Overview

- this PR adds Python types to the base provider
- this makes it so users who are writing custom providers can more clearly understand and validate that their providers are correct
- this should not change any runtime behavior

# Related Issue / discussion

N/A

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
