### PR TITLE
Fix typo in OGC API - Tiles documentation

### DIFF
--- a/docs/source/data-publishing/ogcapi-tiles.rst
+++ b/docs/source/data-publishing/ogcapi-tiles.rst
@@ -49,7 +49,7 @@ This code block shows how to configure pygeoapi to read Mapbox vector tiles gene
              zoom:
                  min: 0
                  max: 5
-        # MVT-elastic always uses WebMercatorQuad tiling scheme
+        # MVT-tippecanoe always uses WebMercatorQuad tiling scheme
          format:
              name: pbf
              mimetype: application/vnd.mapbox-vector-tile


### PR DESCRIPTION
Fixes a small typo in the OGC API - Tiles docs.  
Specifically, in the comment describing tiling scheme usage, replaced:
 `# MVT-elastic always uses WebMercatorQuad tiling scheme`
 with:
 `# MVT-tippecanoe always uses WebMercatorQuad tiling scheme`

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
