### PR TITLE
Send url details to provider

### DIFF
--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -557,12 +557,12 @@ def get_collection_items(
                           select_properties=select_properties,
                           crs_transform_spec=crs_transform_spec,
                           q=q, language=prv_locale, filterq=filter_,
-                          serialized_query_params=serialized_query_params, uri=uri)
+                          serialized_query_params=serialized_query_params,
+                          uri=uri)
     except ProviderGenericError as err:
         return api.get_exception(
             err.http_status_code, headers, request.format,
             err.ogc_exception_code, err.message)
-
 
     if 'links' not in content:
         content['links'] = []


### PR DESCRIPTION
# Overview
Send the URI query params and base URI to the provider so it can generate full nextlinks.

Resolves #2055 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute this feature to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
