### PR TITLE
ensure language .mo files are compiled in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -140,6 +140,10 @@ RUN python3 -m pip install --no-cache-dir -e .
 RUN \
     # Set default config and entrypoint for Docker Image
     cp /pygeoapi/docker/default.config.yml /pygeoapi/local.config.yml \
-    && cp /pygeoapi/docker/entrypoint.sh /entrypoint.sh
+    && cp /pygeoapi/docker/entrypoint.sh /entrypoint.sh \
+    # compile language files
+    && cd /pygeoapi \
+    && for i in locale/*; do echo $i && pybabel compile -d locale -l `basename $i`; done
+
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
# Overview
Adds building of `.mo` files to default Docket image setup.
# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc @Youssef-Harby 
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
