### PR TITLE
HTML: add safe bbox function for dateline crossing

### DIFF
--- a/pygeoapi/static/js/default.js
+++ b/pygeoapi/static/js/default.js
@@ -1,0 +1,46 @@
+/******************************************************************
+*
+* Authors: Tom Kralidis <tomkralidis@gmail.com>
+*
+* Copyright (c) 2026 Tom Kralidis
+*
+* Permission is hereby granted, free of charge, to any person
+* obtaining a copy of this software and associated documentation
+* files (the "Software"), to deal in the Software without
+* restriction, including without limitation the rights to use,
+* copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the
+* Software is furnished to do so, subject to the following
+* conditions:
+*
+* The above copyright notice and this permission notice shall be
+* included in all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+* OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+* HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+* OTHER DEALINGS IN THE SOFTWARE.
+*
+******************************************************************/
+
+/**
+ * Generates a dateline safe bbox
+ *
+ * @param {[number, number, number, number]} bbox
+ *   Array of minx, miny, maxx, maxy
+ *
+ * @returns {[number, number, number, number]}
+ *   Dateline safe bbox
+*/
+
+function gen_safe_bbox(bbox) {
+  if (bbox[2] < bbox[0]) {
+    bbox[2] += 360;
+  }
+
+  return bbox;
+}

--- a/pygeoapi/templates/collections/collection.html
+++ b/pygeoapi/templates/collections/collection.html
@@ -10,7 +10,8 @@
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
     <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
-    <script src='https://unpkg.com/leaflet-imageoverlay-ogcapi@0.1.0/Leaflet.ImageOverlay.OGCAPI.js'></script>
+    <script src="https://unpkg.com/leaflet-imageoverlay-ogcapi@0.1.0/Leaflet.ImageOverlay.OGCAPI.js"></script>
+    <script src="{{ config['server']['url'] }}/static/js/default.js"></script>
 {% endblock %}
 
 {% block body %}
@@ -148,11 +149,13 @@
       }
     ));
 
+    var bbox = gen_safe_bbox({{ data['extent']['spatial']['bbox'][0] }});
+
     var bbox_layer = L.polygon([
-      ['{{ data['extent']['spatial']['bbox'][0][1] }}', '{{ data['extent']['spatial']['bbox'][0][0] }}'],
-      ['{{ data['extent']['spatial']['bbox'][0][3] }}', '{{ data['extent']['spatial']['bbox'][0][0] }}'],
-      ['{{ data['extent']['spatial']['bbox'][0][3] }}', '{{ data['extent']['spatial']['bbox'][0][2] }}'],
-      ['{{ data['extent']['spatial']['bbox'][0][1] }}', '{{ data['extent']['spatial']['bbox'][0][2] }}']
+      [bbox[1], bbox[0]],
+      [bbox[3], bbox[0]],
+      [bbox[3], bbox[2]],
+      [bbox[1], bbox[2]]
     ]);
 
     var lbounds = bbox_layer.getBounds();

--- a/pygeoapi/templates/stac/collection_base.html
+++ b/pygeoapi/templates/stac/collection_base.html
@@ -10,6 +10,7 @@
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
     <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+    <script src="{{ config['server']['url'] }}/static/js/default.js"></script>
 {% endblock %}
 
 {% block body %}
@@ -102,12 +103,16 @@
             attribution: '{{ config['server']['map']['attribution'] | safe }}'
         }
     ));
+
+    var bbox = gen_safe_bbox({{ data['extent']['spatial']['bbox'][0] }});
+
     var bbox_layer = L.polygon([
-        [{{ data['extent']['spatial']['bbox'][0][1] }}, {{ data['extent']['spatial']['bbox'][0][0] }}],
-        [{{ data['extent']['spatial']['bbox'][0][3] }}, {{ data['extent']['spatial']['bbox'][0][0] }}],
-        [{{ data['extent']['spatial']['bbox'][0][3] }}, {{ data['extent']['spatial']['bbox'][0][2] }}],
-        [{{ data['extent']['spatial']['bbox'][0][1] }}, {{ data['extent']['spatial']['bbox'][0][2] }}],
+      [bbox[1], bbox[0]],
+      [bbox[3], bbox[0]],
+      [bbox[3], bbox[2]],
+      [bbox[1], bbox[2]]
     ]);
+
     map.addLayer(bbox_layer);
     map.fitBounds(bbox_layer.getBounds(), {maxZoom: 10});
     </script>

--- a/pygeoapi/templates/stac/item.html
+++ b/pygeoapi/templates/stac/item.html
@@ -10,6 +10,7 @@
 {% block extrahead %}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css"/>
     <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+    <script src="{{ config['server']['url'] }}/static/js/default.js"></script>
 {% endblock %}
 
 {% block body %}
@@ -97,12 +98,16 @@
             attribution: '{{ config['server']['map']['attribution'] | safe }}'
         }
     ));
+
+    var bbox = gen_safe_bbox({{ data['extent']['spatial']['bbox'][0] }});
+
     var bbox_layer = L.polygon([
-        [{{ data['bbox'][1] }}, {{ data['bbox'][0] }}],
-        [{{ data['bbox'][3] }}, {{ data['bbox'][0] }}],
-        [{{ data['bbox'][3] }}, {{ data['bbox'][2] }}],
-        [{{ data['bbox'][1] }}, {{ data['bbox'][2] }}],
+      [bbox[1], bbox[0]],
+      [bbox[3], bbox[0]],
+      [bbox[3], bbox[2]],
+      [bbox[1], bbox[2]]
     ]);
+
     map.addLayer(bbox_layer);
     map.fitBounds(bbox_layer.getBounds(), {maxZoom: 10});
     </script>


### PR DESCRIPTION
# Overview
This PR adds support to HTML to render (collection) polygons supporting cases with dateline crossing.  Note that data is not changed per se, as the bbox adjustment is solely for visualization purposes.

# Related Issue / discussion
Downstream in https://github.com/World-Meteorological-Organization/wis2box/issues/1103
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
Current master:
<img width="1342" height="919" alt="image" src="https://github.com/user-attachments/assets/5d0e4b47-8d56-48e8-834b-92377f8e58e0" />
This PR:

<img width="1414" height="901" alt="image" src="https://github.com/user-attachments/assets/62294a75-f47f-45f5-b0ae-e1eb1a27877b" />

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
