### PR TITLE
Make PyGeoAPI to run rootless (Tested in Openshift)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -121,10 +121,12 @@ case ${entry_cmd} in
 
 	# Run pygeoapi server with hot reload
 	run-with-hot-reload)
-		# Lock all Python files (for gunicorn hot reload)
-		# NOTE: Unecessary when running with non-privileged user. 
-		# If running as root, we can change permissions back, with a dummy shell
-		# find . -type f -name "*.py" | xargs chmod 0444
+		# Lock all Python files (for gunicorn hot reload), if running with user root
+		if [[ $(id -u) -eq 0 ]]
+		then
+			echo "Running pygeoapi as root"
+			find . -type f -name "*.py" | xargs chmod 0444
+		fi
 
 		# Start with hot reload options
 		start_gunicorn --reload --reload-extra-file ${PYGEOAPI_CONFIG}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,8 +37,13 @@ echo "START /entrypoint.sh"
 set +e
 
 export PYGEOAPI_HOME=/pygeoapi
-export PYGEOAPI_CONFIG="${PYGEOAPI_HOME}/local.config.yml"
-export PYGEOAPI_OPENAPI="${PYGEOAPI_HOME}/local.openapi.yml"
+
+if [[ -z "$PYGEOAPI_CONFIG" ]]; then
+	export PYGEOAPI_CONFIG="${PYGEOAPI_HOME}/local.config.yml"
+fi
+if [[ -z "$PYGEOAPI_OPENAPI" ]]; then
+	export PYGEOAPI_OPENAPI="${PYGEOAPI_HOME}/local.openapi.yml"
+fi
 
 # gunicorn env settings with defaults
 SCRIPT_NAME=${SCRIPT_NAME:=/}
@@ -61,6 +66,8 @@ function error() {
 
 # Workdir
 cd ${PYGEOAPI_HOME}
+
+echo "Default config in ${PYGEOAPI_CONFIG}"
 
 echo "Trying to generate openapi.yml"
 pygeoapi openapi generate ${PYGEOAPI_CONFIG} --output-file ${PYGEOAPI_OPENAPI}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -122,7 +122,9 @@ case ${entry_cmd} in
 	# Run pygeoapi server with hot reload
 	run-with-hot-reload)
 		# Lock all Python files (for gunicorn hot reload)
-		find . -type f -name "*.py" | xargs chmod 0444
+		# NOTE: Unecessary when running with non-privileged user. 
+		# If running as root, we can change permissions back, with a dummy shell
+		# find . -type f -name "*.py" | xargs chmod 0444
 
 		# Start with hot reload options
 		start_gunicorn --reload --reload-extra-file ${PYGEOAPI_CONFIG}


### PR DESCRIPTION
# Overview
This PR aims to modify mininal things in entrypoint script to allow the container to run as a non-root user. This is specially important to Openshift because it was denied by default to run rooted containers. 

this PR could be summarized in two items:
1. Allow to modify PYGEOAPI_CONFIG e PYGEOAPI_OPENAPI in runtime.
2. Remove the necessity to chmod python files on hot reload execution, due of using less privileged uids.

This is important because the entrypoint script tries to generate OpenAPI yaml, and the pygeoapi executable can't create on his own dir. We set the env to write in /tmp dir.

# Related Issue / discussion
Add/Update container offerings: https://github.com/geopython/pygeoapi/issues/1753

# Additional information
This two modifications, in addition to set CONTAINER_PORT > 1024 (we used 8080) allowed us to run pygeoapi in OpenShift with default security configurations. 

docker run example:
```bash
# Using a local-builded image
docker run \
  -p 5000:8080 \
  -d \
  --rm \
  -v ./pygeoapi-config.yml:/tmp/local.config.yml \
  -e "PYGEOAPI_CONFIG=/tmp/local.config.yml" \
  -e "PYGEOAPI_OPENAPI=/tmp/local.openapi.yml" \
  -e "CONTAINER_PORT=8080" \
  -u 1000 
ndscprm/pygeoapi:dev run-with-hot-reload
```

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
