### PR TITLE
Change api endpoint to be /api instead of /openapi

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -781,12 +781,12 @@ def landing_page(api: API,
         'rel': 'service-desc',
         'type': 'application/vnd.oai.openapi+json;version=3.0',
         'title': l10n.translate('The OpenAPI definition as JSON', request.locale),  # noqa
-        'href': f"{api.base_url}/openapi"
+        'href': f"{api.base_url}/api"
     }, {
         'rel': 'service-doc',
         'type': FORMAT_TYPES[F_HTML],
         'title': l10n.translate('The OpenAPI definition as HTML', request.locale),  # noqa
-        'href': f"{api.base_url}/openapi?f={F_HTML}",
+        'href': f"{api.base_url}/api?f={F_HTML}",
         'hreflang': api.default_locale
     }, {
         'rel': 'conformance',
@@ -865,7 +865,7 @@ def openapi_(api: API, request: APIRequest) -> Tuple[dict, int, str]:
         if request._args.get('ui') == 'redoc':
             template = 'openapi/redoc.html'
 
-        path = f'{api.base_url}/openapi'
+        path = f'{api.base_url}/api'
         data = {
             'openapi-document-path': path
         }

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -170,7 +170,7 @@ def landing_page():
     return execute_from_flask(core_api.landing_page, request)
 
 
-@BLUEPRINT.route('/openapi')
+@BLUEPRINT.route('/api')
 def openapi():
     """
     OpenAPI endpoint

--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -286,7 +286,7 @@ def get_oas_30(cfg: dict, fail_on_invalid_collection: bool = True) -> dict:
         }
     }
 
-    paths['/openapi'] = {
+    paths['/api'] = {
         'get': {
             'summary': 'This document',
             'description': 'This document',

--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -650,7 +650,7 @@ class ApiRulesMiddleware:
 
 api_routes = [
     Route('/', landing_page),
-    Route('/openapi', openapi),
+    Route('/api', openapi),
     Route('/conformance', conformance),
     Route('/TileMatrixSets/{tileMatrixSetId}', get_tilematrix_set),
     Route('/TileMatrixSets', get_tilematrix_sets),

--- a/pygeoapi/templates/landing_page.html
+++ b/pygeoapi/templates/landing_page.html
@@ -85,10 +85,10 @@
   <section id="openapi">
       <h2>{% trans %}API Definition{% endtrans %}</h2>
       <p>
-        {% trans %}Documentation{% endtrans %}: <a href="{{ config['server']['url'] }}/openapi?f=html">{% trans %}Swagger UI{% endtrans %}</a> <a href="{{ config['server']['url'] }}/openapi?f=html&ui=redoc">{% trans %}ReDoc{% endtrans %}</a>
+        {% trans %}Documentation{% endtrans %}: <a href="{{ config['server']['url'] }}/api?f=html">{% trans %}Swagger UI{% endtrans %}</a> <a href="{{ config['server']['url'] }}/api?f=html&ui=redoc">{% trans %}ReDoc{% endtrans %}</a>
       </p>
       <p>
-        <a href="{{ config['server']['url'] }}/openapi?f=json">{% trans %}OpenAPI Document{% endtrans %}</a>
+        <a href="{{ config['server']['url'] }}/api?f=json">{% trans %}OpenAPI Document{% endtrans %}</a>
       </p>
   </section>
   <section id="conformance">


### PR DESCRIPTION
# Overview

Cf

- OGC API Features - Part 1 (https://docs.ogc.org/is/17-069r4/17-069r4.html#_api_definition_path_rootapi_link) para 7.3.1, permission 1: "it MAY be hosted as a sub-resource to the base path of the API, for example, at path /api"

- OGC API Common Part 1 (https://docs.ogc.org/is/19-072/19-072.html#_6f30c0b2-ff4c-4c38-8d51-bd124f4b76cc) para 9.2, Recommandation 15.A: "The server SHOULD support the HTTP GET operation on the URI {root}/api."

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
