### PR TITLE
Replaced broken redoc link by working link

### DIFF
--- a/pygeoapi/templates/openapi/redoc.html
+++ b/pygeoapi/templates/openapi/redoc.html
@@ -14,6 +14,6 @@
   </head>
   <body>
     <redoc spec-url='{{ data['openapi-document-path'] }}?f=json'></redoc>
-    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"> </script>
   </body>
 </html>


### PR DESCRIPTION
# Overview

The redoc CDN on the templates uses a broken link. 

https://demo.pygeoapi.io/master/openapi?f=html&ui=redoc

```
curl -I https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js
HTTP/2 404
date: Thu, 20 Nov 2025 17:04:40 GMT

```
This PR replaces it by a working link (Thanks @webb-ben !)

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
