### PR TITLE
Added a paragraph about the pygeoapi HTML encoding on the template section of the documentation

### DIFF
--- a/docs/source/html-templating.rst
+++ b/docs/source/html-templating.rst
@@ -79,6 +79,11 @@ The following aspects of the default HTML templates can be customized (within th
 - **icon**: shortcut icon (typically displays on a given web browser tab)
 - **logo**: logo/image banner (displays at the top of HTML pages)
 
+.. warning::
+
+   The pygeoapi web frontend is provided *only* as an example of an alternate ``HTML`` encoding. 
+   It should not be viewed as a replacement for a proper OGC API client, which can add much more capabilities than even the ones you can achieve with HTML templating.
+   On the `Dive into pygeoapi workshop <https://dive.pygeoapi.io/>`_ you can find examples of existing OGC API clients.
 
 .. _`Jinja`: https://palletsprojects.com/p/jinja/
 .. _`Jinja documentation`: https://jinja.palletsprojects.com


### PR DESCRIPTION
# Overview

There are often requests to add more functionality to the UI of pygeoapi. IMHO pygeoapi is an API, and thus it was designed to interact with machines, mainly with JSON or another machine readable encoding. The frontend is provided only as an example of a HTML encoding, and by design, it has limited functionality.

This PR adds a paragraph to clarify this in the documentation.

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
