### PR TITLE
enable skipping of errorneous collections in /collections

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -40,7 +40,7 @@ Root level code of pygeoapi, parsing content provided by web framework.
 Returns content from plugins and sets responses.
 """
 
-from collections import ChainMap, OrderedDict
+from collections import ChainMap
 from copy import deepcopy
 from datetime import datetime
 from functools import partial
@@ -56,21 +56,19 @@ from dateutil.parser import parse as dateparse
 import pytz
 
 from pygeoapi import __version__, l10n
-from pygeoapi.crs import DEFAULT_STORAGE_CRS, get_supported_crs_list
+from pygeoapi.api.collection import gen_collection, OGC_RELTYPES_BASE
+from pygeoapi.formats import FORMAT_TYPES, F_GZIP, F_HTML, F_JSON, F_JSONLD
 from pygeoapi.linked_data import jsonldify, jsonldify_collection
 from pygeoapi.log import setup_logger
 from pygeoapi.plugin import load_plugin
 from pygeoapi.process.manager.base import get_manager
-from pygeoapi.provider import (
-     filter_providers_by_type, get_provider_by_type, get_provider_default)
-from pygeoapi.provider.base import (
-    ProviderConnectionError, ProviderGenericError, ProviderTypeError)
+from pygeoapi.provider import filter_providers_by_type, get_provider_by_type
+from pygeoapi.provider.base import ProviderGenericError, ProviderTypeError
 
 from pygeoapi.util import (
-    TEMPLATESDIR, UrlPrefetcher, dategetter,
-    filter_dict_by_key_value, get_api_rules, get_base_url, get_typed_value,
-    render_j2_template, to_json, get_choice_from_headers, get_from_headers,
-    get_dataset_formatters
+    TEMPLATESDIR, UrlPrefetcher, filter_dict_by_key_value, get_api_rules,
+    get_base_url, get_typed_value, render_j2_template, to_json,
+    get_choice_from_headers, get_from_headers
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -82,26 +80,6 @@ HEADERS = {
 }
 
 CHARSET = ['utf-8']
-F_JSON = 'json'
-F_COVERAGEJSON = 'json'
-F_HTML = 'html'
-F_JSONLD = 'jsonld'
-F_GZIP = 'gzip'
-F_PNG = 'png'
-F_JPEG = 'jpeg'
-F_MVT = 'mvt'
-F_NETCDF = 'NetCDF'
-
-#: Formats allowed for ?f= requests (order matters for complex MIME types)
-FORMAT_TYPES = OrderedDict((
-    (F_HTML, 'text/html'),
-    (F_JSONLD, 'application/ld+json'),
-    (F_JSON, 'application/json'),
-    (F_PNG, 'image/png'),
-    (F_JPEG, 'image/jpeg'),
-    (F_MVT, 'application/vnd.mapbox-vector-tile'),
-    (F_NETCDF, 'application/x-netcdf'),
-))
 
 #: Locale used for system responses (e.g. exceptions)
 SYSTEM_LOCALE = l10n.Locale('en', 'US')
@@ -114,8 +92,6 @@ CONFORMANCE_CLASSES = [
     'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/html',
     'http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30'
 ]
-
-OGC_RELTYPES_BASE = 'http://www.opengis.net/def/rel/ogc/1.0'
 
 
 def all_apis() -> dict:
@@ -511,7 +487,7 @@ class APIRequest:
         if F_GZIP in FORMAT_TYPES:
             if force_encoding:
                 headers['Content-Encoding'] = force_encoding
-            elif F_GZIP in get_from_headers(self._headers, 'accept-encoding'):
+            elif F_GZIP in get_from_headers(self._headers, 'accept-encoding'):  # noqa
                 headers['Content-Encoding'] = F_GZIP
 
         return headers
@@ -950,9 +926,7 @@ def describe_collections(api: API, request: APIRequest,
             HTTPStatus.NOT_FOUND, headers, request.format, 'NotFound', msg)
 
     if dataset is not None:
-        collections_dict = {
-            k: v for k, v in collections.items() if k == dataset
-        }
+        collections_dict = {dataset: api.config['resources'][dataset]}
     else:
         collections_dict = collections
 
@@ -961,439 +935,21 @@ def describe_collections(api: API, request: APIRequest,
         if v.get('visibility', 'default') == 'hidden':
             LOGGER.debug(f'Skipping hidden layer: {k}')
             continue
-        collection_data = get_provider_default(v['providers'])
-        collection_data_type = collection_data['type']
-
-        collection_data_format = None
-
-        if 'format' in collection_data:
-            collection_data_format = collection_data['format']
-
-        is_vector_tile = (collection_data_type == 'tile' and
-                          collection_data_format['name'] not
-                          in [F_PNG, F_JPEG])
-
-        collection = {
-            'id': k,
-            'title': l10n.translate(v['title'], request.locale),
-            'description': l10n.translate(v['description'], request.locale),  # noqa
-            'keywords': l10n.translate(v['keywords'], request.locale),
-            'links': []
-        }
-
-        extents = deepcopy(v['extents'])
-
-        bbox = extents['spatial']['bbox']
-        LOGGER.debug('Setting spatial extents from configuration')
-        # The output should be an array of bbox, so if the user only
-        # provided a single bbox, wrap it in a array.
-        if not isinstance(bbox[0], list):
-            bbox = [bbox]
-        collection['extent'] = {
-            'spatial': {
-                'bbox': bbox
-            }
-        }
-        if 'crs' in extents['spatial']:
-            collection['extent']['spatial']['crs'] = \
-                extents['spatial']['crs']
-
-        t_ext = extents.get('temporal', {})
-        if t_ext:
-            LOGGER.debug('Setting temporal extents from configuration')
-            begins = dategetter('begin', t_ext)
-            ends = dategetter('end', t_ext)
-            collection['extent']['temporal'] = {
-                'interval': [[begins, ends]]
-            }
-            if 'trs' in t_ext:
-                collection['extent']['temporal']['trs'] = t_ext['trs']
-            if 'resolution' in t_ext:
-                collection['extent']['temporal']['grid'] = {
-                    'resolution': t_ext['resolution']
-                }
-            if 'default' in t_ext:
-                collection['extent']['temporal']['default'] = t_ext['default']
-
-        _ = extents.pop('spatial', None)
-        _ = extents.pop('temporal', None)
-
-        for ek, ev in extents.items():
-            LOGGER.debug(f'Adding extent {ek}')
-            collection['extent'][ek] = {
-                'definition': ev['url'],
-                'interval': [ev['range']]
-            }
-            if 'units' in ev:
-                collection['extent'][ek]['unit'] = ev['units']
-
-            if 'values' in ev:
-                collection['extent'][ek]['grid'] = {
-                    'cellsCount': len(ev['values']),
-                    'coordinates': ev['values']
-                }
-
-        LOGGER.debug('Processing configured collection links')
-        for link in l10n.translate(v.get('links', []), request.locale):
-            lnk = {
-                'type': link['type'],
-                'rel': link['rel'],
-                'title': l10n.translate(link['title'], request.locale),
-                'href': l10n.translate(link['href'], request.locale),
-            }
-            if 'hreflang' in link:
-                lnk['hreflang'] = l10n.translate(
-                    link['hreflang'], request.locale)
-            content_length = link.get('length', 0)
-
-            if lnk['rel'] == 'enclosure' and content_length == 0:
-                # Issue HEAD request for enclosure links without length
-                lnk_headers = api.prefetcher.get_headers(lnk['href'])
-                content_length = int(lnk_headers.get('content-length', 0))
-                content_type = lnk_headers.get('content-type', lnk['type'])
-                if content_length == 0:
-                    # Skip this (broken) link
-                    LOGGER.debug(f"Enclosure {lnk['href']} is invalid")
-                    continue
-                if content_type != lnk['type']:
-                    # Update content type if different from specified
-                    lnk['type'] = content_type
-                    LOGGER.debug(
-                        f"Fixed media type for enclosure {lnk['href']}")
-
-            if content_length > 0:
-                lnk['length'] = content_length
-
-            collection['links'].append(lnk)
-
-        # TODO: provide translations
-        LOGGER.debug('Adding JSON and HTML link relations')
-        collection['links'].append({
-            'type': FORMAT_TYPES[F_JSON],
-            'rel': 'root',
-            'title': l10n.translate('The landing page of this server as JSON', request.locale),  # noqa
-            'href': f"{api.base_url}?f={F_JSON}"
-        })
-        collection['links'].append({
-            'type': FORMAT_TYPES[F_HTML],
-            'rel': 'root',
-            'title': l10n.translate('The landing page of this server as HTML', request.locale),  # noqa
-            'href': f"{api.base_url}?f={F_HTML}"
-        })
-        collection['links'].append({
-            'type': FORMAT_TYPES[F_JSON],
-            'rel': request.get_linkrel(F_JSON),
-            'title': l10n.translate('This document as JSON', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}/{k}?f={F_JSON}'
-        })
-        collection['links'].append({
-            'type': FORMAT_TYPES[F_JSONLD],
-            'rel': request.get_linkrel(F_JSONLD),
-            'title': l10n.translate('This document as RDF (JSON-LD)', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}/{k}?f={F_JSONLD}'
-        })
-        collection['links'].append({
-            'type': FORMAT_TYPES[F_HTML],
-            'rel': request.get_linkrel(F_HTML),
-            'title': l10n.translate('This document as HTML', request.locale),  # noqa
-            'href': f'{api.get_collections_url()}/{k}?f={F_HTML}'
-        })
-
-        if collection_data_type == 'record':
-            collection['links'].append({
-                'type': FORMAT_TYPES[F_JSON],
-                'rel': f'{OGC_RELTYPES_BASE}/ogc-catalog',
-                'title': l10n.translate('Record catalogue as JSON', request.locale),  # noqa
-                'href': f'{api.get_collections_url()}/{k}?f={F_JSON}'
-            })
-            collection['links'].append({
-                'type': FORMAT_TYPES[F_HTML],
-                'rel': f'{OGC_RELTYPES_BASE}/ogc-catalog',
-                'title': l10n.translate('Record catalogue as HTML', request.locale),  # noqa
-                'href': f'{api.get_collections_url()}/{k}?f={F_HTML}'
-            })
-
-        if collection_data_type in ['feature', 'coverage', 'record']:
-            collection['links'].append({
-                'type': 'application/schema+json',
-                'rel': f'{OGC_RELTYPES_BASE}/schema',
-                'title': l10n.translate('Schema of collection in JSON', request.locale),  # noqa
-                'href': f'{api.get_collections_url()}/{k}/schema?f={F_JSON}'  # noqa
-            })
-            collection['links'].append({
-                'type': FORMAT_TYPES[F_HTML],
-                'rel': f'{OGC_RELTYPES_BASE}/schema',
-                'title': l10n.translate('Schema of collection in HTML', request.locale),  # noqa
-                'href': f'{api.get_collections_url()}/{k}/schema?f={F_HTML}'  # noqa
-            })
-
-        if is_vector_tile or collection_data_type in ['feature', 'record']:
-            # TODO: translate
-            collection['itemType'] = collection_data_type
-            LOGGER.debug('Adding feature/record based links')
-            collection['links'].append({
-                'type': 'application/schema+json',
-                'rel': f'{OGC_RELTYPES_BASE}/queryables',
-                'title': l10n.translate('Queryables for this collection as JSON', request.locale),  # noqa
-                'href': f'{api.get_collections_url()}/{k}/queryables?f={F_JSON}'  # noqa
-            })
-            collection['links'].append({
-                'type': FORMAT_TYPES[F_HTML],
-                'rel': f'{OGC_RELTYPES_BASE}/queryables',
-                'title': l10n.translate('Queryables for this collection as HTML', request.locale),  # noqa
-                'href': f'{api.get_collections_url()}/{k}/queryables?f={F_HTML}'  # noqa
-            })
-            collection['links'].append({
-                'type': 'application/geo+json',
-                'rel': 'items',
-                'title': l10n.translate('Items as GeoJSON', request.locale),  # noqa
-                'href': f'{api.get_collections_url()}/{k}/items?f={F_JSON}'  # noqa
-            })
-            collection['links'].append({
-                'type': FORMAT_TYPES[F_JSONLD],
-                'rel': 'items',
-                'title': l10n.translate('Items as RDF (GeoJSON-LD)', request.locale),  # noqa
-                'href': f'{api.get_collections_url()}/{k}/items?f={F_JSONLD}'  # noqa
-            })
-            collection['links'].append({
-                'type': FORMAT_TYPES[F_HTML],
-                'rel': 'items',
-                'title': l10n.translate('Items as HTML', request.locale),  # noqa
-                'href': f'{api.get_collections_url()}/{k}/items?f={F_HTML}'  # noqa
-            })
-
-            for key, value in get_dataset_formatters(v).items():
-                collection['links'].append({
-                    'type': value.mimetype,
-                    'rel': 'items',
-                    'title': l10n.translate(f'Items as {key}', request.locale),  # noqa
-                    'href': f'{api.get_collections_url()}/{k}/items?f={value.f}'  # noqa
-                })
-
-        # OAPIF Part 2 - list supported CRSs and StorageCRS
-        if collection_data_type in ['edr', 'feature']:
-            collection['crs'] = get_supported_crs_list(collection_data)
-            collection['storageCrs'] = collection_data.get('storage_crs', DEFAULT_STORAGE_CRS)  # noqa
-            if 'storage_crs_coordinate_epoch' in collection_data:
-                collection['storageCrsCoordinateEpoch'] = collection_data.get('storage_crs_coordinate_epoch')  # noqa
-
-        elif collection_data_type == 'coverage':
-            # TODO: translate
-            LOGGER.debug('Adding coverage based links')
-            collection['links'].append({
-                'type': 'application/prs.coverage+json',
-                'rel': f'{OGC_RELTYPES_BASE}/coverage',
-                'title': l10n.translate('Coverage data', request.locale),
-                'href': f'{api.get_collections_url()}/{k}/coverage?f={F_JSON}'  # noqa
-            })
-            if collection_data_format is not None:
-                title_ = l10n.translate('Coverage data as', request.locale)  # noqa
-                title_ = f"{title_} {collection_data_format['name']}"
-                collection['links'].append({
-                    'type': collection_data_format['mimetype'],
-                    'rel': f'{OGC_RELTYPES_BASE}/coverage',
-                    'title': title_,
-                    'href': f"{api.get_collections_url()}/{k}/coverage?f={collection_data_format['name']}"  # noqa
-                })
-            if dataset is not None:
-                LOGGER.debug('Creating extended coverage metadata')
-                try:
-                    provider_def = get_provider_by_type(
-                        api.config['resources'][k]['providers'],
-                        'coverage')
-                    p = load_plugin('provider', provider_def)
-                except ProviderConnectionError:
-                    msg = 'connection error (check logs)'
-                    return api.get_exception(
-                        HTTPStatus.INTERNAL_SERVER_ERROR,
-                        headers, request.format,
-                        'NoApplicableCode', msg)
-                except ProviderTypeError:
-                    pass
-                else:
-                    collection['extent']['spatial']['grid'] = [{
-                        'cellsCount': p._coverage_properties['width'],
-                        'resolution': p._coverage_properties['resx']
-                    }, {
-                        'cellsCount': p._coverage_properties['height'],
-                        'resolution': p._coverage_properties['resy']
-                    }]
-                    if 'time_range' in p._coverage_properties:
-                        collection['extent']['temporal'] = {
-                            'interval': [p._coverage_properties['time_range']]
-                        }
-                        if 'restime' in p._coverage_properties:
-                            collection['extent']['temporal']['grid'] = {
-                                'resolution': p._coverage_properties['restime']  # noqa
-                            }
-                    if 'uad' in p._coverage_properties:
-                        collection['extent'].update(p._coverage_properties['uad'])  # noqa
 
         try:
-            tile = get_provider_by_type(v['providers'], 'tile')
-            p = load_plugin('provider', tile)
-        except ProviderConnectionError:
-            msg = 'connection error (check logs)'
-            return api.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR,
-                headers, request.format,
-                'NoApplicableCode', msg)
-        except ProviderTypeError:
-            tile = None
+            fcm['collections'].append(
+                gen_collection(api, request, k, request.locale))
+        except Exception as err:
+            LOGGER.warning(f'Error generating collection {k}: {err}')
+            if dataset is None:
+                LOGGER.debug('Skipping failed dataset')
+            else:
+                return api.get_exception(
+                    HTTPStatus.INTERNAL_SERVER_ERROR, headers, request.format,
+                    'NoApplicableCode', 'Error generating collection')
 
-        if tile:
-            # TODO: translate
-
-            LOGGER.debug('Adding tile links')
-            collection['links'].append({
-                'type': FORMAT_TYPES[F_JSON],
-                'rel': f'{OGC_RELTYPES_BASE}/tilesets-{p.tile_type}',
-                'title': l10n.translate('Tiles as JSON', request.locale),
-                'href': f'{api.get_collections_url()}/{k}/tiles?f={F_JSON}'
-            })
-            collection['links'].append({
-                'type': FORMAT_TYPES[F_HTML],
-                'rel': f'{OGC_RELTYPES_BASE}/tilesets-{p.tile_type}',
-                'title': l10n.translate('Tiles as HTML', request.locale),
-                'href': f'{api.get_collections_url()}/{k}/tiles?f={F_HTML}'
-            })
-
-        try:
-            map_ = get_provider_by_type(v['providers'], 'map')
-            p = load_plugin('provider', map_)
-        except ProviderTypeError:
-            map_ = None
-
-        if map_:
-            LOGGER.debug('Adding map links')
-
-            map_mimetype = map_['format']['mimetype']
-            map_format = map_['format']['name']
-
-            title_ = l10n.translate('Map as', request.locale)
-            title_ = f'{title_} {map_format}'
-
-            collection['links'].append({
-                'type': map_mimetype,
-                'rel': f'{OGC_RELTYPES_BASE}/map',
-                'title': title_,
-                'href': f'{api.get_collections_url()}/{k}/map?f={map_format}'
-            })
-
-            if p._fields:
-                schema_reltype = f'{OGC_RELTYPES_BASE}/schema',
-                schema_links = [s for s in collection['links'] if
-                                schema_reltype in s]
-
-                if not schema_links:
-                    title_ = l10n.translate('Schema of collection in JSON', request.locale)  # noqa
-                    collection['links'].append({
-                        'type': 'application/schema+json',
-                        'rel': f'{OGC_RELTYPES_BASE}/schema',
-                        'title': title_,
-                        'href': f'{api.get_collections_url()}/{k}/schema?f=json'  # noqa
-                    })
-                    title_ = l10n.translate('Schema of collection in HTML', request.locale)  # noqa
-                    collection['links'].append({
-                        'type': 'text/html',
-                        'rel': f'{OGC_RELTYPES_BASE}/schema',
-                        'title': title_,
-                        'href': f'{api.get_collections_url()}/{k}/schema?f=html'  # noqa
-                    })
-
-        try:
-            edr = get_provider_by_type(v['providers'], 'edr')
-            p = load_plugin('provider', edr)
-        except ProviderConnectionError:
-            msg = 'connection error (check logs)'
-            return api.get_exception(
-                HTTPStatus.INTERNAL_SERVER_ERROR, headers,
-                request.format, 'NoApplicableCode', msg)
-        except ProviderTypeError:
-            edr = None
-
-        if edr:
-            # TODO: translate
-            LOGGER.debug('Adding EDR links')
-            collection['data_queries'] = {}
-            parameters = p.get_fields()
-            if parameters:
-                collection['parameter_names'] = {}
-                for key, value in parameters.items():
-                    collection['parameter_names'][key] = {
-                        'id': key,
-                        'type': 'Parameter',
-                        'name': value['title'],
-                        'observedProperty': {
-                            'label': {
-                                'id': key,
-                                'en': value['title']
-                            },
-                        },
-                        'unit': {
-                            'label': {
-                                'en': value['title']
-                            },
-                            'symbol': {
-                                'value': value['x-ogc-unit'],
-                                'type': 'http://www.opengis.net/def/uom/UCUM/'  # noqa
-                            }
-                        }
-                    }
-
-                    collection['parameter_names'][key].update({
-                        'description': value['description']}
-                            if 'description' in value else {}
-                    )
-
-            for qt in p.get_query_types():
-                data_query = {
-                    'link': {
-                        'href': f'{api.get_collections_url()}/{k}/{qt}',
-                        'rel': 'data',
-                        'variables': {
-                            'query_type': qt
-                        }
-                    }
-                }
-
-                if request.format is not None and request.format == 'json':
-                    data_query['link']['type'] = 'application/vnd.cov+json'
-
-                collection['data_queries'][qt] = data_query
-
-                title1 = l10n.translate('query for this collection as JSON', request.locale)  # noqa
-                title1 = f'{qt} {title1}'
-                title2 = l10n.translate('query for this collection as HTML', request.locale)  # noqa
-                title2 = f'{qt} {title2}'
-
-                collection['links'].append({
-                    'type': 'application/json',
-                    'rel': 'data',
-                    'title': title1,
-                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_JSON}'
-                })
-                collection['links'].append({
-                    'type': FORMAT_TYPES[F_HTML],
-                    'rel': 'data',
-                    'title': title2,
-                    'href': f'{api.get_collections_url()}/{k}/{qt}?f={F_HTML}'
-                })
-
-                for key, value in get_dataset_formatters(v).items():
-                    title3 = f'{qt} query for this collection as {key}'
-                    collection['links'].append({
-                        'type': value.mimetype,
-                        'rel': 'data',
-                        'title': title3,
-                        'href': f'{api.get_collections_url()}/{k}/{qt}?f={value.f}'  # noqa
-                    })
-
-        if dataset is not None and k == dataset:
-            fcm = collection
-            break
-
-        fcm['collections'].append(collection)
+    if dataset is not None:
+        fcm = fcm['collections'][0]
 
     if dataset is None:
         # TODO: translate

--- a/pygeoapi/api/admin.py
+++ b/pygeoapi/api/admin.py
@@ -3,7 +3,7 @@
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #          Benjamin Webb <benjamin.miller.webb@gmail.com>
 #
-# Copyright (c) 2024 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 # Copyright (c) 2023 Benjamin Webb
 #
 # Permission is hereby granted, free of charge, to any person
@@ -39,8 +39,9 @@ from dateutil.parser import parse as parse_date
 from jsonpatch import make_patch
 from jsonschema.exceptions import ValidationError
 
-from pygeoapi.api import API, APIRequest, F_HTML
+from pygeoapi.api import API, APIRequest
 from pygeoapi.config import get_config, validate_config
+from pygeoapi.formats import F_HTML
 from pygeoapi.openapi import get_oas
 from pygeoapi.util import to_json, render_j2_template, yaml_dump
 

--- a/pygeoapi/api/collection.py
+++ b/pygeoapi/api/collection.py
@@ -1,0 +1,475 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#          Francesco Bartoli <xbartolone@gmail.com>
+#          Sander Schaminee <sander.schaminee@geocat.net>
+#          John A Stevenson <jostev@bgs.ac.uk>
+#          Colin Blackburn <colb@bgs.ac.uk>
+#          Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
+#
+# Copyright (c) 2026 Tom Kralidis
+# Copyright (c) 2026 Francesco Bartoli
+# Copyright (c) 2022 John A Stevenson and Colin Blackburn
+# Copyright (c) 2023 Ricardo Garcia Silva
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from copy import deepcopy
+import logging
+
+from pygeoapi import l10n
+from pygeoapi.formats import (F_JSON, F_JSONLD, F_HTML, F_JPEG,
+                              F_PNG, FORMAT_TYPES)
+from pygeoapi.crs import DEFAULT_STORAGE_CRS, get_supported_crs_list
+from pygeoapi.plugin import load_plugin
+from pygeoapi.provider import get_provider_by_type, get_provider_default
+from pygeoapi.provider.base import ProviderConnectionError, ProviderTypeError
+from pygeoapi.util import dategetter, get_dataset_formatters
+
+LOGGER = logging.getLogger(__name__)
+
+OGC_RELTYPES_BASE = 'http://www.opengis.net/def/rel/ogc/1.0'
+
+
+def gen_collection(api, request, dataset: str,
+                   locale_: str) -> dict:
+    """
+    Generate OGC API Collection description
+
+    :param api: `APIRequest` object
+    :param dataset: `str` of dataset name
+    :param locale_: `str` of requested locale
+
+    :returns: `dict` of OGC API Collection description
+    """
+
+    config = api.config['resources'][dataset]
+
+    data = {
+        'id': dataset,
+        'links': []
+    }
+
+    collection_data = get_provider_default(config['providers'])
+    collection_data_type = collection_data['type']
+
+    collection_data_format = None
+
+    if 'format' in collection_data:
+        collection_data_format = collection_data['format']
+
+    is_vector_tile = (collection_data_type == 'tile' and
+                      collection_data_format['name'] not
+                      in [F_PNG, F_JPEG])
+
+    data.update({
+        'title': l10n.translate(config['title'], locale_),
+        'description': l10n.translate(config['description'], locale_),
+        'keywords': l10n.translate(config['keywords'], locale_),
+    })
+
+    extents = deepcopy(config['extents'])
+
+    bbox = extents['spatial']['bbox']
+    LOGGER.debug('Setting spatial extents from configuration')
+    # The output should be an array of bbox, so if the user only
+    # provided a single bbox, wrap it in a array.
+    if not isinstance(bbox[0], list):
+        bbox = [bbox]
+
+    data['extent'] = {
+        'spatial': {
+            'bbox': bbox
+        }
+    }
+
+    if 'crs' in extents['spatial']:
+        data['extent']['spatial']['crs'] = extents['spatial']['crs']
+
+    t_ext = extents.get('temporal', {})
+    if t_ext:
+        LOGGER.debug('Setting temporal extents from configuration')
+        begins = dategetter('begin', t_ext)
+        ends = dategetter('end', t_ext)
+        data['extent']['temporal'] = {
+            'interval': [[begins, ends]]
+        }
+        if 'trs' in t_ext:
+            data['extent']['temporal']['trs'] = t_ext['trs']
+        if 'resolution' in t_ext:
+            data['extent']['temporal']['grid'] = {
+                'resolution': t_ext['resolution']
+            }
+        if 'default' in t_ext:
+            data['extent']['temporal']['default'] = t_ext['default']
+
+    _ = extents.pop('spatial', None)
+    _ = extents.pop('temporal', None)
+
+    for ek, ev in extents.items():
+        LOGGER.debug(f'Adding extent {ek}')
+        data['extent'][ek] = {
+            'definition': ev['url'],
+            'interval': [ev['range']]
+        }
+        if 'units' in ev:
+            data['extent'][ek]['unit'] = ev['units']
+
+        if 'values' in ev:
+            data['extent'][ek]['grid'] = {
+                'cellsCount': len(ev['values']),
+                'coordinates': ev['values']
+            }
+
+    LOGGER.debug('Processing configured collection links')
+    for link in l10n.translate(config.get('links', []), locale_):
+        lnk = {
+            'type': link['type'],
+            'rel': link['rel'],
+            'title': l10n.translate(link['title'], locale_),
+            'href': l10n.translate(link['href'], locale_),
+        }
+        if 'hreflang' in link:
+            lnk['hreflang'] = l10n.translate(
+                link['hreflang'], locale_)
+        content_length = link.get('length', 0)
+
+        if lnk['rel'] == 'enclosure' and content_length == 0:
+            # Issue HEAD request for enclosure links without length
+            lnk_headers = api.prefetcher.get_headers(lnk['href'])
+            content_length = int(lnk_headers.get('content-length', 0))
+            content_type = lnk_headers.get('content-type', lnk['type'])
+            if content_length == 0:
+                # Skip this (broken) link
+                LOGGER.debug(f"Enclosure {lnk['href']} is invalid")
+                continue
+            if content_type != lnk['type']:
+                # Update content type if different from specified
+                lnk['type'] = content_type
+                LOGGER.debug(
+                    f"Fixed media type for enclosure {lnk['href']}")
+
+        if content_length > 0:
+            lnk['length'] = content_length
+
+        data['links'].append(lnk)
+
+    # TODO: provide translations
+    LOGGER.debug('Adding JSON and HTML link relations')
+    data['links'].extend([{
+        'type': FORMAT_TYPES[F_JSON],
+        'rel': 'root',
+        'title': l10n.translate('The landing page of this server as JSON', locale_),  # noqa
+        'href': f"{api.base_url}?f={F_JSON}"
+    }, {
+        'type': FORMAT_TYPES[F_HTML],
+        'rel': 'root',
+        'title': l10n.translate('The landing page of this server as HTML', locale_),  # noqa
+        'href': f"{api.base_url}?f={F_HTML}"
+    }, {
+        'type': FORMAT_TYPES[F_JSON],
+        'rel': request.get_linkrel(F_JSON),
+        'title': l10n.translate('This document as JSON', locale_),
+        'href': f'{api.get_collections_url()}/{dataset}?f={F_JSON}'
+    }, {
+        'type': FORMAT_TYPES[F_JSONLD],
+        'rel': request.get_linkrel(F_JSONLD),
+        'title': l10n.translate('This document as RDF (JSON-LD)', locale_),
+        'href': f'{api.get_collections_url()}/{dataset}?f={F_JSONLD}'
+    }, {
+        'type': FORMAT_TYPES[F_HTML],
+        'rel': request.get_linkrel(F_HTML),
+        'title': l10n.translate('This document as HTML', locale_),
+        'href': f'{api.get_collections_url()}/{dataset}?f={F_HTML}'
+    }])
+
+    if collection_data_type == 'record':
+        data['links'].extend([{
+            'type': FORMAT_TYPES[F_JSON],
+            'rel': f'{OGC_RELTYPES_BASE}/ogc-catalog',
+            'title': l10n.translate('Record catalogue as JSON', locale_),
+            'href': f'{api.get_collections_url()}/{dataset}?f={F_JSON}'
+        }, {
+            'type': FORMAT_TYPES[F_HTML],
+            'rel': f'{OGC_RELTYPES_BASE}/ogc-catalog',
+            'title': l10n.translate('Record catalogue as HTML', locale_),
+            'href': f'{api.get_collections_url()}/{dataset}?f={F_HTML}'
+        }])
+
+    if collection_data_type in ['feature', 'coverage', 'record']:
+        data['links'].extend([{
+            'type': 'application/schema+json',
+            'rel': f'{OGC_RELTYPES_BASE}/schema',
+            'title': l10n.translate('Schema of collection in JSON', locale_),
+            'href': f'{api.get_collections_url()}/{dataset}/schema?f={F_JSON}'
+        }, {
+            'type': FORMAT_TYPES[F_HTML],
+            'rel': f'{OGC_RELTYPES_BASE}/schema',
+            'title': l10n.translate('Schema of collection in HTML', locale_),
+            'href': f'{api.get_collections_url()}/{dataset}/schema?f={F_HTML}'
+        }])
+
+    if is_vector_tile or collection_data_type in ['feature', 'record']:
+        # TODO: translate
+        data['itemType'] = collection_data_type
+        LOGGER.debug('Adding feature/record based links')
+        data['links'].extend([{
+            'type': 'application/schema+json',
+            'rel': f'{OGC_RELTYPES_BASE}/queryables',
+            'title': l10n.translate('Queryables for this collection as JSON', locale_),  # noqa
+            'href': f'{api.get_collections_url()}/{dataset}/queryables?f={F_JSON}'  # noqa
+        }, {
+            'type': FORMAT_TYPES[F_HTML],
+            'rel': f'{OGC_RELTYPES_BASE}/queryables',
+            'title': l10n.translate('Queryables for this collection as HTML', locale_),  # noqa
+            'href': f'{api.get_collections_url()}/{dataset}/queryables?f={F_HTML}'  # noqa
+        }, {
+            'type': 'application/geo+json',
+            'rel': 'items',
+            'title': l10n.translate('Items as GeoJSON', locale_),
+            'href': f'{api.get_collections_url()}/{dataset}/items?f={F_JSON}'
+        }, {
+            'type': FORMAT_TYPES[F_JSONLD],
+            'rel': 'items',
+            'title': l10n.translate('Items as RDF (GeoJSON-LD)', locale_),
+            'href': f'{api.get_collections_url()}/{dataset}/items?f={F_JSONLD}'
+        }, {
+            'type': FORMAT_TYPES[F_HTML],
+            'rel': 'items',
+            'title': l10n.translate('Items as HTML', locale_),  # noqa
+            'href': f'{api.get_collections_url()}/{dataset}/items?f={F_HTML}'
+        }])
+
+        for key, value in get_dataset_formatters(config).items():
+            data['links'].append({
+                'type': value.mimetype,
+                'rel': 'items',
+                'title': l10n.translate(f'Items as {key}', locale_),  # noqa
+                'href': f'{api.get_collections_url()}/{dataset}/items?f={value.f}'  # noqa
+            })
+
+    # OAPIF Part 2 - list supported CRSs and StorageCRS
+    if collection_data_type in ['edr', 'feature']:
+        data['crs'] = get_supported_crs_list(collection_data)
+        data['storageCrs'] = collection_data.get('storage_crs', DEFAULT_STORAGE_CRS)  # noqa
+        if 'storage_crs_coordinate_epoch' in collection_data:
+            data['storageCrsCoordinateEpoch'] = collection_data.get('storage_crs_coordinate_epoch')  # noqa
+
+    elif collection_data_type == 'coverage':
+        LOGGER.debug('Adding coverage based links')
+        data['links'].append({
+            'type': 'application/prs.coverage+json',
+            'rel': f'{OGC_RELTYPES_BASE}/coverage',
+            'title': l10n.translate('Coverage data', locale_),
+            'href': f'{api.get_collections_url()}/{dataset}/coverage?f={F_JSON}'  # noqa
+        })
+        if collection_data_format is not None:
+            title_ = l10n.translate('Coverage data as', locale_)
+            title_ = f"{title_} {collection_data_format['name']}"
+            data['links'].append({
+                'type': collection_data_format['mimetype'],
+                'rel': f'{OGC_RELTYPES_BASE}/coverage',
+                'title': title_,
+                'href': f"{api.get_collections_url()}/{dataset}/coverage?f={collection_data_format['name']}"  # noqa
+            })
+        if dataset is not None:
+            LOGGER.debug('Creating extended coverage metadata')
+            try:
+                provider_def = get_provider_by_type(
+                    api.config['resources'][dataset]['providers'],
+                    'coverage')
+                p = load_plugin('provider', provider_def)
+            except ProviderConnectionError:
+                raise
+            except ProviderTypeError:
+                pass
+            else:
+                data['extent']['spatial']['grid'] = [{
+                    'cellsCount': p._coverage_properties['width'],
+                    'resolution': p._coverage_properties['resx']
+                }, {
+                    'cellsCount': p._coverage_properties['height'],
+                    'resolution': p._coverage_properties['resy']
+                }]
+                if 'time_range' in p._coverage_properties:
+                    data['extent']['temporal'] = {
+                        'interval': [p._coverage_properties['time_range']]
+                    }
+                    if 'restime' in p._coverage_properties:
+                        data['extent']['temporal']['grid'] = {
+                            'resolution': p._coverage_properties['restime']
+                        }
+                if 'uad' in p._coverage_properties:
+                    data['extent'].update(p._coverage_properties['uad'])
+
+    try:
+        tile = get_provider_by_type(config['providers'], 'tile')
+        p = load_plugin('provider', tile)
+    except ProviderConnectionError:
+        raise
+    except ProviderTypeError:
+        tile = None
+
+    if tile:
+        LOGGER.debug('Adding tile links')
+        data['links'].extend([{
+            'type': FORMAT_TYPES[F_JSON],
+            'rel': f'{OGC_RELTYPES_BASE}/tilesets-{p.tile_type}',
+            'title': l10n.translate('Tiles as JSON', locale_),
+            'href': f'{api.get_collections_url()}/{dataset}/tiles?f={F_JSON}'
+        }, {
+            'type': FORMAT_TYPES[F_HTML],
+            'rel': f'{OGC_RELTYPES_BASE}/tilesets-{p.tile_type}',
+            'title': l10n.translate('Tiles as HTML', locale_),
+            'href': f'{api.get_collections_url()}/{dataset}/tiles?f={F_HTML}'
+        }])
+
+    try:
+        map_ = get_provider_by_type(config['providers'], 'map')
+        p = load_plugin('provider', map_)
+    except ProviderTypeError:
+        map_ = None
+
+    if map_:
+        LOGGER.debug('Adding map links')
+
+        map_mimetype = map_['format']['mimetype']
+        map_format = map_['format']['name']
+
+        title_ = l10n.translate('Map as', locale_)
+        title_ = f'{title_} {map_format}'
+
+        data['links'].append({
+            'type': map_mimetype,
+            'rel': f'{OGC_RELTYPES_BASE}/map',
+            'title': title_,
+            'href': f'{api.get_collections_url()}/{dataset}/map?f={map_format}'
+        })
+
+        if p._fields:
+            schema_reltype = f'{OGC_RELTYPES_BASE}/schema',
+            schema_links = [s for s in data['links'] if
+                            schema_reltype in s]
+
+            if not schema_links:
+                title_ = l10n.translate('Schema of collection in JSON', locale_)  # noqa
+                data['links'].append({
+                    'type': 'application/schema+json',
+                    'rel': f'{OGC_RELTYPES_BASE}/schema',
+                    'title': title_,
+                    'href': f'{api.get_collections_url()}/{dataset}/schema?f=json'  # noqa
+                })
+                title_ = l10n.translate('Schema of collection in HTML', locale_)  # noqa
+                data['links'].append({
+                    'type': 'text/html',
+                    'rel': f'{OGC_RELTYPES_BASE}/schema',
+                    'title': title_,
+                    'href': f'{api.get_collections_url()}/{dataset}/schema?f=html'  # noqa
+                })
+
+    try:
+        edr = get_provider_by_type(config['providers'], 'edr')
+        p = load_plugin('provider', edr)
+    except ProviderConnectionError:
+        raise
+    except ProviderTypeError:
+        edr = None
+
+    if edr:
+        # TODO: translate
+        LOGGER.debug('Adding EDR links')
+        data['data_queries'] = {}
+        parameters = p.get_fields()
+        if parameters:
+            data['parameter_names'] = {}
+            for key, value in parameters.items():
+                data['parameter_names'][key] = {
+                    'id': key,
+                    'type': 'Parameter',
+                    'name': value['title'],
+                    'observedProperty': {
+                        'label': {
+                            'id': key,
+                            'en': value['title']
+                        },
+                    },
+                    'unit': {
+                        'label': {
+                            'en': value['title']
+                        },
+                        'symbol': {
+                            'value': value['x-ogc-unit'],
+                            'type': 'http://www.opengis.net/def/uom/UCUM/'
+                        }
+                    }
+                }
+
+                data['parameter_names'][key].update({
+                    'description': value['description']}
+                        if 'description' in value else {}
+                )
+
+        for qt in p.get_query_types():
+            data_query = {
+                'link': {
+                    'href': f'{api.get_collections_url()}/{dataset}/{qt}',
+                    'rel': 'data',
+                    'variables': {
+                        'query_type': qt
+                    }
+                }
+            }
+
+            if request.format is not None and request.format == 'json':
+                data_query['link']['type'] = 'application/vnd.cov+json'
+
+            data['data_queries'][qt] = data_query
+
+            title1 = l10n.translate('query for this collection as JSON', locale_)  # noqa
+            title1 = f'{qt} {title1}'
+            title2 = l10n.translate('query for this collection as HTML', locale_)  # noqa
+            title2 = f'{qt} {title2}'
+
+            data['links'].extend([{
+                'type': 'application/json',
+                'rel': 'data',
+                'title': title1,
+                'href': f'{api.get_collections_url()}/{dataset}/{qt}?f={F_JSON}'  # noqa
+            }, {
+                'type': FORMAT_TYPES[F_HTML],
+                'rel': 'data',
+                'title': title2,
+                'href': f'{api.get_collections_url()}/{dataset}/{qt}?f={F_HTML}'  # noqa 
+            }])
+
+            for key, value in get_dataset_formatters(config).items():
+                title3 = f'{qt} query for this collection as {key}'
+                data['links'].append({
+                    'type': value.mimetype,
+                    'rel': 'data',
+                    'title': title3,
+                    'href': f'{api.get_collections_url()}/{dataset}/{qt}?f={value.f}'  # noqa
+                })
+
+    return data

--- a/pygeoapi/api/coverages.py
+++ b/pygeoapi/api/coverages.py
@@ -43,6 +43,7 @@ from http import HTTPStatus
 from typing import Tuple
 
 from pygeoapi import l10n
+from pygeoapi.formats import F_JSON
 from pygeoapi.openapi import get_oas_30_parameters
 from pygeoapi.plugin import load_plugin
 from pygeoapi.provider.base import ProviderGenericError, ProviderTypeError
@@ -50,7 +51,7 @@ from pygeoapi.provider import get_provider_by_type
 from pygeoapi.util import filter_dict_by_key_value, to_json
 
 from . import (
-    APIRequest, API, F_JSON, SYSTEM_LOCALE, validate_bbox, validate_datetime,
+    APIRequest, API, SYSTEM_LOCALE, validate_bbox, validate_datetime,
     validate_subset
 )
 

--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -49,6 +49,7 @@ from shapely.wkt import loads as shapely_loads
 
 from pygeoapi import l10n
 from pygeoapi.api import evaluate_limit
+from pygeoapi.formats import F_COVERAGEJSON, F_HTML, F_JSON, F_JSONLD
 from pygeoapi.formatter.base import FormatterSerializationError
 from pygeoapi.crs import (create_crs_transform_spec, set_content_crs_header)
 from pygeoapi.openapi import get_oas_30_parameters
@@ -60,8 +61,7 @@ from pygeoapi.util import (get_dataset_formatters, get_typed_value,
                            render_j2_template, to_json,
                            filter_dict_by_key_value)
 
-from . import (APIRequest, API, F_COVERAGEJSON, F_HTML, F_JSON, F_JSONLD,
-               validate_datetime, validate_bbox)
+from . import APIRequest, API, validate_datetime, validate_bbox
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -54,6 +54,7 @@ from pygeoapi.crs import (DEFAULT_CRS, DEFAULT_STORAGE_CRS,
                           create_crs_transform_spec, get_supported_crs_list,
                           modify_pygeofilter, transform_bbox,
                           set_content_crs_header)
+from pygeoapi.formats import F_JSON, FORMAT_TYPES, F_HTML, F_JSONLD
 from pygeoapi.formatter.base import FormatterSerializationError
 from pygeoapi.linked_data import geojson2jsonld
 from pygeoapi.openapi import get_oas_30_parameters
@@ -66,10 +67,7 @@ from pygeoapi.provider.base import (
 from pygeoapi.util import (to_json, filter_dict_by_key_value, str2bool,
                            render_j2_template, get_dataset_formatters)
 
-from . import (
-    APIRequest, API, SYSTEM_LOCALE, F_JSON, FORMAT_TYPES, F_HTML, F_JSONLD,
-    validate_bbox, validate_datetime
-)
+from . import APIRequest, API, SYSTEM_LOCALE, validate_bbox, validate_datetime
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/api/maps.py
+++ b/pygeoapi/api/maps.py
@@ -44,6 +44,7 @@ import logging
 from typing import Tuple
 
 from pygeoapi.crs import transform_bbox
+from pygeoapi.formats import F_JSON, FORMAT_TYPES
 from pygeoapi.openapi import get_oas_30_parameters
 from pygeoapi.plugin import load_plugin
 from pygeoapi.provider import filter_providers_by_type, get_provider_by_type
@@ -52,9 +53,7 @@ from pygeoapi.provider.base import (
 )
 from pygeoapi.util import to_json, filter_dict_by_key_value
 
-from . import (
-    APIRequest, API, F_JSON, FORMAT_TYPES, validate_datetime, validate_subset
-)
+from . import APIRequest, API, validate_datetime, validate_subset
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -49,6 +49,7 @@ from http import HTTPStatus
 from typing import Tuple
 
 from pygeoapi import l10n
+from pygeoapi.formats import FORMAT_TYPES, F_HTML, F_JSON, F_JSONLD
 from pygeoapi.api import evaluate_limit
 from pygeoapi.api.pubsub import publish_message
 from pygeoapi.process.base import (
@@ -61,9 +62,7 @@ from pygeoapi.util import (
     json_serial, render_j2_template, JobStatus, RequestedProcessExecutionMode,
     to_json, DATETIME_FORMAT)
 
-from . import (
-    APIRequest, API, SYSTEM_LOCALE, F_JSON, FORMAT_TYPES, F_HTML, F_JSONLD,
-)
+from . import APIRequest, API, SYSTEM_LOCALE
 
 LOGGER = logging.getLogger(__name__)
 
@@ -136,6 +135,7 @@ def describe_processes(api: API, request: APIRequest,
                 p2['jobControlOptions'].append('async-execute')
 
             p2['outputTransmission'] = ['value']
+
             p2['links'] = p2.get('links', [])
 
             jobs_url = f"{api.base_url}/jobs"

--- a/pygeoapi/api/stac.py
+++ b/pygeoapi/api/stac.py
@@ -8,7 +8,7 @@
 #          Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
 #          Bernhard Mallinger <bernhard.mallinger@eox.at>
 #
-# Copyright (c) 2025 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 # Copyright (c) 2025 Francesco Bartoli
 # Copyright (c) 2022 John A Stevenson and Colin Blackburn
 # Copyright (c) 2023 Ricardo Garcia Silva
@@ -47,6 +47,7 @@ from urllib.parse import urlencode
 from shapely import from_geojson
 
 from pygeoapi import l10n
+from pygeoapi.formats import FORMAT_TYPES, F_JSON, F_HTML
 from pygeoapi import api as ogc_api
 from pygeoapi.api import itemtypes as itemtypes_api
 from pygeoapi.plugin import load_plugin
@@ -58,7 +59,7 @@ from pygeoapi.provider.base import (
 from pygeoapi.util import (filter_dict_by_key_value, get_current_datetime,
                            render_j2_template, to_json)
 
-from . import APIRequest, API, FORMAT_TYPES, F_JSON, F_HTML
+from . import APIRequest, API
 
 
 LOGGER = logging.getLogger(__name__)

--- a/pygeoapi/api/tiles.py
+++ b/pygeoapi/api/tiles.py
@@ -8,7 +8,7 @@
 #          Ricardo Garcia Silva <ricardo.garcia.silva@geobeyond.it>
 #          Bernhard Mallinger <bernhard.mallinger@eox.at>
 #
-# Copyright (c) 2024 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 # Copyright (c) 2025 Francesco Bartoli
 # Copyright (c) 2022 John A Stevenson and Colin Blackburn
 # Copyright (c) 2023 Ricardo Garcia Silva
@@ -43,6 +43,7 @@ from http import HTTPStatus
 from typing import Tuple
 
 from pygeoapi import l10n
+from pygeoapi.formats import FORMAT_TYPES, F_JSON, F_HTML, F_JSONLD
 from pygeoapi.plugin import load_plugin
 from pygeoapi.models.provider.base import (TilesMetadataFormat,
                                            TileMatrixSetEnum)
@@ -54,9 +55,7 @@ from pygeoapi.provider.tile import ProviderTileNotFoundError
 
 from pygeoapi.util import to_json, filter_dict_by_key_value, render_j2_template
 
-from . import (
-    APIRequest, API, FORMAT_TYPES, F_JSON, F_HTML, SYSTEM_LOCALE, F_JSONLD
-)
+from . import APIRequest, API, SYSTEM_LOCALE
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pygeoapi/formats.py
+++ b/pygeoapi/formats.py
@@ -1,0 +1,51 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2026 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+from collections import OrderedDict
+
+F_JSON = 'json'
+F_COVERAGEJSON = 'json'
+F_HTML = 'html'
+F_JSONLD = 'jsonld'
+F_GZIP = 'gzip'
+F_PNG = 'png'
+F_JPEG = 'jpeg'
+F_MVT = 'mvt'
+F_NETCDF = 'NetCDF'
+
+#: Formats allowed for ?f= requests (order matters for complex MIME types)
+FORMAT_TYPES = OrderedDict((
+    (F_HTML, 'text/html'),
+    (F_JSONLD, 'application/ld+json'),
+    (F_JSON, 'application/json'),
+    (F_PNG, 'image/png'),
+    (F_JPEG, 'image/jpeg'),
+    (F_MVT, 'application/vnd.mapbox-vector-tile'),
+    (F_NETCDF, 'application/x-netcdf'),
+))

--- a/pygeoapi/process/manager/mongodb_.py
+++ b/pygeoapi/process/manager/mongodb_.py
@@ -1,8 +1,10 @@
 # =================================================================
 #
 # Authors: Alexander Pilz <a.pilz@52north.org>
+#          Tom Kralidis <tomkralidis@gmail.com>
 #
 # Copyright (c) 2023 Alexander Pilz
+# Copyright (c) 2026 Alexander Pilz
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -32,11 +34,11 @@ import traceback
 
 from pymongo import MongoClient
 
-from pygeoapi.api import FORMAT_TYPES, F_JSON, F_JSONLD
 from pygeoapi.process.base import (
     JobNotFoundError,
     JobResultNotFoundError,
 )
+from pygeoapi.formats import FORMAT_TYPES, F_JSON, F_JSONLD
 from pygeoapi.process.manager.base import BaseManager
 
 LOGGER = logging.getLogger(__name__)

--- a/pygeoapi/process/manager/postgresql.py
+++ b/pygeoapi/process/manager/postgresql.py
@@ -1,8 +1,10 @@
 # =================================================================
 #
 # Authors: Francesco Martinelli <francesco.martinelli@ingv.it>
+#          Tom Kralidis <tomkralidis@gmail.com>
 #
 # Copyright (c) 2024 Francesco Martinelli
+# Copyright (c) 2026 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -48,12 +50,12 @@ from typing import Any, Tuple
 from sqlalchemy import insert, update, delete
 from sqlalchemy.orm import Session
 
-from pygeoapi.api import FORMAT_TYPES, F_JSON, F_JSONLD
 from pygeoapi.process.base import (
     JobNotFoundError,
     JobResultNotFoundError,
     ProcessorGenericError
 )
+from pygeoapi.formats import FORMAT_TYPES, F_JSON, F_JSONLD
 from pygeoapi.process.manager.base import BaseManager
 from pygeoapi.provider.sql import (
     get_engine, get_table_model, store_db_parameters

--- a/pygeoapi/process/manager/tinydb_.py
+++ b/pygeoapi/process/manager/tinydb_.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2022 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -37,7 +37,7 @@ from typing import Any, Tuple
 import tinydb
 from filelock import FileLock
 
-from pygeoapi.api import FORMAT_TYPES, F_JSON, F_JSONLD
+from pygeoapi.formats import FORMAT_TYPES, F_JSON, F_JSONLD
 from pygeoapi.process.base import (
     JobNotFoundError,
     JobResultNotFoundError,

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -41,11 +41,11 @@ from pyld import jsonld
 import pytest
 
 from pygeoapi.api import (
-    API, APIRequest, CONFORMANCE_CLASSES, FORMAT_TYPES, F_HTML, F_JSON,
-    F_JSONLD, F_GZIP, __version__, validate_bbox, validate_datetime,
-    evaluate_limit, validate_subset, landing_page, openapi_, conformance,
-    describe_collections, get_collection_schema,
-)
+    API, APIRequest, CONFORMANCE_CLASSES, __version__, validate_bbox,
+    validate_datetime, evaluate_limit, validate_subset, landing_page, openapi_,
+    conformance, describe_collections, get_collection_schema)
+
+from pygeoapi.formats import FORMAT_TYPES, F_GZIP, F_JSON, F_JSONLD, F_HTML
 from pygeoapi.util import yaml_load, get_api_rules, get_base_url
 
 from tests.util import (get_test_file_path, mock_api_request, mock_flask,
@@ -80,6 +80,13 @@ def config_hidden_resources():
 
 
 @pytest.fixture()
+def config_failing_collection():
+    filename = 'pygeoapi-test-config-failing-collection.yml'
+    with open(get_test_file_path(filename)) as fh:
+        return yaml_load(fh)
+
+
+@pytest.fixture()
 def enclosure_api(config_enclosure, openapi):
     """ Returns an API instance with a collection with enclosure links. """
     return API(config_enclosure, openapi)
@@ -96,6 +103,11 @@ def rules_api(config_with_rules, openapi):
 @pytest.fixture()
 def api_hidden_resources(config_hidden_resources, openapi):
     return API(config_hidden_resources, openapi)
+
+
+@pytest.fixture()
+def api_failing_collection(config_failing_collection, openapi):
+    return API(config_failing_collection, openapi)
 
 
 def test_apirequest(api_):
@@ -727,6 +739,22 @@ def test_describe_collections_hidden_resources(
 
     collections = json.loads(response)
     assert len(collections['collections']) == 1
+
+
+def test_describe_collections_failing_collection(
+        config_failing_collection, api_failing_collection):
+    req = mock_api_request({})
+    rsp_headers, code, response = describe_collections(api_failing_collection, req)  # noqa
+    assert code == HTTPStatus.OK
+
+    assert len(config_failing_collection['resources']) == 3
+
+    collections = json.loads(response)
+    assert len(collections['collections']) == 2
+
+    req = mock_api_request({})
+    rsp_headers, code, response = describe_collections(api_failing_collection, req, 'cmip5')  # noqa
+    assert code == HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 def test_describe_collections_json_ld(config, api_):

--- a/tests/api/test_itemtypes.py
+++ b/tests/api/test_itemtypes.py
@@ -5,7 +5,7 @@
 #          Colin Blackburn <colb@bgs.ac.uk>
 #          Francesco Bartoli <xbartolone@gmail.com>
 #
-# Copyright (c) 2025 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 # Copyright (c) 2022 John A Stevenson and Colin Blackburn
 # Copyright (c) 2025 Francesco Bartoli
 #
@@ -42,12 +42,12 @@ import pytest
 import pyproj
 from shapely.geometry import Point
 
-from pygeoapi.api import (API, FORMAT_TYPES, F_GZIP, F_HTML, F_JSONLD,
-                          apply_gzip)
+from pygeoapi.api import API, apply_gzip
 from pygeoapi.api.itemtypes import (
     get_collection_queryables, get_collection_item,
     get_collection_items, manage_collection_item)
 from pygeoapi.crs import get_crs
+from pygeoapi.formats import FORMAT_TYPES, F_GZIP, F_HTML, F_JSONLD
 from pygeoapi.util import yaml_load
 
 from tests.util import get_test_file_path, mock_api_request

--- a/tests/api/test_processes.py
+++ b/tests/api/test_processes.py
@@ -5,7 +5,7 @@
 #          Colin Blackburn <colb@bgs.ac.uk>
 #          Bernhard Mallinger <bernhard.mallinger@eox.at>
 #
-# Copyright (c) 2024 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 # Copyright (c) 2022 John A Stevenson and Colin Blackburn
 #
 # Permission is hereby granted, free of charge, to any person
@@ -37,10 +37,10 @@ from http import HTTPStatus
 import time
 from unittest import mock
 
-from pygeoapi.api import FORMAT_TYPES, F_HTML, F_JSON
 from pygeoapi.api.processes import (
     describe_processes, execute_process, delete_job, get_job_result, get_jobs
 )
+from pygeoapi.formats import FORMAT_TYPES, F_HTML, F_JSON
 
 from tests.util import mock_api_request
 

--- a/tests/api/test_stac.py
+++ b/tests/api/test_stac.py
@@ -2,7 +2,7 @@
 #
 # Authors: Tom Kralidis <tomkralidis@gmail.com>
 #
-# Copyright (c) 2025 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -31,8 +31,8 @@ import json
 
 import pytest
 
-from pygeoapi.api import FORMAT_TYPES, F_JSON
 from pygeoapi.api.stac import search, landing_page
+from pygeoapi.formats import FORMAT_TYPES, F_JSON
 from pygeoapi.util import yaml_load
 
 from tests.util import get_test_file_path, mock_api_request

--- a/tests/api/test_tiles.py
+++ b/tests/api/test_tiles.py
@@ -5,7 +5,7 @@
 #          Colin Blackburn <colb@bgs.ac.uk>
 #          Bernhard Mallinger <bernhard.mallinger@eox.at>
 #
-# Copyright (c) 2024 Tom Kralidis
+# Copyright (c) 2026 Tom Kralidis
 # Copyright (c) 2022 John A Stevenson and Colin Blackburn
 # Copyright (c) 2025 Joana Simoes
 #
@@ -37,12 +37,12 @@ import json
 from http import HTTPStatus
 import pytest
 
-from pygeoapi.api import FORMAT_TYPES, F_HTML
 from pygeoapi.api.tiles import (
     get_collection_tiles, tilematrixset,
     tilematrixsets, get_collection_tiles_metadata,
     get_collection_tiles_data
 )
+from pygeoapi.formats import FORMAT_TYPES, F_HTML
 from pygeoapi.models.provider.base import TileMatrixSetEnum
 
 from tests.util import mock_api_request

--- a/tests/pygeoapi-test-config-failing-collection.yml
+++ b/tests/pygeoapi-test-config-failing-collection.yml
@@ -1,0 +1,206 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2026 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+server:
+    bind:
+        host: 0.0.0.0
+        port: 5000
+    url: http://localhost:5000/
+    mimetype: application/json; charset=UTF-8
+    encoding: utf-8
+    gzip: false
+    languages:
+        # First language is the default language
+        - en-US
+        - fr-CA
+    cors: true
+    pretty_print: true
+    limits:
+        default_items: 10
+        max_items: 10
+    # templates: /path/to/templates
+    map:
+        url: https://tile.openstreetmap.org/{z}/{x}/{y}.png
+        attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+    manager:
+        name: TinyDB
+        connection: /tmp/pygeoapi-test-process-manager.db
+        output_dir: /tmp
+
+logging:
+    level: DEBUG
+    #logfile: /tmp/pygeoapi.log
+
+metadata:
+    identification:
+        title:
+            en: pygeoapi default instance
+            fr: instance par défaut de pygeoapi
+        description:
+            en: pygeoapi provides an API to geospatial data
+            fr: pygeoapi fournit une API aux données géospatiales
+        keywords:
+            en:
+                - geospatial
+                - data
+                - api
+            fr:
+                - géospatiale
+                - données
+                - api
+        keywords_type: theme
+        terms_of_service: https://creativecommons.org/licenses/by/4.0/
+        url: http://example.org
+    license:
+        name: CC-BY 4.0 license
+        url: https://creativecommons.org/licenses/by/4.0/
+    provider:
+        name: Organization Name
+        url: https://pygeoapi.io
+    contact:
+        name: Lastname, Firstname
+        position: Position Title
+        address: Mailing Address
+        city: City
+        stateorprovince: Administrative Area
+        postalcode: Zip or Postal Code
+        country: Country
+        phone: +xx-xxx-xxx-xxxx
+        fax: +xx-xxx-xxx-xxxx
+        email: you@example.org
+        url: Contact URL
+        hours: Hours of Service
+        instructions: During hours of service.  Off on weekends.
+        role: pointOfContact
+
+resources:
+    obs:
+        type: collection
+        title:
+            en: Observations
+            fr: Observations
+        description:
+            en: My cool observations
+            fr: Mes belles observations
+        keywords:
+            - observations
+            - monitoring
+        links:
+            - type: text/csv
+              rel: canonical
+              title: data
+              href: https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv
+              hreflang: en-US
+            - type: text/csv
+              rel: alternate
+              title: data
+              href: https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv
+              hreflang: en-US
+        linked-data:
+            context:
+                - schema: https://schema.org/
+                  stn_id:
+                      "@id": schema:identifier
+                      "@type": schema:Text
+                  datetime:
+                      "@type": schema:DateTime
+                      "@id": schema:observationDate
+                  value:
+                      "@type": schema:Number
+                      "@id": schema:QuantitativeValue
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: 2000-10-30T18:24:39Z
+                end: 2007-10-30T08:57:29Z
+                trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+        providers:
+            - type: feature
+              name: CSV
+              data: tests/data/obs.csv
+              id_field: id
+              geometry:
+                  x_field: long
+                  y_field: lat
+
+    cmip5:
+        type: collection
+        title: CMIP5 sample
+        description: CMIP5 sample
+        keywords:
+            - cmip5
+            - climate
+        extents:
+            spatial:
+                bbox: [-150,40,-45,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+        links:
+            - type: text/html
+              rel: canonical
+              title: information
+              href: https://open.canada.ca/data/en/dataset/eddd6eaf-34d7-4452-a994-3d928115a68b
+              hreflang: en-CA
+        providers:
+            - type: coverage
+              name: xarray
+              data: tests/data/CMIP5_rcp8.5_annual_abs_latlon1x1_PCP_pctl25_P1Y.nc404
+              x_field: lon
+              y_field: lat
+              time_field: time
+              format:
+                  name: NetCDF
+                  mimetype: application/x-netcdf
+
+    objects:
+        type: collection
+        title: GeoJSON objects
+        description: GeoJSON geometry types for GeoSparql and Schema Geometry conversion.
+        keywords:
+            - shapes
+        links:
+            - type: text/html
+              rel: canonical
+              title: data source
+              href: https://en.wikipedia.org/wiki/GeoJSON
+              hreflang: en-US
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: null
+                end: null  # or empty (either means open ended)
+        providers:
+            - type: feature
+              name: GeoJSON
+              data: tests/data/items.geojson
+              id_field: fid
+              uri_field: uri


### PR DESCRIPTION
# Overview
This PR moves collection metadata workflow into callable function in order to allow for `/collections` requests to complete on a "best effort" basis (even with failing collections).
# Related Issue / discussion
Fixes #2266

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines