### PR TITLE
Raise ProviderTileNotFoundError instead of returning

### DIFF
--- a/pygeoapi/provider/mvt_postgresql.py
+++ b/pygeoapi/provider/mvt_postgresql.py
@@ -151,7 +151,7 @@ class MVTPostgreSQLProvider(BaseMVTProvider, PostgreSQLProvider):
         ]
         if not self.is_in_limits(tileset_schema, z, x, y):
             LOGGER.warning(f'Tile {z}/{x}/{y} not found')
-            return ProviderTileNotFoundError
+            raise ProviderTileNotFoundError
 
         storage_srid = get_crs_from_uri(self.storage_crs).to_string()
         out_srid = get_crs_from_uri(tileset_schema.crs).to_string()


### PR DESCRIPTION
Fix typo that returned ProviderTileNotFoundError instead of raising it

# Overview

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
