### PR TITLE
Proper handling of query parameter q with multiple search terms for T…

### DIFF
--- a/tests/test_tinydb_catalogue_provider.py
+++ b/tests/test_tinydb_catalogue_provider.py
@@ -133,10 +133,10 @@ def test_query(config):
         assert results['numberMatched'] == 6
         assert results['numberReturned'] == 6
 
-    results = p.query(q='crops barley')
-    assert len(results['features']) == 2
-    assert results['numberMatched'] == 2
-    assert results['numberReturned'] == 2
+    results = p.query(q='Frost free')
+    assert len(results['features']) == 1
+    assert results['numberMatched'] == 1
+    assert results['numberReturned'] == 1
 
     results = p.query(limit=1)
     assert len(results['features']) == 1


### PR DESCRIPTION
…inyDB provider.

# Overview

To my understanding of the OGC API - Records standard the handling of query parameter q in TinyDB provider is incorrect. Search with query parameter q that contains spaces did not return correct results. The related test case returned two matches when zero would be correct. These changes format queries to TinyDB that match the specification.
 
# Related Issue / discussion

# Additional information

OGC API - Records standard https://docs.ogc.org/is/20-004r1/20-004r1.html, especially 7.4.2.4.  Parameter q

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute bugfix in TinyDB provider to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
