### PR TITLE
Pin trivy action version to v0.35.0

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout pygeoapi
       uses: actions/checkout@master
     - name: Scan vulnerabilities with trivy
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         scan-type: fs
         exit-code: 1
@@ -36,7 +36,7 @@ jobs:
       run: |
         docker buildx build -t ${{ github.repository }}:${{ github.sha }} --platform linux/amd64 --no-cache -f Dockerfile .
     - name: Scan locally built Docker image for vulnerabilities with trivy
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.35.0
       env:
         TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1


### PR DESCRIPTION
Pin trivy to a safe version before the incident GHSA-69fq-xp46-6x23

# Overview

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [X] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [X] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
