### PR TITLE
fix job start / duration rendering (#2328)

### DIFF
--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -274,21 +274,33 @@ def to_json(dict_: dict, pretty: bool = False) -> str:
     return json_dump
 
 
-def format_datetime(value: str, format_: str = DATETIME_FORMAT) -> str:
+def format_datetime(value: Union[str, datetime],
+                    format_: str = DATETIME_FORMAT) -> str:
     """
     Parse datetime as ISO 8601 string; re-present it in particular format
     for display in HTML
 
-    :param value: `str` of ISO datetime
+    :param value: `str` of ISO datetime or `datetime.datetime`
     :param format_: `str` of datetime format for strftime
 
     :returns: string
     """
 
-    if not isinstance(value, str) or not value.strip():
+    datetime_ = None
+
+    if any([
+       not isinstance(value, (str, datetime)),
+       isinstance(value, str) and not value.strip()
+       ]):
+        LOGGER.debug(f'Invalid datetime value: {value}')
         return ''
 
-    return dateutil.parser.isoparse(value).strftime(format_)
+    if isinstance(value, str):
+        datetime_ = dateutil.parser.isoparse(value).strftime(format_)
+    if isinstance(value, datetime):
+        datetime_ = value.strftime(format_)
+
+    return datetime_
 
 
 def get_current_datetime(tz: timezone = timezone.utc,
@@ -339,21 +351,45 @@ def human_size(nbytes: int) -> str:
     return f'{f}{suffixes[i]}'
 
 
-def format_duration(start: str, end: str = None) -> str:
+def format_duration(start: Union[str, datetime],
+                    end: Union[str, datetime] = None) -> str:
     """
     Parse a start and (optional) end datetime as ISO 8601 strings, calculate
     the difference, and return that duration as a string.
 
-    :param start: `str` of ISO datetime
-    :param end: `str` of ISO datetime, defaults to `start` for a 0 duration
+    :param start: `str` of ISO datetime or `datetime`
+    :param end: `str` of ISO datetime or `datetime`, defaults to `start`
+                for a 0 duration
 
     :returns: string
     """
 
-    if not isinstance(start, str) or not start.strip():
+    if any([
+       not isinstance(start, (str, datetime)),
+       isinstance(start, str) and not start.strip()
+       ]):
+        LOGGER.debug(f'Invalid datetime start: {start}')
         return ''
+
     end = end or start
-    duration = dateutil.parser.isoparse(end) - dateutil.parser.isoparse(start)
+
+    if isinstance(start, str):
+        start2 = dateutil.parser.isoparse(start)
+    if isinstance(start, datetime):
+        start2 = start
+
+    if isinstance(end, str):
+        end2 = dateutil.parser.isoparse(end)
+    if isinstance(end, datetime):
+        end2 = end
+
+    if start2.tzinfo is None:
+        start2 = start2.replace(tzinfo=timezone.utc)
+    if end2.tzinfo is None:
+        end2 = end2.replace(tzinfo=timezone.utc)
+
+    duration = end2 - start2
+
     return str(duration)
 
 

--- a/tests/other/test_util.py
+++ b/tests/other/test_util.py
@@ -347,3 +347,23 @@ def test_get_choice_from_headers():
 ])
 def test_is_request_allowed(url, allow_internal, result):
     assert util.is_request_allowed(url, allow_internal) is result
+
+
+@pytest.mark.parametrize('value,format_,result', [
+    ['2000-11-11T11:33:31Z', '%Y-%m-%dT%H:%M:%SZ', '2000-11-11T11:33:31Z'],
+    [datetime(2000, 11, 11, 11, 33, 31), '%Y-%m-%dT%H:%M:%SZ', '2000-11-11T11:33:31Z']  # noqa
+])
+def test_format_datetime(value, format_, result):
+    assert util.format_datetime(value, format_) == result
+
+
+@pytest.mark.parametrize('start,end,result', [
+    ['2000-11-11T11:33:31Z', None, '0:00:00'],
+    [datetime(2000, 11, 11, 11, 33, 31), None, '0:00:00'],
+    ['2000-11-11T11:33:31Z', '2000-11-11T11:34:33Z', '0:01:02'],
+    [datetime(2000, 11, 11, 11, 33, 31), datetime(2000, 11, 11, 11, 34, 33), '0:01:02'],  # noqa
+    [datetime(2000, 11, 11, 11, 33, 31), '2000-11-11T11:34:33Z', '0:01:02'],
+    ['2000-11-11T11:33:31Z', datetime(2000, 11, 11, 11, 34, 33), '0:01:02']
+])
+def test_format_duration(start, end, result):
+    assert util.format_duration(start, end) == result


### PR DESCRIPTION
# Overview
This PR adds `datetime.datetime` support for handling datetimes and durations, primarily in support of rendering job starttime and duration in HTML mode.

# Related Issue / discussion
Fixes #2328
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
cc @francescoingv 
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
