### PR TITLE
Only display configured properties in collection schema

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -1076,6 +1076,10 @@ def get_collection_schema(api: API, request: Union[APIRequest, Any],
         }
 
     for k, v in p.fields.items():
+        if p.properties:
+            if k not in p.properties:
+                continue
+
         schema['properties'][k] = v
         if v['type'] == 'float':
             schema['properties'][k]['type'] = 'number'


### PR DESCRIPTION
# Overview
When configuring a feature provider with specific properties exposed, they are correctly hidden in the `/queryables` endpoint, they are exposed in the collection `/schema` view

# Related Issue / discussion
Given configured properties: 
<img width="410" height="292" alt="image" src="https://github.com/user-attachments/assets/4dbbd424-970d-4099-aecf-940948a44b44" />
the fields are still discoverable in the schema
<img width="879" height="788" alt="image" src="https://github.com/user-attachments/assets/7ebe007e-e498-49f1-a07f-88098b1269f7" />
with this change the view is now consistent between the two.
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
