### PR TITLE
add resolution/default to collection extents.temporal configuration (#2260)

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -243,6 +243,8 @@ default.
                   begin: 2000-10-30T18:24:39Z  # start datetime in RFC3339
                   end: 2007-10-30T08:57:29Z  # end datetime in RFC3339
                   trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian  # TRS
+                  resolution: P1D  # ISO 8601 duration
+                  default: 2000-10-30T18:24:39Z  # default time
               # additional extents can be added as desired (1..n)
               foo:
                   url: https://example.org/def  # required URL of the extent

--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1008,6 +1008,12 @@ def describe_collections(api: API, request: APIRequest,
             }
             if 'trs' in t_ext:
                 collection['extent']['temporal']['trs'] = t_ext['trs']
+            if 'resolution' in t_ext:
+                collection['extent']['temporal']['grid'] = {
+                    'resolution': t_ext['resolution']
+                }
+            if 'default' in t_ext:
+                collection['extent']['temporal']['default'] = t_ext['default']
 
         _ = extents.pop('spatial', None)
         _ = extents.pop('temporal', None)

--- a/pygeoapi/resources/schemas/config/pygeoapi-config-0.x.yml
+++ b/pygeoapi/resources/schemas/config/pygeoapi-config-0.x.yml
@@ -477,6 +477,12 @@ properties:
                                               type: string
                                               description: temporal reference system of features
                                               default: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+                                          resolution:
+                                              type: string
+                                              description: temporal resolution
+                                          default:
+                                              type: string
+                                              description: default time value
                               patternProperties:
                                   "^(?!spatial$|temporal$).*":
                                       type: object

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -6,7 +6,7 @@
 #          Bernhard Mallinger <bernhard.mallinger@eox.at>
 #          Francesco Bartoli <xbartolone@gmail.com>
 #
-# Copyright (c) 2024 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 # Copyright (c) 2022 John A Stevenson and Colin Blackburn
 # Copyright (c) 2026 Francesco Bartoli
 #
@@ -635,7 +635,11 @@ def test_describe_collections(config, api_):
             'interval': [
                 ['2000-10-30T18:24:39+00:00', '2007-10-30T08:57:29+00:00']
             ],
-            'trs': 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+            'trs': 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+            'grid': {
+                'resolution': 'P1D'
+            },
+            'default': '2000-10-30T18:24:39+00:00'
         }
     }
 

--- a/tests/pygeoapi-test-config.yml
+++ b/tests/pygeoapi-test-config.yml
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2019 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -142,6 +142,8 @@ resources:
                 begin: 2000-10-30T18:24:39Z
                 end: 2007-10-30T08:57:29Z
                 trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+                resolution: P1D
+                default: 2000-10-30T18:24:39Z
         providers:
             - type: feature
               name: CSV


### PR DESCRIPTION
# Overview
This PR adds `resolution` and `default` to `extents.temporal` in collection configuration.
# Related Issue / discussion
#2260

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
