### PR TITLE
Solve issue #2382

### DIFF
--- a/pygeoapi/process/base.py
+++ b/pygeoapi/process/base.py
@@ -89,6 +89,34 @@ class BaseProcessor:
 
         raise NotImplementedError()
 
+    def remove_resources(self, job_id: str) -> None:
+        """
+        Remove resorces (if any) created by the Processor for the specific
+        job_id.
+        E.g. resources created by the Processor for the job_id to be accessed
+        by reference.
+        Note: only the Processor is aware of the allocated resources and how to
+        handle (add/remove) them.
+
+        :param job_id: the job_id associated to the resources to be removed.
+        
+        The function should be called by the Manager upon receiving a request
+        to delete_job().
+
+        The function should be implemented only by the Processors creating
+        job_id specific resources as result of a call to execute(),
+        where the resources are expected to become unavailable when the job
+        were deleted.
+
+        For the implementing Processors, the Processor needs to have an
+        internal way to map job_id to the resources specific to that job_id.
+
+        No exception is expected to be raised where the remove operation will
+        fail for any reason.
+        """
+
+        pass
+
     def __repr__(self):
         return f'<BaseProcessor> {self.name}'
 

--- a/pygeoapi/process/base.py
+++ b/pygeoapi/process/base.py
@@ -99,7 +99,7 @@ class BaseProcessor:
         handle (add/remove) them.
 
         :param job_id: the job_id associated to the resources to be removed.
-        
+
         The function should be called by the Manager upon receiving a request
         to delete_job().
 

--- a/pygeoapi/process/manager/postgresql.py
+++ b/pygeoapi/process/manager/postgresql.py
@@ -254,6 +254,11 @@ class PostgreSQLManager(BaseManager):
             except FileNotFoundError:
                 pass
 
+        # remove resources if present
+        process_id = job_result.get('process_id')
+        processor = self.get_processor(process_id)
+        processor.remove_resources(job_id)
+
         return rowcount == 1
 
     def get_job_result(self, job_id: str) -> Tuple[str, Any]:

--- a/pygeoapi/process/manager/tinydb_.py
+++ b/pygeoapi/process/manager/tinydb_.py
@@ -161,6 +161,11 @@ class TinyDBManager(BaseManager):
         with self._db() as db:
             removed = bool(db.remove(tinydb.where('identifier') == job_id))
 
+        # remove resources if present
+        process_id = job_result.get('process_id')
+        processor = self.get_processor(process_id)
+        processor.remove_resources(job_id)
+
         return removed
 
     def get_job(self, job_id: str) -> dict:


### PR DESCRIPTION

# Overview
Enable the Processor to delete resources created when a job DELETE is submitted #2382

# Related Issue / discussion
Solve issue #2382 

# Additional information
BaseProcessor: added hook remove_resources() to enable derived classes to handle removal of resources
PostgreSQLManager and TinyDBManager: modified delete_job() to call processor.remove_resources(job_id) when result files are removed.
DummyManager and MongoDBManager: do not modified as not handling result files

# Dependency policy (RFC2)

- [X] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [X] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [X] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
