### PR TITLE
fix boolean OpenAPI typing in HelloWorld process (#2316)

### DIFF
--- a/pygeoapi/process/hello_world.py
+++ b/pygeoapi/process/hello_world.py
@@ -88,7 +88,7 @@ PROCESS_METADATA = {
             'title': 'As bytes',
             'description': 'Whether to force return as bytes',
             'schema': {
-                'type': 'bool',
+                'type': 'boolean',
                 'default': False
             },
             'minOccurs': 0,


### PR DESCRIPTION
# Overview
This PR fixes the OpenAPI `as_bytes` schema definition (`bool` -> `boolean`) for the HelloWorld process.
 
# Related Issue / discussion
Fixes #2316
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
