### PR TITLE
Fix NoData values for Coverage JSON output

### DIFF
--- a/pygeoapi/provider/rasterio_.py
+++ b/pygeoapi/provider/rasterio_.py
@@ -29,6 +29,7 @@
 
 import logging
 
+import numpy as np
 from pyproj import CRS, Transformer
 import rasterio
 from rasterio.io import MemoryFile
@@ -334,7 +335,10 @@ class RasterioProvider(BaseProvider):
                     'shape': [metadata['height'], metadata['width']],
                 }
                 # TODO: deal with multi-band value output
-                cj['ranges'][key]['values'] = data.flatten().tolist()
+                cj['ranges'][key]['values'] = [None if isinstance(v, float)
+                                               and np.isnan(v)
+                                               else v for v in
+                                               data.flatten().tolist()]
         except IndexError as err:
             LOGGER.warning(err)
             raise ProviderQueryError('Invalid query parameter')


### PR DESCRIPTION
# Overview

As seen during the Diving into pygeoapi workshop the JSON coverage output was broken due to NaN values in the output. 

<img width="685" height="143" alt="error" src="https://github.com/user-attachments/assets/fa761c44-b57c-414b-aaad-c848a86908b1" />

This PR ensures NaN are converted to Python `None` values, which are then converted to `null` values in the JSON output, using the same approach as in the xarray driver - https://github.com/geopython/pygeoapi/blob/master/pygeoapi/provider/xarray_.py#L395-L398

<img width="320" height="92" alt="image" src="https://github.com/user-attachments/assets/02c914d4-8de0-4748-8de9-8b9055a501d7" />

# Dependency policy (RFC2)



- [X ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute this bugfix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
