### PR TITLE
OpenSearch: fix property evaluation (#2189)

### DIFF
--- a/pygeoapi/provider/opensearch_.py
+++ b/pygeoapi/provider/opensearch_.py
@@ -373,7 +373,7 @@ class OpenSearchProvider(BaseProvider):
 
             LOGGER.debug(f'Query: {query}')
             try:
-                result = self.os_search(index=self.index_name, **query)
+                result = self.os_.search(index=self.index_name, body=query)
                 if len(result['hits']['hits']) == 0:
                     LOGGER.error(err)
                     raise ProviderItemNotFoundError(err)
@@ -425,7 +425,8 @@ class OpenSearchProvider(BaseProvider):
         identifier, json_data = self._load_and_prepare_item(
             item, identifier, raise_if_exists=False)
 
-        _ = self.os_index(index=self.index_name, id=identifier, body=json_data)
+        _ = self.os_.index(index=self.index_name, id=identifier,
+                           body=json_data)
 
         return True
 
@@ -439,7 +440,7 @@ class OpenSearchProvider(BaseProvider):
         """
 
         LOGGER.debug(f'Deleting item {identifier}')
-        _ = self.os_delete(index=self.index_name, id=identifier)
+        _ = self.os_.delete(index=self.index_name, id=identifier)
 
         return True
 


### PR DESCRIPTION
# Overview
This PR fixes an indentation bug when the OpenSearch provider evaluates query terms with pipes (|).

# Related Issue / discussion
Fixes #2189
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
Follow on of #2200 
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
