### PR TITLE
Fix datetime method deprecation

### DIFF
--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -37,7 +37,7 @@
 
 from collections import ChainMap
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, UTC
 from http import HTTPStatus
 import logging
 from typing import Any, Tuple, Union
@@ -625,7 +625,7 @@ def get_collection_items(
             'href': '/'.join(uri.split('/')[:-1])
         })
 
-    content['timeStamp'] = datetime.utcnow().strftime(
+    content['timeStamp'] = datetime.now(UTC).strftime(
         '%Y-%m-%dT%H:%M:%S.%fZ')
 
     # Set response language to requested provider locale

--- a/tests/load_tinydb_records.py
+++ b/tests/load_tinydb_records.py
@@ -1,8 +1,10 @@
 # =================================================================
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Francesco Bartoli <xbartolone@gmail.com>
 #
 # Copyright (c) 2025 Tom Kralidis
+# Copyright (c) 2025 Francesco Bartoli
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -27,7 +29,7 @@
 #
 # =================================================================
 
-from datetime import datetime
+from datetime import datetime, UTC
 from pathlib import Path
 import sys
 from typing import Union
@@ -226,7 +228,7 @@ for xml_file in xml_dir.glob('*.xml'):
         'geometry': geometry,
         'properties': {
             'created': issued,
-            'updated': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+            'updated': datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%SZ'),
             'type': type_,
             'title': title,
             'description': description,


### PR DESCRIPTION
# Overview

Fix deprecated method from datetime

# Related Issue / discussion

NA

# Additional information

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
