### PR TITLE
Docs update to reflect other environmental variables available in the docker image

### DIFF
--- a/docs/source/running-with-docker.rst
+++ b/docs/source/running-with-docker.rst
@@ -102,6 +102,38 @@ The base Docker image supports two additional environment variables for configur
 
    To learn more about the Admin API see :ref:`admin-api`.
 
+3. **`CONTAINER_HOST`**: 
+   This variable sets the listening address for incoming connections. Normally the server is listening on localhost (the default), but other values are also possible. 
+
+   .. code-block:: bash
+
+      docker run -p 5000:80 -e CONTAINER_HOST=192.168.0.7 -it geopython/pygeoapi
+
+4. **`CONTAINER_PORT`**: 
+   This variable sets the listening port for incoming connections. The default port is `80`; in this example, we change it to 5001.
+
+   .. code-block:: bash
+
+      docker run -p 5000:5001 -e CONTAINER_PORT=5001 -it geopython/pygeoapi
+
+5. **`WSGI_WORKERS`**: 
+
+   This variable sets the number of workers used by the `gunicorn server <https://docs.gunicorn.org/en/latest/>`_, the default being 4.
+   For performance reasons, `it is not recommended to use a high number of workers <https://docs.gunicorn.org/en/latest/design.html#how-many-workers>`_ .
+
+   .. code-block:: bash
+
+      docker run -p 5000:80 -e WSGI_WORKERS=10 -it geopython/pygeoapi
+
+6. **`WSGI_WORKER_TIMEOUT`**: 
+
+   Gunicorn workers silent for more than the seconds set by this variable are killed and restarted. The default value is 6000.
+
+   .. code-block:: bash
+
+      docker run -p 5000:80 -e WSGI_WORKERS=10 -it geopython/pygeoapi
+
+   You can read more about this and other gunicorn settings in the `official documentation <https://docs.gunicorn.org/en/stable/>`_
 
 Deploying on a sub-path
 -----------------------


### PR DESCRIPTION
# Overview

There are quite a few environmental variables about server behaviour that can be injected into the docker image:

https://github.com/geopython/pygeoapi/blob/4fba2a41ca0dbcdd32c7fab1ce45af0eaa697836/docker/entrypoint.sh#L43-L52

This PR adds information about them in the documentation. 

# Additional information

The server port in particular is quite important to document; as it currently stands, the server is ignoring whatever is set in pygeoapi config, and overriding it with port 80. 

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
