### PR TITLE
Update ESRI Provider to respect id_field

### DIFF
--- a/tests/provider/test_esri_provider.py
+++ b/tests/provider/test_esri_provider.py
@@ -35,17 +35,31 @@ from pygeoapi.util import DATETIME_FORMAT
 
 TIME_FIELD = 'Date_Time'
 
+BASE_URL = 'https://sampleserver6.arcgisonline.com/arcgis/rest/services'
+
 
 @pytest.fixture()
 def config():
-    #  National Hurricane Center ()
+    # National Hurricane Center
     # source: ESRI, NOAA/National Weather Service
     return {
         'name': 'ESRI',
         'type': 'feature',
-        'data': 'https://sampleserver6.arcgisonline.com/arcgis/rest/services/Hurricanes/MapServer/0', # noqa
+        'data': f'{BASE_URL}/Hurricanes/MapServer/0',
         'id_field': 'OBJECTID',
         'time_field': TIME_FIELD
+    }
+
+
+@pytest.fixture()
+def config_alt_id():
+    # Emergency Facilities
+    # source: ESRI
+    return {
+        'name': 'ESRI',
+        'type': 'feature',
+        'data': f'{BASE_URL}/EmergencyFacilities/FeatureServer/0',
+        'id_field': 'facilityid'
     }
 
 
@@ -179,3 +193,11 @@ def test_get(config):
     result = p.get(6)
     assert result['id'] == 6
     assert result['properties']['EVENTID'] == 'Alberto'
+
+
+def test_alternative_id_field(config_alt_id):
+    p = ESRIServiceProvider(config_alt_id)
+
+    result = p.get('F0234')
+    assert result['id'] == 'F0234'
+    assert result['properties']['facname'] == 'Redlands Community Hospital'


### PR DESCRIPTION
# Overview
- Allow for alternate id_field
- Do native CRS conversion
- Safe handle empty responses on get_fields

# Related Issue / discussion
https://github.com/geopython/pygeoapi/issues/2103 (ESRI provider previously ignored the `id_field`)
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
