### PR TITLE
Fix `transform_bbox` CRS types

### DIFF
--- a/pygeoapi/crs.py
+++ b/pygeoapi/crs.py
@@ -278,7 +278,7 @@ def crs_transform_feature(feature: dict, transform_func: Callable):
         )
 
 
-def transform_bbox(bbox: list, from_crs: Union[str, pyproj.CRS], 
+def transform_bbox(bbox: list, from_crs: Union[str, pyproj.CRS],
                    to_crs: Union[str, pyproj.CRS]) -> list:
     """
     helper function to transform a bounding box (bbox) from


### PR DESCRIPTION
# Overview

The types for `transform_bbox` are currently too narrow and say that the CRS must be a `str`. However, this function can take in either a `str` or a `pyproj.CRS` object for the crs inputs since it calls `get_crs` which allows either type. As such, the type of the crs inputs to `transform_bbox` should be updated to reflect this.

_get_crs is correctly typed_
```py
get_crs(crs: Union[str, pyproj.CRS])
```

If a user is not using a type checker, it is relevant to have this information for documentation purposes. If they are using a type checker, this causes an error. Since it is a minor change that helps both use cases and affects no runtime behavior, it is relevant to fix. Union is already imported so there are no new imports.

# Related Issue / discussion

N/A

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
