### PR TITLE
Fix config validation for OGC Processes connection field

### DIFF
--- a/pygeoapi/resources/schemas/config/pygeoapi-config-0.x.yml
+++ b/pygeoapi/resources/schemas/config/pygeoapi-config-0.x.yml
@@ -132,9 +132,9 @@ properties:
                         type: string
                         description: plugin name (see `pygeoapi.plugin` for supported process_managers)
                     connection:
-                        oneOf:
-                            - type: string
-                            - type: object
+                        type: 
+                            - string
+                            - object
                         description: connection info to store jobs (e.g. filepath)
                     output_dir:
                         type: string

--- a/tests/other/test_config.py
+++ b/tests/other/test_config.py
@@ -110,7 +110,7 @@ def test_validate_config_process_manager(config):
     cfg_copy['server']['manager'] = {
         'name': 'TinyDB',
         'connection': '/tmp/pygeoapi_test.db',
-        'output_dir': '/tmp/',
+        'output_dir': '/tmp/'
     }
     assert validate_config(cfg_copy)
 
@@ -119,7 +119,7 @@ def test_validate_config_process_manager(config):
         cfg_copy['server']['manager'] = {
             'name': 'TinyDB',
             'connection': 12345,
-            'output_dir': '/tmp/',
+            'output_dir': '/tmp/'
         }
         validate_config(cfg_copy)
 
@@ -130,8 +130,8 @@ def test_validate_config_process_manager(config):
             'port': 5432,
             'database': 'pygeoapi',
             'user': 'pygeoapi',
-            'password': 'pygeoapi',
+            'password': 'pygeoapi'
         },
-        'output_dir': '/tmp/',
+        'output_dir': '/tmp/'
     }
     assert validate_config(cfg_copy)


### PR DESCRIPTION
# Overview

- Fix the pygeoapi schema validation to allow for either a string or an object in the connection 
- Fix the `$id` reference to point to a schema link that isn't 404'd

# Related Issue / discussion

Closes https://github.com/geopython/pygeoapi/issues/2157

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
