### PR TITLE
OAProc: do not pretty print JSON results when document=raw (#2212)

### DIFF
--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -519,8 +519,12 @@ def execute_process(api: API, request: APIRequest,
     else:
         http_status = HTTPStatus.OK
 
-    if mime_type == 'application/json' or requested_response == 'document':
-        response2 = to_json(response, api.pretty_print)
+    if mime_type == 'application/json':
+        if requested_response == 'document':
+            pretty_print_ = api.pretty_print
+        else:  # raw
+            pretty_print_ = False
+        response2 = to_json(response, pretty_print_)
     else:
         response2 = response
 

--- a/tests/api/test_processes.py
+++ b/tests/api/test_processes.py
@@ -204,6 +204,11 @@ def test_execute_process(config, api_):
         },
         'response': 'document'
     }
+    req_body_9 = {
+        'inputs': {
+            'name': 'Test document'
+        }
+    }
 
     cleanup_jobs = set()
 
@@ -363,6 +368,12 @@ def test_execute_process(config, api_):
     assert code == HTTPStatus.OK
     assert 'outputs' in response
     assert isinstance(response['outputs'], list)
+
+    req = mock_api_request(data=req_body_9)
+    rsp_headers, code, response = execute_process(api_, req, 'hello-world')
+
+    response2 = '{"id":"echo","value":"Hello Test document!"}'
+    assert response == response2
 
     # Cleanup
     time.sleep(2)  # Allow time for any outstanding async jobs


### PR DESCRIPTION
# Overview
This PR suppresses JSON pretty printing when `document=raw` (the default) in an execution request payload.
# Related Issue / discussion
#2212 
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc @francescoingv 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
