### PR TITLE
update Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,5 +13,5 @@ The pygeoapi Project Steering Committee (PSC) will release patches for security 
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.10.x  | :white_check_mark: |
-| < 0.10  | :x:                |
+| 0.2x.x  | :white_check_mark: |
+| < 0.20  | :x:                |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,5 +13,5 @@ The pygeoapi Project Steering Committee (PSC) will release patches for security 
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.2x.x  | :white_check_mark: |
+| 0.2x    | :white_check_mark: |
 | < 0.20  | :x:                |


### PR DESCRIPTION
- policy is outdated (from [5 years ago](https://github.com/geopython/pygeoapi/pull/749))
- needs agreement by PSC to handle security for which release branches, such as:
  - only 0.2x releases
  - only latest release, such as 0.23 (and change this security policy during each release)
  - enable GitHub's "[Private vulnerability reporting](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configuring-private-vulnerability-reporting-for-a-repository)" (bonus: it automagically requests a CVE for you)
  - other option?

Purpose of this pull request is only to show the PSC that the policy needs to be updated (sometimes seeing an update such as this PR, even if incorrect, helps others to be motivated to change it - it's an old trick to wake everyone up, ha)
  
  cc @tomkralidis @GeoSander @alpha-beta-soup @francbartoli @jorgejesus @justb4 @kalxas @pvgenuchten
  
  thanks,