### PR TITLE
don't remove id property

### DIFF
--- a/pygeoapi/provider/sql.py
+++ b/pygeoapi/provider/sql.py
@@ -487,8 +487,6 @@ class GenericSQLProvider(BaseProvider):
             if key in item_dict:
                 feature['properties'][key] = item_dict[key]
 
-        feature['properties'].pop(self.id_field, None)
-
         return feature
 
     def _feature_to_sqlalchemy(self, json_data, identifier=None):


### PR DESCRIPTION
# Overview

Notice that you can query for a feature by its id but the attribute you queried for isn't in the response anymore.

https://labs-beta.waterdata.usgs.gov/api/fabric/pygeoapi/collections/nhdplusv2-huc12/items?huc12=170101010306

Or in terms of the pygeoapi demo:

https://demo.pygeoapi.io/master/collections/dutch_windmills/items?gml_id=Molens.1

Notice that the query is for an id that doesn't get returned in the output. 

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
