### PR TITLE
maintain order of PostgreSQL table columns (#2078)

### DIFF
--- a/pygeoapi/provider/sql.py
+++ b/pygeoapi/provider/sql.py
@@ -242,7 +242,8 @@ class GenericSQLProvider(BaseProvider):
             ):
                 response['numberReturned'] += 1
                 response['features'].append(
-                    self._sqlalchemy_to_feature(item, crs_transform_out)
+                    self._sqlalchemy_to_feature(item, crs_transform_out,
+                                                select_properties)
                 )
 
         return response
@@ -447,18 +448,16 @@ class GenericSQLProvider(BaseProvider):
             if not isinstance(v, dict)
         }
 
-    def _sqlalchemy_to_feature(self, item, crs_transform_out=None):
-        feature = {'type': 'Feature'}
+    def _sqlalchemy_to_feature(self, item, crs_transform_out=None,
+                               select_properties=[]):
+        feature = {'type': 'Feature', 'properties': {}}
 
-        # Add properties from item
-        item_dict = item.__dict__
-        item_dict.pop('_sa_instance_state')  # Internal SQLAlchemy metadata
-        feature['properties'] = item_dict
-        feature['id'] = item_dict.pop(self.id_field)
+        # set feature id
+        feature['id'] = item.__dict__[self.id_field]
 
         # Convert geometry to GeoJSON style
-        if feature['properties'].get(self.geom):
-            wkb_geom = feature['properties'].pop(self.geom)
+        if item.__dict__.get(self.geom) is not None:
+            wkb_geom = item.__dict__[self.geom]
             try:
                 shapely_geom = to_shape(wkb_geom)
             except TypeError:
@@ -469,6 +468,13 @@ class GenericSQLProvider(BaseProvider):
             feature['geometry'] = geojson_geom
         else:
             feature['geometry'] = None
+
+        keys = select_properties or self.fields.keys()
+        for key in keys:
+            if key in item.__dict__:
+                feature['properties'][key] = item.__dict__[key]
+
+        feature['properties'].pop(self.id_field, None)
 
         return feature
 
@@ -567,17 +573,19 @@ class GenericSQLProvider(BaseProvider):
     def _select_properties_clause(self, select_properties, skip_geometry):
         # List the column names that we want
         if select_properties:
-            column_names = set(select_properties)
+            column_names = sorted(set(select_properties),
+                                  key=select_properties.index)
         else:
             # get_fields() doesn't include geometry column
-            column_names = set(self.fields.keys())
+            column_names = self.fields.keys()
 
         if self.properties:  # optional subset of properties defined in config
-            properties_from_config = set(self.properties)
-            column_names = column_names.intersection(properties_from_config)
+            properties_from_config = self.properties
+            column_names = column_names and properties_from_config
 
         if not skip_geometry:
-            column_names.add(self.geom)
+            column_names = list(column_names)
+            column_names.append(self.geom)
 
         # Convert names to SQL Alchemy clause
         selected_columns = []

--- a/pygeoapi/provider/sql.py
+++ b/pygeoapi/provider/sql.py
@@ -450,14 +450,27 @@ class GenericSQLProvider(BaseProvider):
 
     def _sqlalchemy_to_feature(self, item, crs_transform_out=None,
                                select_properties=[]):
+        """
+        Helper function to transform an SQLAlchemy result to a
+        GeoJSON feature.
+
+        :param item: SQLAlchemy result
+        :param crs_transform_out: CRS transformation
+        :param select_properties: additional properties to filter on
+
+        :returns: `dict` of GeoJSON feature
+        """
+
         feature = {'type': 'Feature', 'properties': {}}
 
+        item_dict = item.__dict__
+
         # set feature id
-        feature['id'] = item.__dict__[self.id_field]
+        feature['id'] = item_dict[self.id_field]
 
         # Convert geometry to GeoJSON style
-        if item.__dict__.get(self.geom) is not None:
-            wkb_geom = item.__dict__[self.geom]
+        if item_dict.get(self.geom) is not None:
+            wkb_geom = item_dict[self.geom]
             try:
                 shapely_geom = to_shape(wkb_geom)
             except TypeError:
@@ -471,8 +484,8 @@ class GenericSQLProvider(BaseProvider):
 
         keys = select_properties or self.fields.keys()
         for key in keys:
-            if key in item.__dict__:
-                feature['properties'][key] = item.__dict__[key]
+            if key in item_dict:
+                feature['properties'][key] = item_dict[key]
 
         feature['properties'].pop(self.id_field, None)
 

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -161,6 +161,14 @@ def test_query(config):
     feature = features[0]
     properties = feature.get('properties')
     assert properties is not None
+
+    properties_order = [
+        'name', 'waterway', 'covered', 'width', 'depth', 'layer', 'blockage',
+        'tunnel', 'natural', 'water', 'z_index'
+    ]
+
+    assert list(properties.keys()) == properties_order
+
     geometry = feature.get('geometry')
     assert geometry is not None
 


### PR DESCRIPTION
# Overview
This PR preserves the order of PostgreSQL columns when emitting feature properties.
# Related Issue / discussion
#2078 
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
