### PR TITLE
Coverage json time field fix for xarray provider

### DIFF
--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -345,7 +345,12 @@ class XarrayProvider(BaseProvider):
 
         if self.time_field is not None:
             cj['domain']['axes']['t'] = {
-                'values': [str(v) for v in data[self.time_field].values]
+                'values': [str(v) for v in (
+                    data[self.time_field].values
+                    if hasattr(data[self.time_field].values, '__iter__')
+                    else [data[self.time_field].values]
+                    )
+                ]
             }
             cj['domain']['referencing'].append({
                 'coordinates': ['t'],


### PR DESCRIPTION
# Overview
Recent change to coverage json formatting was throwing an error when a single datetime was queried (`TypeError: numpy.datetime64 object is not iterable`). This was happening when I was testing `http://localhost:5000/collections/PRISM/cube?bbox=-148,18,-51,52&datetime=2000` 

This checks if the `data[self.time_field].values` is iterable and makes the appropriate change if not. 

# Related Issue / discussion

None

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute this bugfix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
