### PR TITLE
linked data: safeguard crs typing

### DIFF
--- a/pygeoapi/linked_data.py
+++ b/pygeoapi/linked_data.py
@@ -133,7 +133,7 @@ def jsonldify_collection(cls, collection: dict, locale_: str) -> dict:
 
     spatial_extent = collection.get('extent', {}).get('spatial', {})
     bbox = spatial_extent.get('bbox')
-    crs = spatial_extent.get('crs')
+    crs = spatial_extent.get('crs', '')
     hascrs84 = crs.endswith('CRS84')
 
     dataset = {


### PR DESCRIPTION
# Overview
This PR is a bugfix to safeguard from `None` types.
# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
