### PR TITLE
remove deprecated license, coverage testing and fix test cmdclass in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2025 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -84,26 +84,7 @@ class PyTest(Command):
 
     def run(self):
         import subprocess
-        errno = subprocess.call(['pytest', 'tests/test_api.py'])
-        raise SystemExit(errno)
-
-
-class PyCoverage(Command):
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        import subprocess
-
-        errno = subprocess.call(['coverage', 'run', '--source=pygeoapi',
-                                 '-m', 'unittest',
-                                 'pygeoapi.tests.run_tests'])
-        errno = subprocess.call(['coverage', 'report', '-m'])
+        errno = subprocess.call(['pytest', 'tests/api/test_api.py'])
         raise SystemExit(errno)
 
 
@@ -169,14 +150,12 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Scientific/Engineering :: GIS'
     ],
     cmdclass={
         'test': PyTest,
-        'coverage': PyCoverage,
         'cleanbuild': PyCleanBuild
     }
 )


### PR DESCRIPTION
# Overview
This PR fixes the test cmdclass (`tests/api/test_api.py`), as well as removes deprecated license classifiers as well as the unused coverage cmdclass.
# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
Thanks to @webb-ben for spotting/reporting.
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
