### PR TITLE
Catch EDR `AttributeError` errors more fine grained

### DIFF
--- a/pygeoapi/provider/base_edr.py
+++ b/pygeoapi/provider/base_edr.py
@@ -28,7 +28,6 @@
 # =================================================================
 
 import logging
-from typing import Optional
 
 from pygeoapi.provider.base import (BaseProvider, ProviderInvalidDataError,
                                     ProviderQueryError)


### PR DESCRIPTION
# Overview

- Currrently in the EDR base provider there is a `try` `except` over every `AttributeError` in the `query` function
- Thus, if a provider throws an `AttributeError` it will mistakenly say that the query is not implemented and it is possible to get confusing errors like these, when it reality is was coming from an `AttributeError` in the provider

```
NotImplementedError: Query "cube" not implemented in list ['locations', 'cube', 'area']
```

## Fix

This PR fixes this behavior to:
- put the try catch on only the `getattr` call so other `AttributeErrors` are preserved
- add the names of the registered queries which is useful for debugging purposes
- explicitly make sure `query_type` is passed in. Otherwise you would try to do `getattr` with `None` which could in the future cause other confusing issues

# Related Issue / discussion

N/A

# Additional information

N/A

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
