### PR TITLE
add `path:` to `/collection_id` for `/map`

### DIFF
--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -399,8 +399,8 @@ def get_collection_tiles_data(collection_id: str | None = None,
     )
 
 
-@BLUEPRINT.route('/collections/<collection_id>/map')
-@BLUEPRINT.route('/collections/<collection_id>/styles/<style_id>/map')
+@BLUEPRINT.route('/collections/<path:collection_id>/map')
+@BLUEPRINT.route('/collections/<path:collection_id>/styles/<style_id>/map')
 def collection_map(collection_id: str, style_id: str | None = None):
     """
     OGC API - Maps map render endpoint


### PR DESCRIPTION
# Overview

Most flask endpoints in pygeoapi use  `<path:collection_id>` to allow for nested collection names like `my_map/elevation` vs `my_map/land_use`. 

For instance
`@BLUEPRINT.route('/collections/<path:collection_id>/position')`

However for `/map` this didn't appear to be present

As such, if you change the default WMS provider to have a `/` then it will break, for instance like this.

```yml
    mapserver_world_map/test:
        type: collection
        title: MapServer demo WMS world map
        description: MapServer demo WMS world map
```

<img width="1419" height="122" alt="image" src="https://github.com/user-attachments/assets/25c87b17-ae1c-4e42-8bed-210dc95bb11a" />

However, if I add the `path` fix then it will load fine and allow collection names with `/`

<img width="1051" height="458" alt="image" src="https://github.com/user-attachments/assets/314e8c05-0569-4a1c-94af-04cd82ff5e4d" />

I have changed this to add the `path` since I presume this was missing unless I am missing something about the internal workings of the WMS provider.

# Related Issue / discussion

Discussed offline with @webb-ben 

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
