### PR TITLE
Update Docker API in main GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,6 @@ jobs:
         docker pull elasticsearch:8.17.0 &
         docker pull opensearchproject/opensearch:2.18.0 &
         docker pull mongo:8.0.4 &
-        docker pull ghcr.io/cgs-earth/sensorthings-action:0.1.0 &
         docker pull postgis/postgis:14-3.2 &
     - name: Clear up GitHub runner diskspace
       run: |
@@ -96,8 +95,8 @@ jobs:
       uses: supercharge/mongodb-github-action@1.12.0
       with:
         mongodb-version: '8.0.4'
-#    - name: Install and run SensorThingsAPI
-#      uses: cgs-earth/sensorthings-action@v0.1.0
+    - name: Install and run SensorThingsAPI
+      uses: cgs-earth/sensorthings-action@v0.1.2
     - name: Install sqlite and gpkg dependencies
       uses: awalsh128/cache-apt-pkgs-action@v1.4.3
       with:


### PR DESCRIPTION
# Overview
This PR updates the Docker API to ensure the main GitHub Action/CI passes on 24.04.
# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines