### PR TITLE
ES: fix property evaluation (#2189)

### DIFF
--- a/pygeoapi/provider/elasticsearch_.py
+++ b/pygeoapi/provider/elasticsearch_.py
@@ -302,8 +302,8 @@ class ElasticsearchProvider(BaseProvider):
                 }
                 query['query']['bool']['filter'].append(pf)
 
-            if '|' not in prop[1]:
-                pf['match'][prop_name]['minimum_should_match'] = '100%'
+                if '|' not in prop[1]:
+                    pf['match'][prop_name]['minimum_should_match'] = '100%'
 
         if sortby:
             LOGGER.debug('processing sortby')


### PR DESCRIPTION
# Overview
This PR fixes an indentation bug when the ES provider evaluates query terms with pipes (`|`).
# Related Issue / discussion
Fixes #2189
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
