### PR TITLE
Implement optional count in Feature Providers

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -273,6 +273,7 @@ default.
                 include_extra_query_parameters: false  # include extra query parameters that are not part of the collection properties (default: false)
                 # editable transactions: DO NOT ACTIVATE unless you have setup access control beyond pygeoapi
                 editable: true  # optional: if backend is writable, default is false
+                count: true  # optional: perform a count query for collection queries, default is true
                 # coordinate reference systems (CRS) section is optional
                 # default CRSs are http://www.opengis.net/def/crs/OGC/1.3/CRS84 (coordinates without height)
                 # and http://www.opengis.net/def/crs/OGC/1.3/CRS84h (coordinates with ellipsoidal height)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -273,7 +273,9 @@ default.
                 include_extra_query_parameters: false  # include extra query parameters that are not part of the collection properties (default: false)
                 # editable transactions: DO NOT ACTIVATE unless you have setup access control beyond pygeoapi
                 editable: true  # optional: if backend is writable, default is false
-                count: true  # optional: perform a count query for collection queries, default is true
+                # count: include `numberMatched` in collection results responses, for providers
+                # that require an additional query to calculate this value (e.g. a SQL COUNT query).
+                count: true  # optional: perform additional count on queries, default is true
                 # coordinate reference systems (CRS) section is optional
                 # default CRSs are http://www.opengis.net/def/crs/OGC/1.3/CRS84 (coordinates without height)
                 # and http://www.opengis.net/def/crs/OGC/1.3/CRS84h (coordinates with ellipsoidal height)

--- a/docs/source/publishing/ogcapi-features.rst
+++ b/docs/source/publishing/ogcapi-features.rst
@@ -16,29 +16,35 @@ parameters.
 
 
 .. csv-table::
-   :header: Provider, property filters/display, resulttype, bbox, datetime, sortby, skipGeometry, domains, CQL, transactions, crs
+   :header: Provider, property filters/display, resulttype hits/count, bbox, datetime, sortby, skipGeometry, domains, CQL, transactions, crs
    :align: left
 
-   `CSV`_,✅/✅,results/hits,✅,❌,❌,✅,❌,❌,❌,✅
-   `Elasticsearch`_,✅/✅,results/hits,✅,✅,✅,✅,✅,✅,✅,✅
-   `ERDDAP Tabledap Service`_,❌/❌,results/hits,✅,✅,❌,❌,❌,❌,❌,✅
-   `ESRI Feature Service`_,✅/✅,results/hits,✅,✅,✅,✅,❌,❌,❌,✅
-   `GeoJSON`_,✅/✅,results/hits,✅,❌,❌,✅,❌,❌,❌,✅
-   `MongoDB`_,✅/❌,results,✅,✅,✅,✅,❌,❌,❌,✅
-   `MySQL`_,✅/✅,results/hits,✅,✅,✅,✅,❌,✅,✅,✅
-   `OGR`_,✅/❌,results/hits,✅,❌,❌,✅,❌,❌,❌,✅
-   `OpenSearch`_,✅/✅,results/hits,✅,✅,✅,✅,❌,✅,✅,✅
-   `Oracle`_,✅/✅,results/hits,✅,❌,✅,✅,❌,❌,❌,✅
-   `Parquet`_,✅/✅,results/hits,✅,✅,❌,✅,❌,❌,❌,✅
-   `PostgreSQL`_,✅/✅,results/hits,✅,✅,✅,✅,❌,✅,✅,✅
-   `SQLiteGPKG`_,✅/❌,results/hits,✅,❌,❌,✅,❌,❌,❌,✅
-   `SensorThings API`_,✅/✅,results/hits,✅,✅,✅,✅,❌,❌,✅,✅
-   `Socrata`_,✅/✅,results/hits,✅,✅,✅,✅,❌,❌,❌,✅
-   `TinyDB`_,✅/✅,results/hits,✅,✅,✅,✅,✅,❌,✅,✅
+   `CSV`_,✅/✅,✅/✅,✅,❌,❌,✅,❌,❌,❌,✅
+   `Elasticsearch`_,✅/✅,✅/❌,✅,✅,✅,✅,✅,✅,✅,✅
+   `ERDDAP Tabledap Service`_,❌/❌,❌/❌,✅,✅,❌,❌,❌,❌,❌,✅
+   `ESRI Feature Service`_,✅/✅,✅/✅,✅,✅,✅,✅,❌,❌,❌,✅
+   `GeoJSON`_,✅/✅,✅/✅,✅,❌,❌,✅,❌,❌,❌,✅
+   `MongoDB`_,✅/❌,✅/✅,✅,✅,✅,✅,❌,❌,❌,✅
+   `MySQL`_,✅/✅,✅/✅,✅,✅,✅,✅,❌,✅,✅,✅
+   `OGR`_,✅/❌,✅/❌,✅,❌,❌,✅,❌,❌,❌,✅
+   `OpenSearch`_,✅/✅,✅/❌,✅,✅,✅,✅,❌,✅,✅,✅
+   `Oracle`_,✅/✅,✅/✅,✅,❌,✅,✅,❌,❌,❌,✅
+   `Parquet`_,✅/✅,✅/❌,✅,✅,❌,✅,❌,❌,❌,✅
+   `PostgreSQL`_,✅/✅,✅/✅,✅,✅,✅,✅,❌,✅,✅,✅
+   `SQLiteGPKG`_,✅/❌,✅/✅,✅,❌,❌,✅,❌,❌,❌,✅
+   `SensorThings API`_,✅/✅,✅/❌,✅,✅,✅,✅,❌,❌,✅,✅
+   `Socrata`_,✅/✅,✅/✅,✅,✅,✅,✅,❌,❌,❌,✅
+   `TinyDB`_,✅/✅,✅/✅,✅,✅,✅,✅,✅,❌,✅,✅
 
 .. note::
    For more information on CRS transformations, see :ref:`crs`.
 
+
+.. note::
+   Providers that support the query parameter ``resulttype=hits`` will also
+   include ``numberMatched`` in the default ``resulttype=results`` response.
+   Providers that support the configuration option ``count: false`` will 
+   not include the ``numberMatched`` property in the ``results`` response.
 
 Connection examples
 -------------------

--- a/pygeoapi/provider/csv_.py
+++ b/pygeoapi/provider/csv_.py
@@ -194,8 +194,9 @@ class CSVProvider(BaseProvider):
 
                 feature_collection['features'].append(feature)
 
-                feature_collection['numberMatched'] = \
-                    len(feature_collection['features'])
+                if self.count:
+                    feature_collection['numberMatched'] = \
+                        len(feature_collection['features'])
 
         if identifier is not None and not found:
             return None

--- a/pygeoapi/provider/esri.py
+++ b/pygeoapi/provider/esri.py
@@ -156,8 +156,12 @@ class ESRIServiceProvider(BaseProvider):
         fc = {
             'type': 'FeatureCollection',
             'features': [],
-            'numberMatched': self._get_count(params)
         }
+
+        if self.count or resulttype == 'hits':
+            matched = self._get_count(params)
+            LOGGER.debug(f'Found {matched} result(s)')
+            fc['numberMatched'] = matched
 
         if resulttype == 'hits':
             return fc
@@ -168,7 +172,7 @@ class ESRIServiceProvider(BaseProvider):
         params['resultOffset'] = offset
         params['resultRecordCount'] = limit
 
-        hits_ = min(limit, fc['numberMatched'])
+        hits_ = min(limit, matched) if self.count else limit
         fc['features'] = self._get_all(params, hits_)
 
         fc['numberReturned'] = len(fc['features'])

--- a/pygeoapi/provider/geojson.py
+++ b/pygeoapi/provider/geojson.py
@@ -188,7 +188,8 @@ class GeoJSONProvider(BaseProvider):
                           properties=properties,
                           select_properties=select_properties)
 
-        data['numberMatched'] = len(data['features'])
+        if self.count or resulttype == 'hits':
+            data['numberMatched'] = len(data['features'])
 
         if resulttype == 'hits':
             data['features'] = []

--- a/pygeoapi/provider/socrata.py
+++ b/pygeoapi/provider/socrata.py
@@ -123,9 +123,13 @@ class SODAServiceProvider(BaseProvider):
 
         fc = {
             'type': 'FeatureCollection',
-            'features': [],
-            'numberMatched': self._get_count(params)
+            'features': []
         }
+
+        if self.count or resulttype == 'hits':
+            matched = self._get_count(params)
+            LOGGER.debug(f'Found {matched} result(s)')
+            fc['numberMatched'] = matched
 
         if resulttype == 'hits':
             # Return hits

--- a/pygeoapi/provider/sql.py
+++ b/pygeoapi/provider/sql.py
@@ -220,6 +220,7 @@ class GenericSQLProvider(BaseProvider):
 
             crs_transform_out = get_transform_from_spec(crs_transform_spec)
 
+            response['numberReturned'] = 0
             for item in (
                 results.order_by(*order_by_clauses).offset(offset).limit(limit)
             ):

--- a/pygeoapi/provider/sqlite.py
+++ b/pygeoapi/provider/sqlite.py
@@ -169,18 +169,6 @@ class SQLiteGPKGProvider(BaseProvider):
         else:
             return None
 
-    def __response_feature_hits(self, hits):
-        """Assembles GeoJSON/Feature number
-
-        :returns: GeoJSON FeaturesCollection
-        """
-
-        feature_collection = {"features": [],
-                              "type": "FeatureCollection"}
-        feature_collection['numberMatched'] = hits
-
-        return feature_collection
-
     def __load(self):
         """
         Private method for loading spatiallite,
@@ -305,14 +293,25 @@ class SQLiteGPKGProvider(BaseProvider):
         where_clause, where_values = self.__get_where_clauses(
             properties=properties, bbox=bbox)
 
-        if resulttype == 'hits':
+        feature_collection = {
+            'type': 'FeatureCollection',
+            'features': []
+        }
 
-            sql_query = f"SELECT COUNT(*) as hits FROM {self.table} {where_clause} "  # noqa
+        if self.count or resulttype == 'hits':
+
+            sql_query = (
+                'SELECT COUNT(*) as hits '
+                f'FROM {self.table} {where_clause}'
+            )
 
             res = self.cursor.execute(sql_query, where_values)
 
-            hits = res.fetchone()["hits"]
-            return self.__response_feature_hits(hits)
+            hits = res.fetchone()['hits']
+            feature_collection['numberMatched'] = hits
+
+        if resulttype == 'hits':
+            return feature_collection
 
         sql_query = f"SELECT DISTINCT {self.columns} from \
             {self.table} {where_clause} limit ? offset ?"
@@ -326,14 +325,12 @@ class SQLiteGPKGProvider(BaseProvider):
         row_data = self.cursor.execute(
             sql_query, where_values + (limit, offset))
 
-        feature_collection = {
-            'type': 'FeatureCollection',
-            'features': []
-        }
-
+        feature_collection['numberReturned'] = 0
         for rd in row_data:
             feature_collection['features'].append(
-                self.__response_feature(rd, skip_geometry=skip_geometry))
+                self.__response_feature(rd, skip_geometry=skip_geometry)
+            )
+            feature_collection['numberReturned'] += 1
 
         return feature_collection
 

--- a/pygeoapi/provider/tinydb_.py
+++ b/pygeoapi/provider/tinydb_.py
@@ -229,7 +229,10 @@ class TinyDBProvider(BaseProvider):
             LOGGER.error(f'{msg}: {err}')
             raise ProviderInvalidQueryError(msg)
 
-        feature_collection['numberMatched'] = len(results)
+        if self.count or resulttype == 'hits':
+            matched = len(results)
+            LOGGER.debug(f'Found {matched} result(s)')
+            feature_collection['numberMatched'] = matched
 
         if resulttype == 'hits':
             return feature_collection

--- a/pygeoapi/resources/schemas/config/pygeoapi-config-0.x.yml
+++ b/pygeoapi/resources/schemas/config/pygeoapi-config-0.x.yml
@@ -546,6 +546,10 @@ properties:
                                           type: boolean
                                           description: whether the resource is editable
                                           default: false
+                                      count:
+                                          type: boolean
+                                          description: whether to perform a count query for collection queries
+                                          default: true
                                       table:
                                           type: string
                                           description: table name for RDBMS-based providers

--- a/tests/provider/test_csv__provider.py
+++ b/tests/provider/test_csv__provider.py
@@ -144,6 +144,19 @@ def test_query(config):
     assert len(results['features'][0]['properties']) == 2
 
 
+def test_no_count(config):
+    p = CSVProvider(config)
+    results = p.query()
+    assert results['numberMatched'] == 5
+    assert results['numberReturned'] == 5
+
+    config['count'] = False
+    p = CSVProvider(config)
+    results = p.query()
+    assert 'numberMatched' not in results
+    assert results['numberReturned'] == 5
+
+
 def test_get_invalid_property(config):
     """Testing query for an invalid property name"""
     p = CSVProvider(config)

--- a/tests/provider/test_esri_provider.py
+++ b/tests/provider/test_esri_provider.py
@@ -85,6 +85,19 @@ def test_query(config):
     assert results['numberMatched'] == 406
 
 
+def test_no_count(config):
+    p = ESRIServiceProvider(config)
+    results = p.query()
+    assert results['numberMatched'] == 406
+    assert results['numberReturned'] == 10
+
+    config['count'] = False
+    p = ESRIServiceProvider(config)
+    results = p.query()
+    assert 'numberMatched' not in results
+    assert results['numberReturned'] == 10
+
+
 def test_geometry(config):
     p = ESRIServiceProvider(config)
 

--- a/tests/provider/test_geojson_provider.py
+++ b/tests/provider/test_geojson_provider.py
@@ -117,6 +117,20 @@ def test_get(fixture, config):
     assert 'Dinagat' in results['properties']['name']
 
 
+def test_no_count(fixture, config):
+    p = GeoJSONProvider(config)
+
+    results = p.query()
+    assert results['numberMatched'] == 1
+    assert results['numberReturned'] == 1
+
+    config['count'] = False
+    p = GeoJSONProvider(config)
+    results = p.query()
+    assert 'numberMatched' not in results
+    assert results['numberReturned'] == 1
+
+
 def test_get_not_existing_item_raise_exception(
     fixture, config
 ):

--- a/tests/provider/test_mongo_provider.py
+++ b/tests/provider/test_mongo_provider.py
@@ -111,6 +111,20 @@ def test_get(config):
     assert 'Reykjavik' in result['properties']['ls_name']
 
 
+def test_no_count(config):
+    p = MongoProvider(config)
+
+    results = p.query()
+    assert results['numberMatched'] == 243
+    assert results['numberReturned'] == 10
+
+    config['count'] = False
+    p = MongoProvider(config)
+    results = p.query()
+    assert 'numberMatched' not in results
+    assert results['numberReturned'] == 10
+
+
 def test_get_not_existing_item_raise_exception(config):
     """Testing query for a not existing object"""
     p = MongoProvider(config)

--- a/tests/provider/test_mysql_provider.py
+++ b/tests/provider/test_mysql_provider.py
@@ -134,6 +134,20 @@ def test_query_with_paging(config):
     assert feature_collection['numberReturned'] == ALL_ITEMS_IN_DB - 3
 
 
+def test_no_count(config):
+    """Test query with no count"""
+    p = MySQLProvider(config)
+    feature_collection = p.query()
+    assert feature_collection['numberMatched'] == 5
+    assert feature_collection['numberReturned'] == 5
+
+    config['count'] = False
+    p = MySQLProvider(config)
+    feature_collection = p.query()
+    assert 'numberMatched' not in feature_collection
+    assert feature_collection['numberReturned'] == 5
+
+
 def test_query_bbox(config):
     """Test query with a specified bounding box"""
     p = MySQLProvider(config)

--- a/tests/provider/test_postgresql_provider.py
+++ b/tests/provider/test_postgresql_provider.py
@@ -246,6 +246,20 @@ def test_query_with_property_filter(config):
     assert feature_collection['numberReturned'] == 50
 
 
+def test_no_count(config):
+    """Test query with count disabled"""
+    p = PostgreSQLProvider(config)
+    results = p.query()
+    assert results['numberMatched'] == 14776
+    assert results['numberReturned'] == 10
+
+    config['count'] = False
+    p = PostgreSQLProvider(config)
+    results = p.query()
+    assert 'numberMatched' not in results
+    assert results['numberReturned'] == 10
+
+
 def test_query_with_paging(config):
     """Test query valid features with paging"""
     p = PostgreSQLProvider(config)

--- a/tests/provider/test_socrata_provider.py
+++ b/tests/provider/test_socrata_provider.py
@@ -191,6 +191,20 @@ def test_query(config, mock_socrata):
     assert results['numberMatched'] == 1006
 
 
+def test_no_count(config, mock_socrata):
+    p = SODAServiceProvider(config)
+
+    results = p.query()
+    assert results['numberMatched'] == 1006
+    assert results['numberReturned'] == 10
+
+    config['count'] = False
+    p = SODAServiceProvider(config)
+    results = p.query()
+    assert 'numberMatched' not in results
+    assert results['numberReturned'] == 10
+
+
 def test_geometry(config, mock_socrata):
     p = SODAServiceProvider(config)
 

--- a/tests/provider/test_sqlite_geopackage_provider.py
+++ b/tests/provider/test_sqlite_geopackage_provider.py
@@ -164,6 +164,20 @@ def test_query_bbox_sqlite_geopackage(config_sqlite):
         boxed_feature_collection['features'][0]['properties']['name']
 
 
+def test_no_count(config_sqlite):
+    """Test query with count disabled"""
+    p = SQLiteGPKGProvider(config_sqlite)
+    results = p.query()
+    assert results['numberMatched'] == 177
+    assert results['numberReturned'] == 10
+
+    config_sqlite['count'] = False
+    p = SQLiteGPKGProvider(config_sqlite)
+    results = p.query()
+    assert 'numberMatched' not in results
+    assert results['numberReturned'] == 10
+
+
 def test_get_sqlite(config_sqlite):
     p = SQLiteGPKGProvider(config_sqlite)
     result = p.get(118)

--- a/tests/provider/test_tinydb_provider.py
+++ b/tests/provider/test_tinydb_provider.py
@@ -194,6 +194,20 @@ def test_get(config):
     assert result['properties']['FLOW'] == 2.059999942779541
 
 
+def test_no_count(config):
+    p = TinyDBProvider(config)
+
+    results = p.query()
+    assert results['numberMatched'] == 50
+    assert results['numberReturned'] == 10
+
+    config['count'] = False
+    p = TinyDBProvider(config)
+    results = p.query()
+    assert 'numberMatched' not in results
+    assert results['numberReturned'] == 10
+
+
 def test_get_not_existing_item_raise_exception(config):
     """Testing query for a not existing object"""
     p = TinyDBProvider(config)

--- a/tests/pygeoapi-test-config.yml
+++ b/tests/pygeoapi-test-config.yml
@@ -244,6 +244,7 @@ resources:
             - type: feature
               name: GeoJSON
               data: tests/data/ne_110m_lakes.geojson
+              count: false
               id_field: id
               crs:
                 - http://www.opengis.net/def/crs/OGC/1.3/CRS84

--- a/tests/pygeoapi-test-config.yml
+++ b/tests/pygeoapi-test-config.yml
@@ -244,7 +244,6 @@ resources:
             - type: feature
               name: GeoJSON
               data: tests/data/ne_110m_lakes.geojson
-              count: false
               id_field: id
               crs:
                 - http://www.opengis.net/def/crs/OGC/1.3/CRS84


### PR DESCRIPTION
# Overview
Implement `count` field in provider def allowing providers with expensive **count** actions to skip returning a `numberMatched` value in the normal feature collection response when count is false.

# Related Issue / discussion
Closes: https://github.com/geopython/pygeoapi/issues/1969
Pending: https://github.com/geopython/pygeoapi/pull/2174
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
- Providers that do not have this added either require a count or may return it without performing an expensive count query.
- https://github.com/cgs-earth/pygeoapi-plugins/blob/master/pygeoapi_plugins/provider/postgresql.py offers a Postgis provider with a psuedocount which is faster but less accurate than a full count.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
