### PR TITLE
Pydantic v1/2 compatibility for provider models

### DIFF
--- a/pygeoapi/models/provider/base.py
+++ b/pygeoapi/models/provider/base.py
@@ -35,8 +35,8 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel
 import pydantic
+from pydantic import BaseModel
 
 
 class TilesMetadataFormat(str, Enum):

--- a/pygeoapi/models/provider/base.py
+++ b/pygeoapi/models/provider/base.py
@@ -36,6 +36,7 @@ from enum import Enum
 from typing import List, Optional
 
 from pydantic import BaseModel
+import pydantic
 
 
 class TilesMetadataFormat(str, Enum):
@@ -875,3 +876,10 @@ class TileSetMetadata(BaseModel):
     tileMatrixSetURI: Optional[str] = None
     # Links to related resources.
     links: Optional[List[LinkType]] = None
+
+
+if pydantic.VERSION.startswith('1'):
+    def _dump(self, *, exclude_none: bool = False, **kwargs):
+        return self.dict(exclude_none=exclude_none, **kwargs)
+
+    TileSetMetadata.model_dump = _dump

--- a/pygeoapi/models/provider/mvt.py
+++ b/pygeoapi/models/provider/mvt.py
@@ -27,8 +27,8 @@
 #
 # =================================================================
 
-from pydantic import BaseModel
 import pydantic
+from pydantic import BaseModel
 from typing import List, Optional
 
 

--- a/pygeoapi/models/provider/mvt.py
+++ b/pygeoapi/models/provider/mvt.py
@@ -28,6 +28,7 @@
 # =================================================================
 
 from pydantic import BaseModel
+import pydantic
 from typing import List, Optional
 
 
@@ -50,3 +51,10 @@ class MVTTilesJson(BaseModel):
     attribution: Optional[str] = None
     description: Optional[str] = None
     vector_layers: Optional[List[VectorLayers]] = None
+
+
+if pydantic.VERSION.startswith('1'):
+    def _dump(self, *, exclude_none: bool = False, **kwargs):
+        return self.dict(exclude_none=exclude_none, **kwargs)
+
+    MVTTilesJson.model_dump = _dump

--- a/pygeoapi/provider/mvt_elastic.py
+++ b/pygeoapi/provider/mvt_elastic.py
@@ -263,4 +263,4 @@ class MVTElasticProvider(BaseMVTProvider):
 
         content.links = links
 
-        return content.dict(exclude_none=True)
+        return content.model_dump(exclude_none=True)

--- a/pygeoapi/provider/mvt_proxy.py
+++ b/pygeoapi/provider/mvt_proxy.py
@@ -259,4 +259,4 @@ class MVTProxyProvider(BaseMVTProvider):
 
         content.links = links
 
-        return content.dict(exclude_none=True)
+        return content.model_dump(exclude_none=True)

--- a/pygeoapi/provider/wmts_facade.py
+++ b/pygeoapi/provider/wmts_facade.py
@@ -278,4 +278,4 @@ class WMTSFacadeProvider(BaseTileProvider):
 
         content.links = links
 
-        return content.dict(exclude_none=True)
+        return content.model_dump(exclude_none=True)


### PR DESCRIPTION
# Overview
Extending https://github.com/geopython/pygeoapi/pull/2014 to ensure pydantic models are safely used across pygeoapi.
This PR makes `model_dump` from Pydantic v2 the standard vocabulary - patching the models that are created with pydantic v1 to wrap `dict` in an execution of `model_dump`

cc: @doublebyte1


# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
