### PR TITLE
OARec: update ES q= support per Req 27

### DIFF
--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -333,7 +333,11 @@ class ElasticsearchProvider(BaseProvider):
 
         if q is not None:
             LOGGER.debug('Adding free-text search')
-            query['query']['bool']['must'] = {'query_string': {'query': q}}
+            # split inclusive on ',' (OR)
+            q_tokens = [f'"{t}"' for t in q.split(',')]
+            # enclose each token as a search phrase
+            q2 = ' OR '.join(q_tokens)
+            query['query']['bool']['must'] = {'query_string': {'query': q2}}
 
             query['_source'] = {
                 'excludes': [

--- a/tests/test_elasticsearch__provider.py
+++ b/tests/test_elasticsearch__provider.py
@@ -251,6 +251,22 @@ def test_query(config):
     assert len(results['features'][0]['properties']) == 1
 
 
+def test_query_q(config):
+    p = ElasticsearchProvider(config)
+
+    result = p.query(q='vatican')
+    assert len(result['features']) == 1
+
+    result = p.query(q='vatican,lazio')
+    assert len(result['features']) == 2
+
+    result = p.query(q='vatican lazio')
+    assert len(result['features']) == 0
+
+    result = p.query(q='holy see')
+    assert len(result['features']) == 1
+
+
 def test_query_ordered_properties(config_ordered_properties):
     p = ElasticsearchProvider(config_ordered_properties)
 


### PR DESCRIPTION
# Overview
This PR updates ES `q=` support per OARec Req 27.
# Related Issue / discussion
#2053 
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
