### PR TITLE
Fix visibility hidden edge case

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -932,7 +932,8 @@ def describe_collections(api: API, request: APIRequest,
 
     LOGGER.debug('Creating collections')
     for k, v in collections_dict.items():
-        if v.get('visibility', 'default') == 'hidden':
+        if v.get('visibility', 'default') == 'hidden' \
+                and dataset is None:
             LOGGER.debug(f'Skipping hidden layer: {k}')
             continue
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -80,6 +80,13 @@ def config_hidden_resources():
 
 
 @pytest.fixture()
+def config_exclusively_hidden_resources():
+    filename = 'pygeoapi-test-config-exclusively-hidden-resources.yml'
+    with open(get_test_file_path(filename)) as fh:
+        return yaml_load(fh)
+
+
+@pytest.fixture()
 def config_failing_collection():
     filename = 'pygeoapi-test-config-failing-collection.yml'
     with open(get_test_file_path(filename)) as fh:
@@ -103,6 +110,12 @@ def rules_api(config_with_rules, openapi):
 @pytest.fixture()
 def api_hidden_resources(config_hidden_resources, openapi):
     return API(config_hidden_resources, openapi)
+
+
+@pytest.fixture()
+def api_exclusively_hidden_resources(config_exclusively_hidden_resources, openapi): # noqa
+    '''Returns an API instance where all resources are marked as hidden'''
+    return API(config_exclusively_hidden_resources, openapi)
 
 
 @pytest.fixture()
@@ -739,6 +752,32 @@ def test_describe_collections_hidden_resources(
 
     collections = json.loads(response)
     assert len(collections['collections']) == 1
+
+
+def test_describe_collections_with_only_hidden_resources(
+    api_exclusively_hidden_resources
+):
+    '''
+    Test an API with only hidden resources to ensure
+    there are no indexing errors when no collections are returned
+    '''
+    req = mock_api_request({})
+    _, code, response = describe_collections(api_exclusively_hidden_resources, req)  # noqa
+    assert code == HTTPStatus.OK
+
+    collections = json.loads(response)
+    assert len(collections['collections']) == 0, \
+        'All collections are hidden so there should be none in the response'
+
+    hidden_collection_name = 'objects'
+    _, code, response = describe_collections(
+        api_exclusively_hidden_resources, req, hidden_collection_name
+    )
+
+    assert code == HTTPStatus.OK
+    collection = json.loads(response)
+    assert collection['title'] == 'GeoJSON objects', \
+        'The collection should have its normal title even if hidden'
 
 
 def test_describe_collections_failing_collection(

--- a/tests/pygeoapi-test-config-exclusively-hidden-resources.yml
+++ b/tests/pygeoapi-test-config-exclusively-hidden-resources.yml
@@ -1,0 +1,180 @@
+# =================================================================
+#
+# Authors: Tom Kralidis <tomkralidis@gmail.com>
+#
+# Copyright (c) 2019 Tom Kralidis
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation
+# files (the "Software"), to deal in the Software without
+# restriction, including without limitation the rights to use,
+# copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following
+# conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# =================================================================
+
+server:
+    bind:
+        host: 0.0.0.0
+        port: 5000
+    url: http://localhost:5000/
+    mimetype: application/json; charset=UTF-8
+    encoding: utf-8
+    gzip: false
+    languages:
+        # First language is the default language
+        - en-US
+        - fr-CA
+    cors: true
+    pretty_print: true
+    limits:
+        default_items: 10
+        max_items: 10
+    # templates: /path/to/templates
+    map:
+        url: https://tile.openstreetmap.org/{z}/{x}/{y}.png
+        attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
+    manager:
+        name: TinyDB
+        connection: /tmp/pygeoapi-test-process-manager.db
+        output_dir: /tmp
+
+logging:
+    level: DEBUG
+    #logfile: /tmp/pygeoapi.log
+
+metadata:
+    identification:
+        title:
+            en: pygeoapi default instance
+            fr: instance par défaut de pygeoapi
+        description:
+            en: pygeoapi provides an API to geospatial data
+            fr: pygeoapi fournit une API aux données géospatiales
+        keywords:
+            en:
+                - geospatial
+                - data
+                - api
+            fr:
+                - géospatiale
+                - données
+                - api
+        keywords_type: theme
+        terms_of_service: https://creativecommons.org/licenses/by/4.0/
+        url: http://example.org
+    license:
+        name: CC-BY 4.0 license
+        url: https://creativecommons.org/licenses/by/4.0/
+    provider:
+        name: Organization Name
+        url: https://pygeoapi.io
+    contact:
+        name: Lastname, Firstname
+        position: Position Title
+        address: Mailing Address
+        city: City
+        stateorprovince: Administrative Area
+        postalcode: Zip or Postal Code
+        country: Country
+        phone: +xx-xxx-xxx-xxxx
+        fax: +xx-xxx-xxx-xxxx
+        email: you@example.org
+        url: Contact URL
+        hours: Hours of Service
+        instructions: During hours of service.  Off on weekends.
+        role: pointOfContact
+
+resources:
+    obs:
+        type: collection
+        visibility: hidden
+        title:
+            en: Observations
+            fr: Observations
+        description:
+            en: My cool observations
+            fr: Mes belles observations
+        keywords:
+            - observations
+            - monitoring
+        links:
+            - type: text/csv
+              rel: canonical
+              title: data
+              href: https://github.com/mapserver/mapserver/blob/branch-7-0/msautotest/wxs/data/obs.csv
+              hreflang: en-US
+            - type: text/csv
+              rel: alternate
+              title: data
+              href: https://raw.githubusercontent.com/mapserver/mapserver/branch-7-0/msautotest/wxs/data/obs.csv
+              hreflang: en-US
+        linked-data:
+            context:
+                - schema: https://schema.org/
+                  stn_id:
+                      "@id": schema:identifier
+                      "@type": schema:Text
+                  datetime:
+                      "@type": schema:DateTime
+                      "@id": schema:observationDate
+                  value:
+                      "@type": schema:Number
+                      "@id": schema:QuantitativeValue
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: 2000-10-30T18:24:39Z
+                end: 2007-10-30T08:57:29Z
+                trs: http://www.opengis.net/def/uom/ISO-8601/0/Gregorian
+        providers:
+            - type: feature
+              name: CSV
+              data: tests/data/obs.csv
+              id_field: id
+              geometry:
+                  x_field: long
+                  y_field: lat
+
+    objects:
+        type: collection
+        title: GeoJSON objects
+        visibility: hidden
+        description: GeoJSON geometry types for GeoSparql and Schema Geometry conversion.
+        keywords:
+            - shapes
+        links:
+            - type: text/html
+              rel: canonical
+              title: data source
+              href: https://en.wikipedia.org/wiki/GeoJSON
+              hreflang: en-US
+        extents:
+            spatial:
+                bbox: [-180,-90,180,90]
+                crs: http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            temporal:
+                begin: null
+                end: null  # or empty (either means open ended)
+        providers:
+            - type: feature
+              name: GeoJSON
+              data: tests/data/items.geojson
+              id_field: fid
+              uri_field: uri


### PR DESCRIPTION
# Overview

There is an edge case in the visibility hidden logic where an error can be thrown, I believe if the user requests collections/{id}

In the sample `pygeoapi-config.yml`  set the config to

```
    canada-metadata:
        type: collection
        visibility: hidden
```

and go to http://localhost:5005/collections/canada-metadata?f=json and an error will be thrown.

This fixes it by not skipping hidden collections if the specific dataset was requested. i.e. skip the dataset for `collections/` but not `collections/{id}`

I also added a test to ensure it works if all resources are hidden

# Related Issue / discussion

N/A

# Additional information

This is the error at  http://localhost:5005/collections/canada-metadata?f=json that will be fixed

<img width="1620" height="911" alt="image" src="https://github.com/user-attachments/assets/c93d5dfc-1bdf-4f54-908a-2025b1846e91" />


# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
