### PR TITLE
catch EDR instance queries in Starlette

### DIFF
--- a/pygeoapi/starlette_app.py
+++ b/pygeoapi/starlette_app.py
@@ -523,6 +523,11 @@ async def get_collection_edr_query(request: Request,
     if 'collection_id' in request.path_params:
         collection_id = request.path_params['collection_id']
 
+        if '/instances/' in collection_id:
+            tokens = collection_id.split('/instances/')
+            collection_id = tokens[0]
+            instance_id = tokens[-1]
+
     if 'instance_id' in request.path_params:
         instance_id = request.path_params['instance_id']
 


### PR DESCRIPTION
# Overview
This PR handles Starlette greedy routing for EDR instance queries.

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
