### PR TITLE
Correct conformance class URLs

### DIFF
--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -76,15 +76,15 @@ OGC_RELTYPES_BASE = 'http://www.opengis.net/def/rel/ogc/1.0'
 
 CONFORMANCE_CLASSES_FEATURES = [
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
-    'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30',
+    'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas3',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson',
     'http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs',
     'http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables',
     'http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/queryables-query-parameters',  # noqa
     'http://www.opengis.net/spec/ogcapi-features-4/1.0/conf/create-replace-delete',  # noqa
-    'http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/schemas',
-    'http://www.opengis.net/spec/ogcapi-features-5/1.0/conf/core-roles-features',  # noqa
+    'http://www.opengis.net/spec/ogcapi-common-3/1.0/conf/schemas',
+    'http://www.opengis.net/spec/ogcapi-common-3/1.0/conf/advanced-property-roles',  # noqa
     'http://www.opengis.net/spec/cql2/1.0/conf/cql2-text',
     'http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2'
 

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -76,7 +76,7 @@ OGC_RELTYPES_BASE = 'http://www.opengis.net/def/rel/ogc/1.0'
 
 CONFORMANCE_CLASSES_FEATURES = [
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core',
-    'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas3',
+    'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html',
     'http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson',
     'http://www.opengis.net/spec/ogcapi-features-2/1.0/conf/crs',


### PR DESCRIPTION
# Overview
Per the conformance class in [OGC API - Feaures: 5](https://docs.ogc.org/DRAFTS/23-058r1.html#_conformance), use OGC API - Common conformance URL sets.
- `.../ogcapi-features-5/1.0/conf/schemas` -> `.../ogcapi-common-3/1.0/conf/schemas`
- `.../ogcapi-features-5/1.0/conf/core-roles-features` -> `.../ogcapi-common-3/1.0/conf/advanced-property-roles`

~~As introduced in https://github.com/geopython/pygeoapi/pull/1967, pygeoapi uses the conformance class in the specification: http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30. However, the url that resolves is http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas3.~~

~~I was able to find multiple references to the `.../oas3` version of the the oas conformance class in the NamingAuthority repository: [search:opengeospatial/NamingAuthority)](https://github.com/search?q=repo:opengeospatial/NamingAuthority+http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas3). I did not find any references in the naming authority to `ogcapi-features-1/1.0/conf/oas30` or `ogcapi-features-1/1.0/conf/oas30` Not sure if this is a fix that is first needed in the OAF spec.~~

Remaining specification URLs that do not resolve are in draft as described in https://github.com/geopython/pygeoapi/issues/1637.

# Related Issue / discussion
https://github.com/geopython/pygeoapi/pull/1967
https://github.com/geopython/pygeoapi/issues/1637
https://github.com/opengeospatial/ogcapi-features/issues/1045
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
