### PR TITLE
Fix image builds for tags

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -10,6 +10,9 @@ on:
     workflows: ["Build"]
     types: [completed]
     branches: [master]
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
     
 env:
   DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY || 'geopython/pygeoapi' }}
@@ -19,7 +22,7 @@ jobs:
   on-success:
     name: Build, Test and Push Docker Image to DockerHub
     runs-on: ubuntu-24.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
# Overview

Currently, multi-platform (ARM64/AMD64) Docker images are only built for latest because the container workflow doesn't trigger on tag pushes. This PR adds a tag trigger so that release versions (e.g., 0.23.0) also receive multi-platform manifests. Without tagged ARM64 images, developers on Apple Silicon Macs cannot use specific versions and must either build locally or rely on latest, causing friction in development workflows.

# Related Issue / discussion

Could not find a PR relevant for this feature.

# Additional information

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute feature/bugfix to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution

I agree to the pygeoapi Contributions and Licensing Guidelines.

- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
