### PR TITLE
Fix multiple SQL schema paths

### DIFF
--- a/pygeoapi/provider/sql.py
+++ b/pygeoapi/provider/sql.py
@@ -648,10 +648,23 @@ def get_table_model(
             f'Could not connect to {repr(engine.url)} (password hidden).'
         )
     except InvalidRequestError:
-        raise ProviderQueryError(
+        msg = (
             f"Table '{table_name}' not found in schema '{schema}' "
             f'on {repr(engine.url)}.'
         )
+        LOGGER.error(msg)
+
+        if len(db_search_path) > 1:
+            # If the table is not found in the first schema, try the next one
+            return get_table_model(
+                table_name, 
+                id_field, 
+                db_search_path[1:],
+                engine
+            )
+        else:
+            # If the table is not found in any schema, raise an error
+            raise ProviderQueryError(msg)
 
     # Create SQLAlchemy model from reflected table
     # It is necessary to add the primary key constraint because SQLAlchemy

--- a/pygeoapi/provider/sql.py
+++ b/pygeoapi/provider/sql.py
@@ -657,8 +657,8 @@ def get_table_model(
         if len(db_search_path) > 1:
             # If the table is not found in the first schema, try the next one
             return get_table_model(
-                table_name, 
-                id_field, 
+                table_name,
+                id_field,
                 db_search_path[1:],
                 engine
             )

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -149,6 +149,14 @@ def test_valid_connection_options(config):
             assert key in ['connect_timeout', 'tcp_user_timeout', 'keepalives',
                            'keepalives_idle', 'keepalives_count',
                            'keepalives_interval']
+            
+def test_schema_path_search(config):
+    config['data']['search_path'] = ['public', 'osm']
+    PostgreSQLProvider(config)
+
+    config['data']['search_path'] = ['public', 'notosm']
+    with pytest.raises(ProviderQueryError):
+        PostgreSQLProvider(config)
 
 
 def test_query(config):

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -149,7 +149,8 @@ def test_valid_connection_options(config):
             assert key in ['connect_timeout', 'tcp_user_timeout', 'keepalives',
                            'keepalives_idle', 'keepalives_count',
                            'keepalives_interval']
-            
+
+
 def test_schema_path_search(config):
     config['data']['search_path'] = ['public', 'osm']
     PostgreSQLProvider(config)


### PR DESCRIPTION
# Overview
Fixes the ability for the SQL provider to find a table on a Schema Path. While this still only loads a single schema, it at least tries to load the table schema on more than just the first search path in the configuration.

# Related Issue / discussion
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
