### PR TITLE
OAProc: derive process execution mode OpenAPI prefer option from process metadata

### DIFF
--- a/pygeoapi/api/processes.py
+++ b/pygeoapi/api/processes.py
@@ -760,7 +760,7 @@ def get_oas_30(cfg: dict, locale: str
                     'description': 'Indicates client preferences, including whether the client is capable of asynchronous processing.',  # noqa
                     'schema': {
                         'type': 'string',
-                        'enum': ['respond-async']
+                        'enum': []
                     }
                 }],
                 'responses': {
@@ -783,6 +783,12 @@ def get_oas_30(cfg: dict, locale: str
                 }
             }
         }
+
+        jco = p.metadata.get('jobControlOptions', ['sync-execute'])
+        if 'sync-execute' in jco:
+            paths[f'{process_name_path}/execution']['post']['parameters'][0]['schema']['enum'].append('respond-sync')  # noqa
+        if 'async-execute' in jco:
+            paths[f'{process_name_path}/execution']['post']['parameters'][0]['schema']['enum'].append('respond-async')  # noqa
 
         try:
             first_key = list(p.metadata['outputs'])[0]


### PR DESCRIPTION
# Overview
This PR derives OGC API - Process execution mode options in the OpenAPI definition from process metadata.

# Related Issue / discussion
Follow on of #2232
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
