### PR TITLE
add bbox support for CSV and GeoJSON feature providers

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -19,11 +19,11 @@ parameters.
    :header: Provider, property filters/display, resulttype, bbox, datetime, sortby, skipGeometry, domains, CQL, transactions, crs
    :align: left
 
-   `CSV`_,✅/✅,results/hits,❌,❌,❌,✅,❌,❌,❌,✅
+   `CSV`_,✅/✅,results/hits,✅,❌,❌,✅,❌,❌,❌,✅
    `Elasticsearch`_,✅/✅,results/hits,✅,✅,✅,✅,✅,✅,✅,✅
    `ERDDAP Tabledap Service`_,❌/❌,results/hits,✅,✅,❌,❌,❌,❌,❌,✅
    `ESRI Feature Service`_,✅/✅,results/hits,✅,✅,✅,✅,❌,❌,❌,✅
-   `GeoJSON`_,✅/✅,results/hits,❌,❌,❌,✅,❌,❌,❌,✅
+   `GeoJSON`_,✅/✅,results/hits,✅,❌,❌,✅,❌,❌,❌,✅
    `MongoDB`_,✅/❌,results,✅,✅,✅,✅,❌,❌,❌,✅
    `MySQL`_,✅/✅,results/hits,✅,✅,✅,✅,❌,✅,✅,✅
    `OGR`_,✅/❌,results/hits,✅,❌,❌,✅,❌,❌,❌,✅

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -136,6 +136,7 @@ class CSVProvider(BaseProvider):
                         [p[prop[0]] == prop[1] for prop in properties]), data_)
 
             if bbox:
+                LOGGER.debug('processing bbox parameter')
                 data_ = filter(
                     lambda f: all(
                         [self._intersects(f, bbox)]), data_)
@@ -214,7 +215,7 @@ class CSVProvider(BaseProvider):
         """
 
         if None in [data.get(self.geometry_x), data.get(self.geometry_y)]:
-            return False
+            return True
 
         point = Point(data[self.geometry_x], data[self.geometry_y])
         bbox2 = box(*bbox)

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -32,6 +32,8 @@ import csv
 import itertools
 import logging
 
+from shapely import box, Point
+
 from pygeoapi.provider.base import (BaseProvider, ProviderInvalidQueryError,
                                     ProviderItemNotFoundError,
                                     ProviderQueryError)
@@ -99,6 +101,7 @@ class CSVProvider(BaseProvider):
         :param limit: number of records to return (default 10)
         :param datetime_: temporal (datestamp or extent)
         :param resulttype: return results or hit limit (default results)
+        :param bbox: bounding box [minx,miny,maxx,maxy]
         :param properties: list of tuples (name, value)
         :param select_properties: list of property names
         :param skip_geometry: bool of whether to skip geometry (default False)
@@ -120,6 +123,7 @@ class CSVProvider(BaseProvider):
         with open(self.data) as ff:
             LOGGER.debug('Serializing DictReader')
             data_ = csv.DictReader(ff)
+
             if properties:
                 for prop in properties:
                     if prop[0] not in data_.fieldnames:
@@ -131,10 +135,16 @@ class CSVProvider(BaseProvider):
                     lambda p: all(
                         [p[prop[0]] == prop[1] for prop in properties]), data_)
 
+            if bbox:
+                data_ = filter(
+                    lambda f: all(
+                        [self._intersects(f, bbox)]), data_)
+
             if resulttype == 'hits':
                 LOGGER.debug('Returning hits only')
                 feature_collection['numberMatched'] = len(list(data_))
                 return feature_collection
+
             LOGGER.debug('Slicing CSV rows')
             for row in itertools.islice(data_, 0, None):
                 try:
@@ -193,6 +203,24 @@ class CSVProvider(BaseProvider):
 
         return feature_collection
 
+    def _intersects(self, data, bbox):
+        """
+        Helper function to evaluate point geometry intersection with a bbox
+
+        :param geometry: `dict` of CSV row
+        :param bbox: `list` of bbox
+
+        :returns: `bool` of whether point geometry intersects with bbox
+        """
+
+        if None in [data.get(self.geometry_x), data.get(self.geometry_y)]:
+            return False
+
+        point = Point(data[self.geometry_x], data[self.geometry_y])
+        bbox2 = box(*bbox)
+
+        return bbox2.intersects(point)
+
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',
               bbox=[], datetime_=None, properties=[], sortby=[],
@@ -215,7 +243,7 @@ class CSVProvider(BaseProvider):
         """
 
         return self._load(offset, limit, resulttype,
-                          properties=properties,
+                          bbox=bbox, properties=properties,
                           select_properties=select_properties,
                           skip_geometry=skip_geometry)
 

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -126,6 +126,7 @@ class GeoJSONProvider(BaseProvider):
 
         # filter by bbox if set
         if bbox:
+            LOGGER.debug('processing bbox parameter')
             data['features'] = [f for f in data['features'] if \
                 self._intersects(f['geometry'], bbox)]  # noqa
 
@@ -151,7 +152,7 @@ class GeoJSONProvider(BaseProvider):
         """
 
         if geometry is None:
-            return False
+            return True
 
         bbox2 = box(*bbox)
         geometry2 = from_geojson(json.dumps(geometry))

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -33,6 +33,8 @@ import logging
 import os
 import uuid
 
+from shapely import box, from_geojson
+
 from pygeoapi.provider.base import BaseProvider, ProviderItemNotFoundError
 from pygeoapi.util import crs_transform
 
@@ -96,7 +98,8 @@ class GeoJSONProvider(BaseProvider):
 
         return self._fields
 
-    def _load(self, skip_geometry=None, properties=[], select_properties=[]):
+    def _load(self, bbox=[], skip_geometry=None, properties=[],
+              select_properties=[]):
         """Load and validate the source GeoJSON file
         at self.data
 
@@ -121,6 +124,11 @@ class GeoJSONProvider(BaseProvider):
             data['features'] = [f for f in data['features'] if \
                 all([str(f['properties'][p[0]]) == str(p[1]) for p in properties])]  # noqa
 
+        # filter by bbox if set
+        if bbox:
+            data['features'] = [f for f in data['features'] if \
+                self._intersects(f['geometry'], bbox)]  # noqa
+
         # All features must have ids, TODO must be unique strings
         for i in data['features']:
             if 'id' not in i and self.id_field in i['properties']:
@@ -131,6 +139,24 @@ class GeoJSONProvider(BaseProvider):
                 i['properties'] = {k: v for k, v in i['properties'].items()
                                    if k in set(self.properties) | set(select_properties)}  # noqa
         return data
+
+    def _intersects(self, geometry, bbox):
+        """
+        Helper function to evaluate feature geometry intersection with a bbox
+
+        :param geometry: `dict` of GeoJSON geometry
+        :param bbox: `list` of bbox
+
+        :returns: `bool` of whether geometry intersects with bbox
+        """
+
+        if geometry is None:
+            return False
+
+        bbox2 = box(*bbox)
+        geometry2 = from_geojson(json.dumps(geometry))
+
+        return geometry2.intersects(bbox2)
 
     @crs_transform
     def query(self, offset=0, limit=10, resulttype='results',
@@ -154,7 +180,8 @@ class GeoJSONProvider(BaseProvider):
         """
 
         # TODO filter by bbox without resorting to third-party libs
-        data = self._load(skip_geometry=skip_geometry, properties=properties,
+        data = self._load(bbox=bbox, skip_geometry=skip_geometry,
+                          properties=properties,
                           select_properties=select_properties)
 
         data['numberMatched'] = len(data['features'])

--- a/tests/api/test_itemtypes.py
+++ b/tests/api/test_itemtypes.py
@@ -263,20 +263,29 @@ def test_get_collection_items(config, api_):
     rsp_headers, code, response = get_collection_items(api_, req, 'obs')
     features = json.loads(response)
 
+    assert len(features['features']) == 0
+
+    req = mock_api_request({
+        'offset': '1',
+        'limit': '1'
+    })
+    rsp_headers, code, response = get_collection_items(api_, req, 'obs')
+    features = json.loads(response)
+
     assert len(features['features']) == 1
 
     links = features['links']
     assert len(links) == 6
-    assert '/collections/obs/items?f=json&limit=1&bbox=-180,90,180,90' in \
+    assert '/collections/obs/items?f=json&limit=1' in \
         links[0]['href']
     assert links[0]['rel'] == 'self'
-    assert '/collections/obs/items?f=jsonld&limit=1&bbox=-180,90,180,90' in \
+    assert '/collections/obs/items?f=jsonld&limit=1' in \
         links[1]['href']
     assert links[1]['rel'] == 'alternate'
-    assert '/collections/obs/items?f=html&limit=1&bbox=-180,90,180,90' in \
+    assert '/collections/obs/items?f=html&limit=1' in \
         links[2]['href']
     assert links[2]['rel'] == 'alternate'
-    assert '/collections/obs/items?offset=0&limit=1&bbox=-180,90,180,90' \
+    assert '/collections/obs/items?offset=0&limit=1' \
         in links[3]['href']
     assert links[3]['rel'] == 'prev'
     assert '/collections/obs' in links[4]['href']

--- a/tests/api/test_itemtypes.py
+++ b/tests/api/test_itemtypes.py
@@ -258,16 +258,7 @@ def test_get_collection_items(config, api_):
     req = mock_api_request({
         'offset': '1',
         'limit': '1',
-        'bbox': '-180,90,180,90'
-    })
-    rsp_headers, code, response = get_collection_items(api_, req, 'obs')
-    features = json.loads(response)
-
-    assert len(features['features']) == 0
-
-    req = mock_api_request({
-        'offset': '1',
-        'limit': '1'
+        'bbox': '-180,-90,180,90'
     })
     rsp_headers, code, response = get_collection_items(api_, req, 'obs')
     features = json.loads(response)
@@ -276,16 +267,16 @@ def test_get_collection_items(config, api_):
 
     links = features['links']
     assert len(links) == 6
-    assert '/collections/obs/items?f=json&limit=1' in \
+    assert '/collections/obs/items?f=json&limit=1&bbox=-180,-90,180,90' in \
         links[0]['href']
     assert links[0]['rel'] == 'self'
-    assert '/collections/obs/items?f=jsonld&limit=1' in \
+    assert '/collections/obs/items?f=jsonld&limit=1&bbox=-180,-90,180,90' in \
         links[1]['href']
     assert links[1]['rel'] == 'alternate'
-    assert '/collections/obs/items?f=html&limit=1' in \
+    assert '/collections/obs/items?f=html&limit=1&bbox=-180,-90,180,90' in \
         links[2]['href']
     assert links[2]['rel'] == 'alternate'
-    assert '/collections/obs/items?offset=0&limit=1' \
+    assert '/collections/obs/items?offset=0&limit=1&bbox=-180,-90,180,90' \
         in links[3]['href']
     assert links[3]['rel'] == 'prev'
     assert '/collections/obs' in links[4]['href']

--- a/tests/test_csv__provider.py
+++ b/tests/test_csv__provider.py
@@ -136,6 +136,10 @@ def test_query(config):
     results = p.query()
     assert len(results['features'][0]['properties']) == 2
 
+    p = CSVProvider(config)
+    results = p.query(bbox=[-75, 45, -64, 55])
+    assert len(results['features'][0]['properties']) == 2
+
 
 def test_get_invalid_property(config):
     """Testing query for an invalid property name"""

--- a/tests/test_geojson_provider.py
+++ b/tests/test_geojson_provider.py
@@ -94,6 +94,16 @@ def test_query(fixture, config):
     assert results['numberMatched'] == 1
     assert results['numberReturned'] == 1
 
+    results = p.query(bbox=[-154, 33, -120, 55])
+    assert len(results['features']) == 0
+    assert results['numberMatched'] == 0
+    assert results['numberReturned'] == 0
+
+    results = p.query(bbox=[120, 10, 126, 11])
+    assert len(results['features']) == 1
+    assert results['numberMatched'] == 1
+    assert results['numberReturned'] == 1
+
 
 def test_get(fixture, config):
     p = GeoJSONProvider(config)


### PR DESCRIPTION
# Overview
This PR adds bbox support for CSV and GeoJSON providers using Shapely (which is already part of the core dependency chain).

# Related Issue / discussion
Somewhat related to #2000
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
