### PR TITLE
Use formatter filetype as dataset_formatters key

### DIFF
--- a/pygeoapi/api/__init__.py
+++ b/pygeoapi/api/__init__.py
@@ -206,11 +206,11 @@ class APIRequest:
         self._raw_locale, self._locale = self._get_locale(request.headers,
                                                           supported_locales)
 
-        # Determine format
-        self._format = self._get_format(request.headers)
-
         # Get received headers
         self._headers = self.get_request_headers(request.headers)
+
+        # Determine format
+        self._format = self._get_format()
 
     @classmethod
     def from_flask(cls, request, supported_locales) -> 'APIRequest':
@@ -298,12 +298,10 @@ class APIRequest:
 
         return raw, default_locale
 
-    def _get_format(self, headers: dict,
-                    extra_formats: dict = {}) -> Union[str, None]:
+    def _get_format(self, extra_formats: dict = {}) -> Union[str, None]:
         """
         Get `Request` format type from query parameters or headers.
 
-        :param headers: Dict of Request headers
         :param extra_formats: Dict of extra dataset specific formats
 
         :returns: format value or None if not found/specified
@@ -317,19 +315,25 @@ class APIRequest:
 
         # Format not specified: get from Accept headers (MIME types)
         # e.g. Accept: 'text/html;q=0.5,application/ld+json'
-        types_ = get_choice_from_headers(headers, 'accept', all=True)
+        types_ = get_choice_from_headers(self.headers, 'accept', all=True)
         if types_ is None:
             return
 
-        merged_format_types = FORMAT_TYPES | extra_formats
+        # Add formatters to accepted format types
+        extra_formats_mimes = {
+            k: v.mimetype for k, v in extra_formats.items()
+            if hasattr(v, 'mimetype')
+        }
+        merged_format_types = FORMAT_TYPES | extra_formats_mimes
 
-        (fmts, mimes) = zip(*merged_format_types.items())
-        mimes2 = [m.split(';')[0] for m in mimes]
-
+        # Lookup formatter by mimetype
+        mimes = {
+            merged_format_types[k].split(';')[0]: k
+            for k in merged_format_types
+        }
         for type_ in types_:
-            if type_ in mimes2:
-                idx_ = mimes2.index(type_)
-                return fmts[idx_]
+            if type_ in mimes:
+                return mimes[type_]
 
     @property
     def data(self) -> bytes:

--- a/pygeoapi/api/collection.py
+++ b/pygeoapi/api/collection.py
@@ -265,8 +265,8 @@ def gen_collection(api, request, dataset: str,
             data['links'].append({
                 'type': value.mimetype,
                 'rel': 'items',
-                'title': l10n.translate(f'Items as {key}', locale_),  # noqa
-                'href': f'{api.get_collections_url()}/{dataset}/items?f={value.f}'  # noqa
+                'title': l10n.translate(f'Items as {value.name}', locale_),  # noqa
+                'href': f'{api.get_collections_url()}/{dataset}/items?f={key}'  # noqa
             })
 
     # OAPIF Part 2 - list supported CRSs and StorageCRS

--- a/pygeoapi/api/environmental_data_retrieval.py
+++ b/pygeoapi/api/environmental_data_retrieval.py
@@ -298,13 +298,11 @@ def get_collection_edr_query(api: API, request: APIRequest,
 
     if dataset_formatters:
         LOGGER.debug(f'Dataset formatters: {dataset_formatters}')
-        request._format = request._get_format(
-            request.get_request_headers(request.headers),
-            {v.f: v.mimetype for v in dataset_formatters.values()})
+        request._format = request._get_format(dataset_formatters)
 
         LOGGER.debug(f'Request format: {request.format}')
 
-    if not request.is_valid(dataset_formatters.keys()):
+    if not request.is_valid(dataset_formatters):
         return api.get_format_exception(request)
 
     crs_transform_spec = None
@@ -475,9 +473,8 @@ def get_collection_edr_query(api: API, request: APIRequest,
         content = render_j2_template(api.tpl_config, tpl_config,
                                      'collections/edr/query.html', data,
                                      api.default_locale)
-    elif request.format in [df.f for df in dataset_formatters.values()]:
-        formatter = [v for v in dataset_formatters.values() if
-                     v.f == request.format][0]
+    elif request.format in dataset_formatters:
+        formatter = dataset_formatters[request.format]
 
         try:
             content = formatter.write(
@@ -581,10 +578,10 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
                         '$ref': f"{OPENAPI_YAML['oaedr']}/parameters/{eqe['qt']}Coords.yaml"  # noqa
                     }
 
+                # Add data formatters to OAS
                 dataset_formatters = get_dataset_formatters(v)
                 coll_f_parameter = deepcopy(get_oas_30_parameters(cfg, locale))['f']  # noqa
-                for key, value in dataset_formatters.items():
-                    coll_f_parameter['schema']['enum'].append(value.f)
+                coll_f_parameter['schema']['enum'].extend(dataset_formatters)
 
                 paths[eqe['path']] = {
                     'get': {

--- a/pygeoapi/api/itemtypes.py
+++ b/pygeoapi/api/itemtypes.py
@@ -358,13 +358,11 @@ def get_collection_items(
 
     if dataset_formatters:
         LOGGER.debug(f'Dataset formatters: {dataset_formatters}')
-        request._format = request._get_format(
-            request.get_request_headers(request.headers),
-            {v.f: v.mimetype for v in dataset_formatters.values()})
+        request._format = request._get_format(dataset_formatters)
 
         LOGGER.debug(f'Request format: {request.format}')
 
-    if not request.is_valid(dataset_formatters.keys()):
+    if not request.is_valid(dataset_formatters):
         return api.get_format_exception(request)
 
     crs_transform_spec = None
@@ -600,8 +598,8 @@ def get_collection_items(
         content['links'].append({
             'type': value.mimetype,
             'rel': 'alternate',
-            'title': f'This document as {key}',
-            'href': f'{uri}?f={value.name}{serialized_query_params}'
+            'title': f'This document as {value.name}',
+            'href': f'{uri}?f={key}{serialized_query_params}'
         })
 
     next_link = False
@@ -685,9 +683,8 @@ def get_collection_items(
                                      'collections/items/index.html',
                                      content, request.locale)
         return headers, HTTPStatus.OK, content
-    elif request.format in [df.f for df in dataset_formatters.values()]:
-        formatter = [v for v in dataset_formatters.values() if
-                     v.f == request.format][0]
+    elif request.format in dataset_formatters:
+        formatter = dataset_formatters[request.format]
 
         try:
             content = formatter.write(
@@ -1109,10 +1106,10 @@ def get_oas_30(cfg: dict, locale: str) -> tuple[list[dict[str, str]], dict[str, 
                 v.get('limits', {})
             )
 
+            # Add data formatters to OAS
             dataset_formatters = get_dataset_formatters(v)
             coll_f_parameter = deepcopy(oas_30_parameters)['f']
-            for key, value in dataset_formatters.items():
-                coll_f_parameter['schema']['enum'].append(value.f)
+            coll_f_parameter['schema']['enum'].extend(dataset_formatters)
 
             paths[items_path] = {
                 'get': {

--- a/pygeoapi/formatter/base.py
+++ b/pygeoapi/formatter/base.py
@@ -56,7 +56,9 @@ class BaseFormatter:
         self.geom = formatter_def.get('geom', False)
         self.attachment = formatter_def.get('attachment', False)
 
-    def write(self, options: dict = {}, data: dict | None = None) -> str:
+    def write(
+        self, options: dict = {}, data: dict | None = None
+    ) -> str | bytes:
         """
         Generate data in specified format
 

--- a/pygeoapi/formatter/base.py
+++ b/pygeoapi/formatter/base.py
@@ -65,7 +65,7 @@ class BaseFormatter:
         :param options: formatting options
         :param data: dict representation of GeoJSON object
 
-        :returns: string representation of format
+        :returns: string or bytes representation of format
         """
 
         raise NotImplementedError()

--- a/pygeoapi/util.py
+++ b/pygeoapi/util.py
@@ -768,17 +768,17 @@ def get_dataset_formatters(dataset: dict) -> dict:
     dataset_formatters = {}
     provider_type = get_provider_default(dataset['providers'])['type']
 
-    for key, value in PLUGINS['formatter'].items():
+    for key in PLUGINS['formatter']:
         # workaround to keep items-based collections supporting CSV
         if provider_type not in ['feature', 'record']:
             continue
 
         df2 = load_plugin('formatter', {'name': key})
-        dataset_formatters[key] = df2
+        dataset_formatters[df2.f] = df2
 
     for df in dataset.get('formatters', []):
         df2 = load_plugin('formatter', df)
-        dataset_formatters[df2.name] = df2
+        dataset_formatters[df2.f] = df2
 
     return dataset_formatters
 


### PR DESCRIPTION
# Overview
- Use the formatter format `f` as the lookup key in external dataset_formatters
- Add bytes as return type for BaseFormatter

# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
This PR largely aims to simplify how the formatters are selected by options for a dictionary instead of list comprehension. 

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
