### PR TITLE
Create get_parameters in BaseEDRProvider

### DIFF
--- a/pygeoapi/api/collection.py
+++ b/pygeoapi/api/collection.py
@@ -400,37 +400,7 @@ def gen_collection(api, request, dataset: str,
         # TODO: translate
         LOGGER.debug('Adding EDR links')
         data['data_queries'] = {}
-        parameters = p.get_fields()
-        if parameters:
-            data['parameter_names'] = {}
-            for key, value in parameters.items():
-                p_label = value.get('title')
-                p_description = value.get('description')
-                data['parameter_names'][key] = {
-                    'id': key,
-                    'type': 'Parameter',
-                    'observedProperty': {
-                        'label': {
-                            'en': p_label
-                        }
-                    },
-                    'unit': {
-                        'label': {
-                            'en': value['title']
-                        },
-                        'symbol': {
-                            'value': value['x-ogc-unit'],
-                            'type': 'http://www.opengis.net/def/uom/UCUM/'
-                        }
-                    }
-                }
-
-                if p_description is not None:
-                    data['parameter_names'][key]['observedProperty'].update({
-                        'description': {
-                            'en': p_description
-                        }
-                    })
+        data['parameter_names'] = p.get_parameters()
 
         for qt in p.get_query_types():
             data_query = {

--- a/pygeoapi/provider/base_edr.py
+++ b/pygeoapi/provider/base_edr.py
@@ -113,6 +113,9 @@ class BaseEDRProvider(BaseProvider):
 
         :param parameters: List of the subset of parameters include.
         :param as_list: bool to return as a list of parameter definitions.
+                        GeoJSON parameters are returned as an array
+                        https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/issues/633
+
 
         :returns: A dictionary or list containing the parameter definition.
         """
@@ -149,8 +152,6 @@ class BaseEDRProvider(BaseProvider):
                 })
 
         if as_list:
-            # GeoJSON Parameters are a list
-            # https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/issues/633
             return list(out_params.values())
         else:
             return out_params

--- a/pygeoapi/provider/base_edr.py
+++ b/pygeoapi/provider/base_edr.py
@@ -105,6 +105,56 @@ class BaseEDRProvider(BaseProvider):
 
         return self.query_types
 
+    def get_parameters(
+        self, parameters: set | list = [], as_list=False
+    ) -> dict | list:
+        """
+        Generate CoverageJSON parameters from provider field defintions
+
+        :param parameters: List of the subset of parameters include.
+        :param as_list: bool to return as a list of parameter definitions.
+
+        :returns: A dictionary or list containing the parameter definition.
+        """
+        if not parameters:
+            parameters = set(self.fields.keys())
+
+        out_params = {}
+        for name in set(parameters):
+            conf_ = self.fields[name]
+            p_label = conf_.get('title')
+            out_params[name] = {
+                'id': name,
+                'type': 'Parameter',
+                'name': p_label,
+                'observedProperty': {
+                    'id': name,
+                    'label': {'en': p_label}
+                },
+                'unit': {
+                    'symbol': {
+                        'value': conf_['x-ogc-unit'],
+                        'type': 'http://www.opengis.net/def/uom/UCUM/'
+                    }
+                }
+            }
+
+            # Add description if available
+            p_description = conf_.get('description')
+            if p_description is not None:
+                out_params[name]['observedProperty'].update({
+                    'description': {
+                        'en': p_description
+                    }
+                })
+
+        if as_list:
+            # GeoJSON Parameters are a list
+            # https://github.com/opengeospatial/ogcapi-environmental-data-retrieval/issues/633
+            return list(out_params.values())
+        else:
+            return out_params
+
     def query(self, **kwargs):
         """
         Extract data from collection collection

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -44,6 +44,7 @@ from pygeoapi.provider.base import (BaseProvider,
                                     ProviderConnectionError,
                                     ProviderNoDataError,
                                     ProviderQueryError)
+from pygeoapi.provider.base_edr import BaseEDRProvider
 from pygeoapi.util import read_data
 
 LOGGER = logging.getLogger(__name__)
@@ -378,24 +379,7 @@ class XarrayProvider(BaseProvider):
             })
 
         LOGGER.debug('Adding parameters')
-        for key, value in selected_fields.items():
-            parameter = {
-                'type': 'Parameter',
-                'description': {
-                    'en': value['title']
-                },
-                'unit': {
-                    'symbol': value['x-ogc-unit']
-                },
-                'observedProperty': {
-                    'id': key,
-                    'label': {
-                        'en': value['title']
-                    }
-                }
-            }
-
-            cj['parameters'][key] = parameter
+        cj['parameters'] = BaseEDRProvider.get_parameters(self, selected_fields)
 
         data = data.fillna(None)
 

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -379,7 +379,9 @@ class XarrayProvider(BaseProvider):
             })
 
         LOGGER.debug('Adding parameters')
-        cj['parameters'] = BaseEDRProvider.get_parameters(self, selected_fields)
+        cj['parameters'] = BaseEDRProvider.get_parameters(
+            self, selected_fields
+        )
 
         data = data.fillna(None)
 

--- a/tests/api/test_environmental_data_retrieval.py
+++ b/tests/api/test_environmental_data_retrieval.py
@@ -54,7 +54,6 @@ def test_describe_collection_edr(config, api_):
     assert sst['id'] == 'SST'
     assert sst['type'] == 'Parameter'
     assert sst['observedProperty']['label']['en'] == 'SEA SURFACE TEMPERATURE'
-    assert sst['unit']['label']['en'] == 'SEA SURFACE TEMPERATURE'
     assert sst['unit']['symbol']['value'] == 'Deg C'
 
 


### PR DESCRIPTION
# Overview
Migrate creation of CoverageJSON Parameters object to BaseEDRProvider to allow downstream providers to control the creation of the parameters representation at the `.../collections/{collection_id}` endpoint.

# Related Issue / discussion
Addresses https://github.com/geopython/pygeoapi/issues/2362
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
This allow allows for a unified implementation of CovJSON parameters between the parameters offered at the metdata endpoint and the literal parameters returned by the provider. This is demonstrated in the implementation of the get_parameters function for Coverages returned by the Xarray provider.

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
