### PR TITLE
EDR: emit data link JSON media type as CoverageJSON

### DIFF
--- a/pygeoapi/api/collection.py
+++ b/pygeoapi/api/collection.py
@@ -454,7 +454,7 @@ def gen_collection(api, request, dataset: str,
             title2 = f'{qt} {title2}'
 
             data['links'].extend([{
-                'type': 'application/json',
+                'type': 'application/vnd.cov+json',
                 'rel': 'data',
                 'title': title1,
                 'href': f'{api.get_collections_url()}/{dataset}/{qt}?f={F_JSON}'  # noqa

--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -461,7 +461,7 @@ def get_collection_edr_query(api: API, request: APIRequest,
             'title': collections[dataset]['title'],
             'href': data['dataset_path']
         }, {
-            'type': 'application/prs.coverage+json',
+            'type': 'application/vnd.cov+json',
             'rel': request.get_linkrel(F_COVERAGEJSON),
             'title': l10n.translate('This document as CoverageJSON', request.locale),  # noqa
             'href': f'{uri}?f={F_COVERAGEJSON}{serialized_query_params}'
@@ -603,7 +603,7 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
                             '200': {
                                 'description': 'Response',
                                 'content': {
-                                    'application/prs.coverage+json': {
+                                    'application/vnd.cov+json': {
                                         'schema': {
                                             '$ref': f"{OPENAPI_YAML['oaedr']}/schemas/coverageJSON.yaml"  # noqa
                                         }
@@ -687,7 +687,7 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
                             '200': {
                                 'description': 'Response',
                                 'content': {
-                                    'application/prs.coverage+json': {
+                                    'application/vnd.cov+json': {
                                         'schema': {
                                             '$ref': f"{OPENAPI_YAML['oaedr']}/schemas/coverageJSON.yaml"  # noqa
                                         }


### PR DESCRIPTION
# Overview
This PR updates EDR query type links to provide `application/vnd.cov+json` as the media type when `f=json`.
# Related Issue / discussion
None
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
