### PR TITLE
Documentation for extra_params for the oracle provider.

### DIFF
--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -558,12 +558,18 @@ The ``ORACLE_POOL_MIN`` and ``ORACLE_POOL_MAX`` environment variables are used t
 If none or only one of the environment variables is set, session pooling will not be activated and standalone connections are established at every request.
 
 
+Extra_params
+"""""""""""""""""""""""""""""
+The oracle provider allows for additional parameters that can be passed in the request. It allows for the processing of additional parameters that are not defined in the ``pygeoapi-config.yml`` to be passed to a custom SQL-Manipulator-Plugin. An example use case of this is advanced filtering without exposing the filtered columns like follows ``.../collections/some_data/items?is_recent=true``. The ``SqlManipulator`` plugin's ``process_query`` method would receive ``extra_params = {'is_recent': 'true'}`` and could dynamically add a custom condition to the SQL query, like ``AND SYSDATE - create_date < 30``.
+
+
+
 Custom SQL Manipulator Plugin
 """""""""""""""""""""""""""""
 The provider supports a SQL-Manipulator-Plugin class. With this, the SQL statement could be manipulated. This is
 useful e.g. for authorization at row level or manipulation of the explain plan with hints. 
 
-An example an more information about that feature you can find in the test class in tests/test_oracle_provider.py.
+An example and more information about that feature can be found in the test class in tests/test_oracle_provider.py.
 
 .. _Parquet:
 

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -561,7 +561,7 @@ If none or only one of the environment variables is set, session pooling will no
 Extra_params
 """""""""""""""""""""""""""""
 The oracle provider allows for additional parameters that can be passed in the request. It allows for the processing of additional parameters that are not defined in the ``pygeoapi-config.yml`` to be passed to a custom SQL-Manipulator-Plugin. An example use case of this is advanced filtering without exposing the filtered columns like follows ``.../collections/some_data/items?is_recent=true``. The ``SqlManipulator`` plugin's ``process_query`` method would receive ``extra_params = {'is_recent': 'true'}`` and could dynamically add a custom condition to the SQL query, like ``AND SYSDATE - create_date < 30``.
-
+The ``include_extra_query_parameters`` has to be set to ``true`` for the collection in the ``pygeoapi-config.yml``. This ensures that the additional request parameters (e.g. ``is_recent=true``) are not discarded. 
 
 
 Custom SQL Manipulator Plugin

--- a/docs/source/data-publishing/ogcapi-features.rst
+++ b/docs/source/data-publishing/ogcapi-features.rst
@@ -559,9 +559,10 @@ If none or only one of the environment variables is set, session pooling will no
 
 
 Extra_params
-"""""""""""""""""""""""""""""
-The oracle provider allows for additional parameters that can be passed in the request. It allows for the processing of additional parameters that are not defined in the ``pygeoapi-config.yml`` to be passed to a custom SQL-Manipulator-Plugin. An example use case of this is advanced filtering without exposing the filtered columns like follows ``.../collections/some_data/items?is_recent=true``. The ``SqlManipulator`` plugin's ``process_query`` method would receive ``extra_params = {'is_recent': 'true'}`` and could dynamically add a custom condition to the SQL query, like ``AND SYSDATE - create_date < 30``.
-The ``include_extra_query_parameters`` has to be set to ``true`` for the collection in the ``pygeoapi-config.yml``. This ensures that the additional request parameters (e.g. ``is_recent=true``) are not discarded. 
+""""""""""""
+The Oracle provider allows for additional parameters that can be passed in the request. It allows for the processing of additional parameters that are not defined in the ``pygeoapi-config.yml`` to be passed to a custom SQL-Manipulator-Plugin. An example use case of this is advanced filtering without exposing the filtered columns like follows ``.../collections/some_data/items?is_recent=true``. The ``SqlManipulator`` plugin's ``process_query`` method would receive ``extra_params = {'is_recent': 'true'}`` and could dynamically add a custom condition to the SQL query, like ``AND SYSDATE - create_date < 30``.
+
+The ``include_extra_query_parameters`` has to be set to ``true`` for the collection in ``pygeoapi-config.yml``. This ensures that the additional request parameters (e.g. ``is_recent=true``) are not discarded. 
 
 
 Custom SQL Manipulator Plugin


### PR DESCRIPTION
# Overview
Documentation on the extra_params variable in the oracle provider and the reasoning behind it was suggested by @doublebyte1 in https://github.com/geopython/pygeoapi/pull/1673. 

Added the documentation and an example use case for the extra_params variable..

# Related Issue / discussion
See discussion under
https://github.com/geopython/pygeoapi/pull/1673
and potentially related issue
https://github.com/geopython/pygeoapi/pull/2071 (introduction of ``include_extra_query_parameters``)


# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
