### PR TITLE
Change default language to string, not list

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -410,9 +410,7 @@ def get_oas_30(cfg: dict, fail_on_invalid_collection: bool = True) -> dict:
                     'language': {
                         'description': 'the language used for the title and description', # noqa
                         'type': 'string',
-                        'default': [
-                            'en'
-                        ]
+                        'default': 'en'
                     },
                     'type': {
                         'description': 'the data type of the queryable', # noqa


### PR DESCRIPTION
# Overview

Changes the default language to a string rather than a list.

# Related Issue / discussion

If you scroll to the bottom of the SwaggerUI for pygeoapi, you'll see a bright yellow "INVALID" sticker:
https://demo.pygeoapi.io/master/openapi?f=html

Clicking that gives you this error message:
> {"messages":["attribute components.schemas.queryable.default is not of type `string`"],"schemaValidationMessages":[]}
https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fdemo.pygeoapi.io%2Fmaster%2Fopenapi%3Ff%3Djson

The root cause seems to be this key being provided as a list instead of a string.

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
