### PR TITLE
Fix to_json escape

### DIFF
--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -265,10 +265,9 @@ def to_json(dict_: dict, pretty: bool = False) -> str:
     json_dump = json.dumps(dict_, default=json_serial, indent=indent,
                            separators=(',', ':'))
 
-    LOGGER.debug('Removing < and >')
+    LOGGER.debug('Escaping < and >')
     json_dump = json_dump.replace('<', '&lt;')
     json_dump = json_dump.replace('>', '&gt;')
-
 
     return json_dump
 

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -266,7 +266,9 @@ def to_json(dict_: dict, pretty: bool = False) -> str:
                            separators=(',', ':'))
 
     LOGGER.debug('Removing < and >')
-    json_dump = json_dump.replace('<', '&lt').replace('>', '&gt')
+    json_dump = json_dump.replace('<', '&lt;')
+    json_dump = json_dump.replace('>', '&gt;')
+
 
     return json_dump
 

--- a/tests/other/test_util.py
+++ b/tests/other/test_util.py
@@ -33,6 +33,7 @@ from copy import deepcopy
 from io import StringIO
 from unittest import mock
 import uuid
+from xml.sax.saxutils import unescape
 
 import pytest
 
@@ -77,12 +78,19 @@ def test_get_typed_value():
 @pytest.mark.parametrize('data,minified,pretty_printed', [
     [{'foo': 'bar'}, '{"foo":"bar"}', '{\n    "foo":"bar"\n}'],
     [{'foo<script>alert("hi")</script>': 'bar'},
-     '{"foo&ltscript&gtalert(\\"hi\\")&lt/script&gt":"bar"}',
-     '{\n    "foo&ltscript&gtalert(\\"hi\\")&lt/script&gt":"bar"\n}']
+     '{"foo&lt;script&gt;alert(\\"hi\\")&lt;/script&gt;":"bar"}',
+     '{\n    "foo&lt;script&gt;alert(\\"hi\\")&lt;/script&gt;":"bar"\n}']
 ])
 def test_to_json(data, minified, pretty_printed):
-    assert util.to_json(data) == minified
+    output = util.to_json(data)
+    assert output == minified
     assert util.to_json(data, pretty=True) == pretty_printed
+
+    unescaped_output = unescape(output)
+    if '&lt;' in output:
+        assert '<' in unescaped_output
+    if '&gt;' in output:
+        assert '>' in unescaped_output
 
 
 def test_yaml_load(config):


### PR DESCRIPTION
# Overview
Fix to_json escape of <> to align the implementation with [XML escape & unescape](https://docs.python.org/3/library/xml.sax.utils.html#xml.sax.saxutils) ([source code](https://github.com/python/cpython/blob/main/Lib/xml/sax/saxutils.py#L18))

# Related Issue / discussion
Related to https://github.com/geopython/pygeoapi/issues/2304, we have a process that outputs JSON keys of XML sitemaps. The sitemaps are unable to be read because `to_json` is incorrectly escaping <> by omiting the trailing semi-colon.
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
