### PR TITLE
Filtering Geospatial Data

### DIFF
--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -108,6 +108,8 @@ class XarrayProvider(BaseProvider):
         if not self._fields:
             for key, value in self._data.variables.items():
                 if key not in self._data.coords:
+                    if not {self.time_field, self.x_field, self.y_field}.issubset(value.dims):
+                        continue
                     LOGGER.debug('Adding variable')
                     dtype = value.dtype
                     if dtype.name.startswith('float'):


### PR DESCRIPTION
# Overview

This PR filters out **non-spatiotemporal parameters** (e.g., `crs`, `lat_bounds`, other auxiliary variables) from collections so they are not treated as queryable parameters during position queries or displayed in the collection's Parameters table.  

This resolves the issue where pygeoapi attempts to collect timeseries data for fields like `crs`, causing:

- The **position query UI popup** to render blank.
- **Invalid parameters** (with `"None"` values) to appear in the collection's Parameters table.

After filtering these fields, position queries behave correctly, and the Parameter table only lists actual geospatial/temporal variables. 

---

# Related Issue / discussion

- **Primary Issue:** [geopython/pygeoapi#(insert number when created)](https://github.com/geopython/pygeoapi/issues/2164)
- **USGS original issue:** https://code.usgs.gov/wma/nhgf/pygeoapi/-/issues/65  
- **LimnoTech related issue + fix:** https://github.com/LimnoTech/pygeoapi/pull/11

---

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
