### PR TITLE
Fix `Access-Control-Expose-Headers` for Flask

### DIFF
--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -86,7 +86,7 @@ ADMIN_BLUEPRINT = Blueprint(
 if CONFIG['server'].get('cors', False):
     try:
         from flask_cors import CORS
-        CORS(APP, CORS_EXPOSE_HEADERS=['*'])
+        CORS(APP, CORS_EXPOSE_HEADERS='*')
     except ModuleNotFoundError:
         print('Python package flask-cors required for CORS support')
 

--- a/pygeoapi/flask_app.py
+++ b/pygeoapi/flask_app.py
@@ -86,7 +86,7 @@ ADMIN_BLUEPRINT = Blueprint(
 if CONFIG['server'].get('cors', False):
     try:
         from flask_cors import CORS
-        CORS(APP, CORS_EXPOSE_HEADERS='*')
+        CORS(APP, expose_headers='*')
     except ModuleNotFoundError:
         print('Python package flask-cors required for CORS support')
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -282,7 +282,7 @@ def test_apirules_active(config_with_rules, rules_api):
         assert response.status_code in (307, 308)
         # Ensure that the expose-headers are set regardless of
         # whether apirules are active or not
-        assert response.headers["Access-Control-Expose-Headers"] == "*"
+        assert response.headers['Access-Control-Expose-Headers'] == '*'
 
         # Test links on landing page for correct URLs
         response = flask_client.get(flask_prefix, follow_redirects=True)
@@ -347,7 +347,7 @@ def test_apirules_inactive(config, api_):
         assert response.status_code == 200
         # Ensure that the expose-headers are set regardless of
         # whether apirules are active or not
-        assert response.headers["Access-Control-Expose-Headers"] == "*"
+        assert response.headers['Access-Control-Expose-Headers'] == '*'
 
         # Test trailing slashes
         response = flask_client.get('/')

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -280,6 +280,9 @@ def test_apirules_active(config_with_rules, rules_api):
         assert response.status_code == 200
         response = flask_client.get(flask_prefix)
         assert response.status_code in (307, 308)
+        # Ensure that the expose-headers are set regardless of
+        # whether apirules are active or not
+        assert response.headers["Access-Control-Expose-Headers"] == "*"
 
         # Test links on landing page for correct URLs
         response = flask_client.get(flask_prefix, follow_redirects=True)
@@ -342,6 +345,9 @@ def test_apirules_inactive(config, api_):
                flask_client.application.url_for('pygeoapi.conformance')
         response = flask_client.get('/static/img/pygeoapi.png')
         assert response.status_code == 200
+        # Ensure that the expose-headers are set regardless of
+        # whether apirules are active or not
+        assert response.headers["Access-Control-Expose-Headers"] == "*"
 
         # Test trailing slashes
         response = flask_client.get('/')


### PR DESCRIPTION
# Overview

It appears that although it was intended to be set, the header `Access-Control-Expose-Headers` is not being set for Flask.

If `Access-Control-Expose-Headers: *` is not set, then browser clients will not be able to read headers in http responses. This prevents JS clients from accessing returned urls in the OGC API Process responses since the url is in the headers.

It seems like this was intended to be set, but `flask_cors` isn't using the argument that is currently being supplied.

# Related Issue / discussion

N/A

# Additional information

If you try to fetch the headers from the demo pygeoapi site which I presume is running flask, you can see that `Access-Control-Expose-Headers` is missing.
```
curl -i "https://demo.pygeoapi.io/master"

HTTP/2 200 
access-control-allow-origin: *
content-language: en-US
content-type: application/json
date: Mon, 27 Apr 2026 22:18:21 GMT
server: gunicorn
strict-transport-security: max-age=63072000; includeSubDomains; preload
vary: Origin
x-content-type-options: nosniff
x-powered-by: pygeoapi 0.23.4
content-length: 2887
```

If you try to fetch a pygeoapi server like my own that includes this change, the headers for `access-control-expose-headers: *` are set as expected

```
curl -i "https://asu-awo-pygeoapi-864861257574.us-south1.run.app/"
HTTP/2 200 
content-type: application/json
x-powered-by: pygeoapi 0.24.dev0
content-language: en-US
access-control-allow-origin: *
access-control-expose-headers: *
x-cloud-trace-context: 19b0436388bc8d84c0171c7c68335524;o=1
date: Mon, 27 Apr 2026 22:17:41 GMT
server: Google Frontend
content-length: 3381
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
