### PR TITLE
Update base64 encoding to return UTF-8 string

### DIFF
--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -378,7 +378,7 @@ def json_serial(obj: Any) -> str:
             return obj.decode('utf-8')
         except UnicodeDecodeError:
             LOGGER.debug('Returning as base64 encoded JSON object')
-            return base64.b64encode(obj)
+            return base64.b64encode(obj).decode('utf-8')
     elif isinstance(obj, Decimal):
         return float(obj)
     elif type(obj).__name__ in ['int32', 'int64']:


### PR DESCRIPTION
# Overview
Fixed a simple error in json_serial() not returning a string: Decode base64 encoded JSON object to UTF-8 string.

# Related Issue / discussion
No previous issue: just a code fix.
Difficult to provide a test.

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
