### PR TITLE
Fix urllib3 vulnerabilities CVE-2025-66418 CVE-2025-66471

### DIFF
--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -8,3 +8,4 @@ s3fs<=2023.6.0
 Flask>=2.2.0
 Flask-Cors
 urllib3>2
+botocore>1.42


### PR DESCRIPTION
# Overview

Fix urllib3 vulnerabilities CVE-2025-66418 CVE-2025-66471

# Related Issue / discussion

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
- [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
