### PR TITLE
Implement OGC API - Processes, Requirement 25, for jobControlOptions async-execute only, and no user preference (Issue #2231)

### DIFF
--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -524,7 +524,7 @@ def execute_process(api: API, request: APIRequest,
     else:
         response2 = response
 
-    if (headers.get('Preference-Applied', '') == RequestedProcessExecutionMode.respond_async.value):
+    if (headers.get('Preference-Applied', '') == RequestedProcessExecutionMode.respond_async.value):  # noqa
         LOGGER.debug('Asynchronous mode detected, returning statusInfo')
         response2 = {
             'jobID': job_id,

--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -433,7 +433,7 @@ class BaseManager:
                 LOGGER.debug('Synchronous execution')
                 handler = self._execute_handler_sync
                 if execution_mode == RequestedProcessExecutionMode.wait:
-	            response_headers = None
+                    response_headers = None
                 else:
                     response_headers = {
                         'Preference-Applied': (


### PR DESCRIPTION
# Overview
Added logic to treat process where jobControlOption allow async-execute only.

# Related Issue / discussion
Issue #2231

# Dependency policy (RFC2)
- [ X ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo
- [ X ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ X ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ X ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ X ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
