### PR TITLE
Add static OpenAPI document in Dockerfile

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -80,12 +80,22 @@ cd ${PYGEOAPI_HOME}
 
 echo "Default config in ${PYGEOAPI_CONFIG}"
 
-echo "Trying to generate openapi.yml"
-/venv/bin/pygeoapi openapi generate ${PYGEOAPI_CONFIG} --output-file ${PYGEOAPI_OPENAPI} ${OPENAPI_GENERATE_FAIL_ON_INVALID_COLLECTION}
+ensure_openapi_exists() {
+    if [ ! -f ${PYGEOAPI_OPENAPI} ] ; then
+        echo "Trying to generate openapi.yml"
+        /venv/bin/pygeoapi openapi generate ${PYGEOAPI_CONFIG} \
+            --output-file ${PYGEOAPI_OPENAPI} ${OPENAPI_GENERATE_FAIL_ON_INVALID_COLLECTION}
 
-[[ $? -ne 0 ]] && error "openapi.yml could not be generated ERROR"
+        [[ $? -ne 0 ]] && error "openapi.yml could not be generated ERROR"
 
-echo "openapi.yml generated continue to pygeoapi"
+        echo "openapi.yml generated continue to pygeoapi"
+    else
+        echo "openapi.yml found, skipping generation"
+    fi
+}
+
+
+
 
 start_gunicorn() {
     # SCRIPT_NAME should not have value '/'


### PR DESCRIPTION
# Overview
Implementation of the OpenAPI document support noted in https://github.com/geopython/pygeoapi/issues/1849 and https://github.com/geopython/pygeoapi/issues/2188, generating the full OpenAPI document can be troublesome or take an extended period to generate (some pygeoapi instances we have take >50 seconds) which makes horizontal scaling pygeoapi containers slow. The entrypoint should only generate the OpenAPI document if it does not already exist and respect an existing OpenAPI document. This allows for https://github.com/geopython/pygeoapi/issues/2188 to also be resolved with a static OpenAPI document that stays in lock step with a configuration document. 


# Related Issue / discussion
This is a reimplementation of https://github.com/geopython/pygeoapi/pull/1850. The goal of the entrypoint script is to handle entry commands, so while I appreciate that @yharby found a workaround, I think it makes sense to use the entrypoint where possible instead of requiring a user to overwrite the behavior of both the entrypoint and command.

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
