### PR TITLE
0.21.0 fix for queries 

### DIFF
--- a/pygeoapi/provider/xarray_edr.py
+++ b/pygeoapi/provider/xarray_edr.py
@@ -107,6 +107,19 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
         z = kwargs.get('z')
         if z is not None:
             if self.z_field is not None:
+                coord = self._data[self.z_field]
+                coord_dtype = getattr(coord, 'dtype', None)
+
+                if coord_dtype is not None and coord_dtype.kind in {'i', 'u', 'f'}:
+                    if isinstance(z, str):
+                        try:
+                            z = coord_dtype.type(z)
+                        except ValueError:
+                            LOGGER.debug(
+                                'Unable to cast value %s to %s',
+                                z,
+                                coord_dtype,
+                            )
                 query_params[self.z_field] = z
             else:
                 LOGGER.debug('No vertical level found')

--- a/pygeoapi/provider/xarray_edr.py
+++ b/pygeoapi/provider/xarray_edr.py
@@ -254,9 +254,13 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
         if '/' in datetime_:
             begin, end = datetime_.split('/')
             if begin == '..':
-                begin = self._data[self.time_field].min().values
+                begin = _to_datetime_string(
+                    self._data[self.time_field].min().values
+                ).rstrip('Z')
             if end == '..':
-                end = self._data[self.time_field].max().values
+                end = _to_datetime_string(
+                    self._data[self.time_field].max().values
+                ).rstrip('Z')
             if np.datetime64(begin) < np.datetime64(end):
                 return slice(begin, end)
             else:

--- a/pygeoapi/provider/xarray_edr.py
+++ b/pygeoapi/provider/xarray_edr.py
@@ -110,7 +110,12 @@ class XarrayEDRProvider(BaseEDRProvider, XarrayProvider):
                 coord = self._data[self.z_field]
                 coord_dtype = getattr(coord, 'dtype', None)
 
-                if coord_dtype is not None and coord_dtype.kind in {'i', 'u', 'f'}:
+                coord_is_numeric = (
+                    coord_dtype is not None and
+                    coord_dtype.kind in {'i', 'u', 'f'}
+                )
+
+                if coord_is_numeric:
                     if isinstance(z, str):
                         try:
                             z = coord_dtype.type(z)


### PR DESCRIPTION
# Overview

# Related Issue / discussion

`xarray_edr.py` produces the follwing on a `.sel` when parameters are given via a web/url query:
<img width="553" height="29" alt="image" src="https://github.com/user-attachments/assets/c9742a78-11ba-4768-8ce7-a080cbbd019c" />

As seen, the code is pulling the datetime as `numpy.datetime64` . Changes introduced that normalize it.

Additionally, for the `z` parameter, it was querying `z` as a `str` which is incorrect. Changes introduced now check for the `dtype` of the `z` axis and cast to it prior to .`sel`. 

Those 2 were causing the queries to error. Changes have been locally tested and queries are valid/successful.


<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
