### PR TITLE
Parquet batch configuration and documentation for spec updates

### DIFF
--- a/docs/source/publishing/ogcapi-features.rst
+++ b/docs/source/publishing/ogcapi-features.rst
@@ -616,7 +616,7 @@ For GeoParquet data which complies to spec version 1.1, all geometry metadata wi
 detected. 
 
 Note that for any version of parquet, you may optionally specify ``batch_size`` and ``batch_readahead`` in the ``data`` section of the parquet provider config.
-``batch_size`` controls how many rows are fetched per batch. Large batch sizes speed up data processing, but add more I/O, increase latency when fetching data from an object store, and increase memory usage. If not defined it will 
+``batch_size`` controls how many rows are fetched per batch. Large batch sizes speed up data processing, but add more I/O time like increased latency when fetching data from an object store, and . If not defined it will 
 default to 20,000 rows. 
 
 ``batch_readahead`` controls how many batches are buffered in memory. If not specified it will default to 2. 

--- a/pygeoapi/provider/parquet.py
+++ b/pygeoapi/provider/parquet.py
@@ -124,17 +124,17 @@ class ParquetProvider(BaseProvider):
         self.source = self.data.get('source')
         # When iterating over a dataset, the batch size
         # controls how many records are read at a time;
-        # a larger batch size can reduce latency for large
-        # requests the cost of memory and potentially overfetching
-        # the default batch size for pyarrow is 131_072 as specified
-        # by the following link:
+        # a larger batch size can reduce latency for large/complex
+        # requests at the cost of more memory usage
+        # and potentially overfetching;
+        # More information on batching can be found here:
         # https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Dataset.html#pyarrow.dataset.Dataset.scanner # noqa
-        # This can potentially be reduced if fetching the dataset from
-        # an object store
+        # This value can be reduced to decrease network transfer
+        # if fetching data from an object store
         self.batch_size = self.data.get('batch_size', 20_000)
 
-        # Batch readahead is the number of batches to prefetch
-        # this adds extra memory but can reduce latency for large
+        # batch_readahead is the number of batches to prefetch;
+        # This adds extra memory but can reduce latency for large
         # or complicated queries; in an OGC API Features context,
         # it generally makes sense to have some buffering but keep it
         # low since most responses are small


### PR DESCRIPTION
# Overview

When using the parquet provider, previously there was no config option for `batch_size` or `batch_readahead`. pyarrow defaults to batch sizes of over 100k with a default readahead of 16 batches. This is fine for analytics but in a server use case it is generally far too large and when using parquet over s3, adds a lot of extra data transfer.

I changed the provider to allow these options to have smaller defaults and to allow them to be configurable in the provider definition.

I added comments for documentation for this in the code and in the rst docs. I brought some extra info for the docs from #2271  as well while I was at it.

# Related Issue / discussion

Sorta #2271 / #2150 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
