### PR TITLE
OATiles: remove popup and id_field

### DIFF
--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -157,6 +157,7 @@ This code block shows how to configure pygeoapi to render Mapbox vector tiles fr
              user: postgres
              password: postgres
              search_path: [osm, public]
+         id_field: osm_id
          table: hotosm_bdi_waterways
          geom_field: foo_geom
          storage_crs: http://www.opengis.net/def/crs/EPSG/0/4326

--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -157,7 +157,6 @@ This code block shows how to configure pygeoapi to render Mapbox vector tiles fr
              user: postgres
              password: postgres
              search_path: [osm, public]
-         id_field: osm_id
          table: hotosm_bdi_waterways
          geom_field: foo_geom
          storage_crs: http://www.opengis.net/def/crs/EPSG/0/4326

--- a/pygeoapi/templates/collections/tiles/index.html
+++ b/pygeoapi/templates/collections/tiles/index.html
@@ -9,12 +9,6 @@
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.3.1/leaflet.js"></script>
     <script src="https://unpkg.com/leaflet.vectorgrid@latest/dist/Leaflet.VectorGrid.bundled.js"></script>
-    <style>
-      .leaflet-popup-content {
-          width: 200px;
-          height: 100px;
-      }
-    </style>
 {% endblock %}
 
 {% block body %}
@@ -144,12 +138,6 @@
 
         var tilesPbfLayer = L.vectorGrid.protobuf(url, VectorTileOptions)
             .on('click', function(e) { // The .on method attaches an event handler
-                L.popup()
-                    .setContent("<b>Name</b>: " + e.layer.properties.name +
-                        "<br><b>Class</b>: " + e.layer.properties.featureclass)
-                    .setLatLng(e.latlng)
-                    .openOn(map);
-
                 clearHighlight();
                 highlight = e.layer.properties.id || e.layer.properties.fid || e.layer.properties.uri;
                 tilesPbfLayer.setFeatureStyle(highlight, {


### PR DESCRIPTION
# Overview
This PR fixes hardcoded id values for OATiles HTML rendering.
# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
