### PR TITLE
set f= in next/prev links (#2175)

### DIFF
--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -616,19 +616,26 @@ def get_collection_items(
         if offset > 0:
             prev_link = True
 
+    print(request.format)
     if prev_link:
         prev = max(0, offset - limit)
+        url = f'{uri}?offset={prev}{serialized_query_params}'
+        if request.format is not None:
+            url = f'{uri}?f={request.format}&offset={prev}{serialized_query_params}'  # noqa
+
         content['links'].append(
             {
                 'type': 'application/geo+json',
                 'rel': 'prev',
                 'title': l10n.translate('Items (prev)', request.locale),
-                'href': f'{uri}?offset={prev}{serialized_query_params}'
+                'href': url
             })
 
     if next_link:
         next_ = offset + limit
         next_href = f'{uri}?offset={next_}{serialized_query_params}'
+        if request.format is not None:
+            next_href = f'{uri}?f={request.format}&offset={next_}{serialized_query_params}'  # noqa
         content['links'].append(
             {
                 'type': 'application/geo+json',

--- a/tests/api/test_itemtypes.py
+++ b/tests/api/test_itemtypes.py
@@ -285,8 +285,7 @@ def test_get_collection_items(config, api_):
     assert '/collections/obs/items?f=csv&limit=1&bbox=-180,-90,180,90' \
         in links[3]['href']
     assert links[3]['rel'] == 'alternate'
-    assert '/collections/obs/items?offset=0&limit=1&bbox=-180,-90,180,90' \
-        in links[4]['href']
+    assert '/collections/obs/items?offset=0&limit=1&bbox=-180,-90,180,90' in links[4]['href']  # noqa
     assert links[4]['rel'] == 'prev'
     assert '/collections/obs' in links[5]['href']
     assert links[4]['rel'] == 'prev'


### PR DESCRIPTION
# Overview
This PR fixes `.../items` `next` and `prev` links to keep/preserve `f=json`.

# Related Issue / discussion
#2175

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
