### PR TITLE
add support to provider z_field for EDR queries with vertical level

### DIFF
--- a/docs/source/data-publishing/ogcapi-edr.rst
+++ b/docs/source/data-publishing/ogcapi-edr.rst
@@ -55,6 +55,7 @@ The `xarray-edr`_ provider plugin reads and extracts `NetCDF`_ and `Zarr`_ data 
          # to derive automagically
          x_field: lon
          y_field: lat
+         z_field: z
          time_field: time
          # optionally specify the coordinate reference system of your dataset
          # else pygeoapi assumes it is WGS84 (EPSG:4326).

--- a/pygeoapi/provider/base.py
+++ b/pygeoapi/provider/base.py
@@ -69,6 +69,7 @@ class BaseProvider:
         self.uri_field = provider_def.get('uri_field')
         self.x_field = provider_def.get('x_field')
         self.y_field = provider_def.get('y_field')
+        self.z_field = provider_def.get('z_field')
         self.time_field = provider_def.get('time_field')
         self.title_field = provider_def.get('title_field')
         self.properties = provider_def.get('properties', [])

--- a/pygeoapi/provider/xarray_edr.py
+++ b/pygeoapi/provider/xarray_edr.py
@@ -105,6 +105,13 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
         if datetime_ is not None:
             query_params[self.time_field] = self._make_datetime(datetime_)
 
+        z = kwargs.get('z')
+        if z is not None:
+            if self.z_field is not None:
+                query_params[self.z_field] = z
+            else:
+                LOGGER.debug('No vertical level found')
+
         LOGGER.debug(f'query parameters: {query_params}')
 
         try:


### PR DESCRIPTION
# Overview
Supports EDR queries with vertical level for providers supporting `z_field`.
# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
