### PR TITLE
Pass content CRS to formatters

### DIFF
--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -483,6 +483,7 @@ def get_collection_edr_query(api: API, request: APIRequest,
             content = formatter.write(
                 data=data,
                 options={
+                    'content_crs': query_crs_uri,
                     'provider_def': get_provider_by_type(
                         collections[dataset]['providers'],
                         'edr')

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -690,6 +690,7 @@ def get_collection_items(
             content = formatter.write(
                 data=content,
                 options={
+                    'content_crs': query_crs_uri,
                     'provider_def': get_provider_by_type(
                         collections[dataset]['providers'],
                         'feature')


### PR DESCRIPTION
# Overview
This PR passes the content crs to formatters to allow them to act on it. Some examples where this is relevant is [JSON-FG](https://github.com/geopython/pygeoapi/pull/2136) and various OGR downloadable file types which store content CRS inline [Shapefile](https://github.com/cgs-earth/pygeoapi-plugins/blob/master/pygeoapi_plugins/formatter/shape.py#L42) and [GPKG](https://github.com/cgs-earth/pygeoapi-plugins/blob/master/pygeoapi_plugins/formatter/shape.py#L143)

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
