### PR TITLE
fix AsyncAPI handling on Docker startup

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -93,8 +93,7 @@ echo "openapi.yml generated continue to pygeoapi"
 echo "Trying to generate asyncapi.yml"
 /venv/bin/pygeoapi asyncapi generate ${PYGEOAPI_CONFIG} --output-file ${PYGEOAPI_ASYNCAPI}
 
-[[ $? -ne 0 ]] && error "asyncapi.yml could not be generated ERROR"
-echo "asyncapi.yml generated continue to pygeoapi"
+[[ $? -ne 0 ]] && echo "asyncapi.yml could not be generated; skipping"
 
 start_gunicorn() {
     # SCRIPT_NAME should not have value '/'

--- a/pygeoapi/asyncapi.py
+++ b/pygeoapi/asyncapi.py
@@ -222,8 +222,8 @@ def load_asyncapi_document() -> dict:
     if not os.path.exists(pygeoapi_asyncapi):
         msg = (f'AsyncAPI document {pygeoapi_asyncapi} does not exist.  '
                'Please generate before starting pygeoapi')
-        LOGGER.error(msg)
-        raise RuntimeError(msg)
+        LOGGER.warning(msg)
+        return {}
 
     with open(pygeoapi_asyncapi, encoding='utf8') as ff:
         if pygeoapi_asyncapi.endswith(('.yaml', '.yml')):


### PR DESCRIPTION
# Overview
Follow on PR of #2220 to ensure Docker builds run as expected (with AsyncAPI being an optional capability).
# Related Issue / discussion
#2146 #2220
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
Thanks to @justb4 and the [GeoQoS service](https://demo.geohealthcheck.org/resource/575) for catching!
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
