### PR TITLE
Add early support for JSON-FG

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -109,7 +109,7 @@ CONFORMANCE_CLASSES = [
     'http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections',
     'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page',
     'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json',
-    'http://www.opengis.net/spec/json-fg-1/0.2/conf/core',
+    'http://www.opengis.net/spec/json-fg-1/0.3/conf/core',
     'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30'
 ]
 

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -95,7 +95,7 @@ FORMAT_TYPES = OrderedDict((
     (F_HTML, 'text/html'),
     (F_JSONLD, 'application/ld+json'),
     (F_JSON, 'application/json'),
-    (F_JSONFG, 'application/vnd.geo+json'),
+    (F_JSONFG, 'application/geo+json'),
     (F_JPEG, 'image/jpeg'),
     (F_MVT, 'application/vnd.mapbox-vector-tile'),
     (F_NETCDF, 'application/x-netcdf'),
@@ -1129,6 +1129,12 @@ def describe_collections(api: API, request: APIRequest,
                 'href': f'{api.get_collections_url()}/{k}/items?f={F_JSON}'  # noqa
             })
             collection['links'].append({
+                'type': FORMAT_TYPES[F_JSONFG],
+                'rel': 'items',
+                'title': l10n.translate('Items as JSON-FG', request.locale),  # noqa
+                'href': f'{api.get_collections_url()}/{k}/items?f={F_JSONFG}'  # noqa
+            })
+            collection['links'].append({
                 'type': FORMAT_TYPES[F_JSONLD],
                 'rel': 'items',
                 'title': l10n.translate('Items as RDF (GeoJSON-LD)', request.locale),  # noqa
@@ -1333,6 +1339,12 @@ def describe_collections(api: API, request: APIRequest,
             'rel': request.get_linkrel(F_JSON),
             'title': l10n.translate('This document as JSON', request.locale),  # noqa
             'href': f'{api.get_collections_url()}?f={F_JSON}'
+        })
+        fcm['links'].append({
+            'type': FORMAT_TYPES[F_JSONFG],
+            'rel': request.get_linkrel(F_JSONFG),
+            'title': l10n.translate('This document as JSON-FG', request.locale),  # noqa
+            'href': f'{api.get_collections_url()}?f={F_JSONFG}'
         })
         fcm['links'].append({
             'type': FORMAT_TYPES[F_JSONLD],

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -82,6 +82,7 @@ CHARSET = ['utf-8']
 F_JSON = 'json'
 F_COVERAGEJSON = 'json'
 F_HTML = 'html'
+F_JSONFG = 'jsonfg'
 F_JSONLD = 'jsonld'
 F_GZIP = 'gzip'
 F_PNG = 'png'
@@ -94,7 +95,7 @@ FORMAT_TYPES = OrderedDict((
     (F_HTML, 'text/html'),
     (F_JSONLD, 'application/ld+json'),
     (F_JSON, 'application/json'),
-    (F_PNG, 'image/png'),
+    (F_JSONFG, 'application/vnd.geo+json'),
     (F_JPEG, 'image/jpeg'),
     (F_MVT, 'application/vnd.mapbox-vector-tile'),
     (F_NETCDF, 'application/x-netcdf'),
@@ -108,7 +109,7 @@ CONFORMANCE_CLASSES = [
     'http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections',
     'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page',
     'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json',
-    'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/html',
+    'http://www.opengis.net/spec/json-fg-1/0.2/conf/core',
     'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30'
 ]
 

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -710,7 +710,10 @@ def get_collection_items(
 
         try:
             content = formatter.write(
+                api=api,
                 data=content,
+                dataset=dataset,
+                id_field=(p.uri_field or 'id'),
                 options={
                     'provider_def': get_provider_by_type(
                         collections[dataset]['providers'],
@@ -723,7 +726,9 @@ def get_collection_items(
                 HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
                 'NoApplicableCode', msg)
 
-        return headers, HTTPStatus.OK, content
+        headers['Content-Type'] = formatter.mimetype
+
+        return headers, HTTPStatus.OK, to_json(content, api.pretty_print)
 
     return headers, HTTPStatus.OK, to_json(content, api.pretty_print)
 
@@ -947,6 +952,11 @@ def get_collection_item(api: API, request: APIRequest,
         'title': l10n.translate('This document as JSON', request.locale),
         'href': f'{uri}?f={F_JSON}'
         }, {
+        'rel': request.get_linkrel(F_JSONFG),
+        'type': FORMAT_TYPES[F_JSONFG],
+        'title': l10n.translate('This document as JSON-FG (JSON-FG)', request.locale),  # noqa
+        'href': f'{uri}?f={F_JSONFG}'
+        }, {
         'rel': request.get_linkrel(F_JSONLD),
         'type': FORMAT_TYPES[F_JSONLD],
         'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa
@@ -1010,15 +1020,15 @@ def get_collection_item(api: API, request: APIRequest,
         return headers, HTTPStatus.OK, content
 
     elif request.format == F_JSONFG:
-        # content = geojson2jsonfg(
-        #     api, content, dataset, id_field=(p.uri_field or 'id')
-        # )
         formatter = load_plugin('formatter',
                                 {'name': F_JSONFG, 'geom': True})
 
         try:
             content = formatter.write(
+                api=api,
                 data=content,
+                dataset=dataset,
+                id_field=(p.uri_field or 'id'),
                 options={
                     'provider_def': get_provider_by_type(
                         collections[dataset]['providers'],
@@ -1031,7 +1041,7 @@ def get_collection_item(api: API, request: APIRequest,
                 HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
                 'NoApplicableCode', msg)
 
-        return headers, HTTPStatus.OK, content
+        return headers, HTTPStatus.OK, to_json(content, api.pretty_print)
 
     return headers, HTTPStatus.OK, to_json(content, api.pretty_print)
 

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -710,7 +710,6 @@ def get_collection_items(
 
         try:
             content = formatter.write(
-                api=api,
                 data=content,
                 dataset=dataset,
                 id_field=(p.uri_field or 'id'),
@@ -1025,7 +1024,6 @@ def get_collection_item(api: API, request: APIRequest,
 
         try:
             content = formatter.write(
-                api=api,
                 data=content,
                 dataset=dataset,
                 id_field=(p.uri_field or 'id'),

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -575,6 +575,11 @@ def get_collection_items(
         'title': l10n.translate('This document as GeoJSON', request.locale),
         'href': f'{uri}?f={F_JSON}{serialized_query_params}'
     }, {
+        'rel': request.get_linkrel(F_JSONFG),
+        'type': FORMAT_TYPES[F_JSONFG],
+        'title': l10n.translate('This document as JSON-FG', request.locale),  # noqa
+        'href': f'{uri}?f={F_JSONFG}{serialized_query_params}'
+    }, {
         'rel': request.get_linkrel(F_JSONLD),
         'type': FORMAT_TYPES[F_JSONLD],
         'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -50,7 +50,6 @@ from pyproj.exceptions import CRSError
 from pygeoapi import l10n
 from pygeoapi.api import evaluate_limit
 from pygeoapi.formatter.base import FormatterSerializationError
-from pygeoapi.formatter.jsonfg import geojson2jsonfg
 from pygeoapi.linked_data import geojson2jsonld
 from pygeoapi.plugin import load_plugin, PLUGINS
 from pygeoapi.provider.base import (
@@ -63,7 +62,8 @@ from pygeoapi.util import (CrsTransformSpec, filter_providers_by_type,
                            to_json, transform_bbox)
 
 from . import (
-    APIRequest, API, SYSTEM_LOCALE, F_JSON, FORMAT_TYPES, F_HTML, F_JSONFG, F_JSONLD,
+    APIRequest, API, SYSTEM_LOCALE, F_JSON,
+    FORMAT_TYPES, F_HTML, F_JSONFG, F_JSONLD,
     validate_bbox, validate_datetime
 )
 

--- a/pygeoapi/formatter/jsonfg.py
+++ b/pygeoapi/formatter/jsonfg.py
@@ -1,0 +1,128 @@
+# =================================================================
+#
+# Authors: Francesco Bartoli <xbartolone@gmail.com>
+#
+# Copyright (c) 2025 Francesco Bartoli
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+"""JSON-FG capabilities
+Returns content as JSON-FG representations
+"""
+
+import json
+import logging
+import uuid
+from typing import Union
+
+from osgeo import gdal
+
+from pygeoapi.formatter.base import BaseFormatter, FormatterSerializationError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class JSONFGFormatter(BaseFormatter):
+    """JSON-FG formatter"""
+
+    def __init__(self, formatter_def: dict):
+        """
+        Initialize object
+
+        :param formatter_def: formatter definition
+
+        :returns: `pygeoapi.formatter.jsonfg.JSONFGFormatter`
+        """
+
+        geom = False
+        if "geom" in formatter_def:
+            geom = formatter_def["geom"]
+
+        super().__init__({"name": "jsonfg", "geom": geom})
+        self.mimetype = "application/vnd.ogc.fg+json"
+
+    def write(self, data: dict, options: dict = {}) -> str:
+        """
+        Generate data in JSON-FG format
+
+        :param options: JSON-FG formatting options
+        :param data: dict of GeoJSON data
+
+        :returns: string representation of format
+        """
+
+        try:
+            fields = list(data["features"][0]["properties"].keys())
+        except IndexError:
+            LOGGER.error("no features")
+            return str()
+
+        LOGGER.debug(f"JSONFG fields: {fields}")
+
+        try:
+            output = geojson2jsonfg(data=data, dataset="items")
+            return output
+        except ValueError as err:
+            LOGGER.error(err)
+            raise FormatterSerializationError("Error writing JSONFG output")
+
+    def __repr__(self):
+        return f"<JSONFGFormatter> {self.name}"
+
+
+def geojson2jsonfg(
+    data: dict,
+    dataset: str,
+    identifier: Union[str, None] = None,
+    id_field: str = "id",
+) -> str:
+    """
+    Return JSON-FG from a GeoJSON content.
+
+    :param cls: API object
+    :param data: dict of data:
+
+    :returns: string of rendered JSON (JSON-FG)
+    """
+    gdal.UseExceptions()
+    LOGGER.debug("Dump GeoJSON content into a data source")
+    # breakpoint()
+    try:
+        with gdal.OpenEx(json.dumps(data)) as srcDS:
+            tmpfile = f"/vsimem/{uuid.uuid1()}.json"
+            LOGGER.debug("Translate GeoJSON into a JSONFG memory file")
+            gdal.VectorTranslate(tmpfile, srcDS, format="JSONFG")
+            LOGGER.debug("Read JSONFG content from a memory file")
+            data = gdal.VSIFOpenL(tmpfile, "rb")
+            if not data:
+                raise ValueError("Failed to read JSONFG content")
+            gdal.VSIFSeekL(data, 0, 2)
+            length = gdal.VSIFTellL(data)
+            gdal.VSIFSeekL(data, 0, 0)
+            jsonfg = json.loads(gdal.VSIFReadL(1, length, data).decode())
+            return jsonfg
+    except Exception as e:
+        LOGGER.error(f"Failed to convert GeoJSON to JSON-FG: {e}")
+        raise
+    finally:
+        gdal.VSIFCloseL(data)

--- a/pygeoapi/formatter/jsonfg.py
+++ b/pygeoapi/formatter/jsonfg.py
@@ -72,7 +72,10 @@ class JSONFGFormatter(BaseFormatter):
         """
 
         try:
-            fields = list(data["features"][0]["properties"].keys())
+            if data.get("features"):
+                fields = list(data["features"][0]["properties"].keys())
+            else:
+                fields = data["properties"].keys()
         except IndexError:
             LOGGER.error("no features")
             return str()

--- a/pygeoapi/formatter/jsonfg.py
+++ b/pygeoapi/formatter/jsonfg.py
@@ -63,8 +63,7 @@ class JSONFGFormatter(BaseFormatter):
         self.mimetype = "application/geo+json"
 
     def write(
-        self, api: APIRequest, data: dict,
-        dataset: str, id_field: str, options: dict = {}
+        self, data: dict, dataset: str, id_field: str, options: dict = {}
     ) -> dict:
         """
         Generate data in JSON-FG format
@@ -108,8 +107,10 @@ def geojson2jsonfg(
     """
     Return JSON-FG from a GeoJSON content.
 
-    :param cls: API object
-    :param data: dict of data:
+    :param data: dict of data
+    :param dataset: dataset name
+    :param identifier: identifier field name
+    :param id_field: id field name
 
     :returns: dict of converted GeoJSON (JSON-FG)
     """

--- a/pygeoapi/formatter/jsonfg.py
+++ b/pygeoapi/formatter/jsonfg.py
@@ -38,7 +38,7 @@ from typing import Union
 from osgeo import gdal
 
 from pygeoapi.formatter.base import BaseFormatter, FormatterSerializationError
-from pygeoapi.api import APIRequest
+
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/formatter/jsonfg.py
+++ b/pygeoapi/formatter/jsonfg.py
@@ -59,7 +59,7 @@ class JSONFGFormatter(BaseFormatter):
             geom = formatter_def["geom"]
 
         super().__init__({"name": "jsonfg", "geom": geom})
-        self.mimetype = "application/vnd.ogc.fg+json"
+        self.mimetype = "application/geo+json"
 
     def write(self, data: dict, options: dict = {}) -> str:
         """

--- a/pygeoapi/plugin.py
+++ b/pygeoapi/plugin.py
@@ -73,7 +73,8 @@ PLUGINS = {
         'xarray-edr': 'pygeoapi.provider.xarray_edr.XarrayEDRProvider'
     },
     'formatter': {
-        'CSV': 'pygeoapi.formatter.csv_.CSVFormatter'
+        'CSV': 'pygeoapi.formatter.csv_.CSVFormatter',
+        'jsonfg': 'pygeoapi.formatter.jsonfg.JSONFGFormatter',
     },
     'process': {
         'HelloWorld': 'pygeoapi.process.hello_world.HelloWorldProcessor',

--- a/requirements-provider.txt
+++ b/requirements-provider.txt
@@ -4,7 +4,6 @@ cftime
 elasticsearch
 elasticsearch-dsl
 fiona
-GDAL<=3.11.3
 geoalchemy2
 geopandas
 netCDF4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Babel
 click
 filelock
 Flask
-GDAL<=3.11.3
+GDAL<4
 jinja2
 jsonschema
 pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Babel
 click
 filelock
 Flask
-GDAL<4
+GDAL>=3.12.0,<4.0.0
 jinja2
 jsonschema
 pydantic

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Babel
 click
 filelock
 Flask
+GDAL<=3.11.3
 jinja2
 jsonschema
 pydantic

--- a/tests/formatter/test_jsonfg__formatter.py
+++ b/tests/formatter/test_jsonfg__formatter.py
@@ -30,3 +30,52 @@
 import pytest
 
 from pygeoapi.formatter.jsonfg import JSONFGFormatter
+
+
+@pytest.fixture()
+def fixture():
+    data = {
+        'type': 'FeatureCollection',
+        'features': [{
+            'type': 'Feature',
+            'id': '123-456',
+            'geometry': {
+                'type': 'Point',
+                'coordinates': [125.6, 10.1]},
+            'properties': {
+                'name': 'Dinagat Islands',
+                'foo': 'bar'
+            }}
+        ],
+        'links': [{
+            'rel': 'self',
+            'type': 'application/geo+json',
+            'title': 'GeoJSON',
+            'href': 'http://example.com'
+        }]
+    }
+
+    return data
+
+
+def test_jsonfg__formatter(fixture):
+    f = JSONFGFormatter({'geom': True})
+    f_jsonfg = f.write(data=fixture, dataset='test', id_field='id', options={})
+
+    assert f.mimetype == "application/geo+json"
+
+    assert f_jsonfg['type'] == 'FeatureCollection'
+    assert f_jsonfg['features'][0]['type'] == 'Feature'
+    assert f_jsonfg['features'][0]['geometry']['type'] == 'Point'
+    assert f_jsonfg['features'][0]['geometry']['coordinates'] == [125.6, 10.1]
+    assert f_jsonfg['features'][0]['properties']['id'] == '123-456'
+    assert f_jsonfg['features'][0]['properties']['name'] == 'Dinagat Islands'
+    assert f_jsonfg['features'][0]['properties']['foo'] == 'bar'
+
+    assert f_jsonfg['featureType'] == 'OGRGeoJSON'
+    assert f_jsonfg['conformsTo']
+    assert f_jsonfg['coordRefSys'] == '[EPSG:4326]'
+    assert f_jsonfg['features'][0]['place'] is None
+    assert f_jsonfg['features'][0]['time'] is None
+
+    assert len(f_jsonfg['links']) == 1

--- a/tests/formatter/test_jsonfg__formatter.py
+++ b/tests/formatter/test_jsonfg__formatter.py
@@ -1,0 +1,32 @@
+# =================================================================
+#
+# Authors: Francesco Bartoli <xbartolone@gmail.com>
+#
+# Copyright (c) 2025 Francesco Bartoli
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+import pytest
+
+from pygeoapi.formatter.jsonfg import JSONFGFormatter


### PR DESCRIPTION
# Overview

This PR adds support to the most recent JSON-FG [specification](https://portal.ogc.org/files/107269#_patterns) `0.3`. It returns JSON-FG formatted payload with the following conformance classes:

- `http://www.opengis.net/spec/json-fg-1/0.3/conf/core`
- `http://www.opengis.net/spec/json-fg-1/0.3/conf/types-schemas`

A new formatter has been added to the core for that scope and must rely on `GDAL>=3.12` which supports `0.3` (not yet released as of today). As a consequence, this is a breaking change for our dependencies chain and cannot be merged until `rasterio` will support that version as well.
This potentially might be relaxed after the merge of this branch https://github.com/geopython/pygeoapi/tree/formatters to have the formatter configurable at resource level and so the GDAL requirement needed only if it is configured.

# Related Issue / discussion

- [Configurable formatter](https://github.com/geopython/pygeoapi/tree/formatters)

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
- [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
