### PR TITLE
OpenAPI: avoid double slashes for local schema setup

### DIFF
--- a/pygeoapi/openapi.py
+++ b/pygeoapi/openapi.py
@@ -81,7 +81,7 @@ def get_ogc_schemas_location(server_config: dict) -> str:
         if osl.startswith('http'):
             value = osl
         elif osl.startswith('/'):
-            base_url = get_base_url({'server': server_config})
+            base_url = get_base_url({'server': server_config}).rstrip('/')
             value = f'{base_url}/schemas'
 
     return value


### PR DESCRIPTION
# Overview
This PR ensures that OpenAPI generation does not emit double slashes for local OGC API schema configurations.
# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
