### PR TITLE
Remove duplicated word in docs

### DIFF
--- a/docs/source/publishing/ogcapi-edr.rst
+++ b/docs/source/publishing/ogcapi-edr.rst
@@ -103,7 +103,7 @@ SensorThingsEDR
 ^^^^^^^^^^^^^^^
 
 The SensorThings API EDR Provider for pygeaopi extends the feature provider to
-produce CoverageJSON representations from SensorThings responses repsonses. This provider
+produce CoverageJSON representations from SensorThings responses. This provider
 relies on using the ObservedProperty Entity to create the `parameter-name` set.
 
 .. code-block:: yaml


### PR DESCRIPTION
# Overview

This is a tiny docs PR to remove a duplicated word. Unlike #2285, I left the one spelled correctly this time :) 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
