### PR TITLE
Force a 404 code for tiles out of bounds

### DIFF
--- a/pygeoapi/provider/mvt_proxy.py
+++ b/pygeoapi/provider/mvt_proxy.py
@@ -176,7 +176,7 @@ class MVTProxyProvider(BaseMVTProvider):
                     else:
                         resp = session.get(f'{base_url}/{layer}/{z}/{x}/{y}{url_query}')  # noqa
 
-                    if resp.status_code == 404:
+                    if resp.status_code == 404 or resp.status_code == 500:
                         if (self.is_in_limits(self.get_tilematrixset(tileset), z, x, y)): # noqa
                             return None
                         raise ProviderTileNotFoundError

--- a/pygeoapi/provider/mvt_proxy.py
+++ b/pygeoapi/provider/mvt_proxy.py
@@ -176,7 +176,7 @@ class MVTProxyProvider(BaseMVTProvider):
                     else:
                         resp = session.get(f'{base_url}/{layer}/{z}/{x}/{y}{url_query}')  # noqa
 
-                    if resp.status_code == 404 or resp.status_code == 500:
+                    if resp.status_code in [404, 500]:
                         if (self.is_in_limits(self.get_tilematrixset(tileset), z, x, y)): # noqa
                             return None
                         raise ProviderTileNotFoundError


### PR DESCRIPTION
# Overview

# Related Issue / discussion

https://github.com/geopython/pygeoapi/issues/2364

# Additional information

On the mvt-proxy provider, we are not sure what the behaviour of the upstream server is regarding tiles out of bounds; however, we need to make sure that if the tile is out of bounds we return a 404. This PR forces that behaviour on mvt-proxy, by evaluating if the 500 error was caused by requesting a tile outside the limits of the TMS. This also ensures that we pass the conformance test.

```
curl -I localhost:5000/collections/srup_arvores_point/tiles/WebMercatorQuad/0/0/100?f=pbf
HTTP/1.1 404 NOT FOUND
Server: Werkzeug/3.1.8 Python/3.12.0
Date: Fri, 19 Jun 2026 12:58:03 GMT
Content-Type: application/vnd.mapbox-vector-tile
X-Powered-By: pygeoapi 0.24.dev0
Content-Language: en-US
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: *
Content-Length: 14
Connection: close

```

<img width="2350" height="1279" alt="Screenshot from 2026-06-19 13-56-56" src="https://github.com/user-attachments/assets/eedff9f9-bea2-40cf-87e8-1b3f6a3b93ae" />


# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
