### PR TITLE
OGR: sanitize attribute filter values

### DIFF
--- a/pygeoapi/provider/ogr.py
+++ b/pygeoapi/provider/ogr.py
@@ -322,7 +322,7 @@ class OGRProvider(BaseProvider):
                 LOGGER.debug('processing properties')
 
                 attribute_filter = ' and '.join(
-                    map(lambda x: f'{x[0]} = \'{x[1]}\'', properties)
+                    map(lambda x: f'{x[0]} = {sanitize_attribute_value(x[1])}', properties)  # noqa
                 )
 
                 LOGGER.debug(attribute_filter)
@@ -410,7 +410,9 @@ class OGRProvider(BaseProvider):
             LOGGER.debug(f'Fetching identifier {identifier}')
             layer = self._get_layer()
 
-            layer.SetAttributeFilter(f"{self.id_field} = '{identifier}'")
+            identifier2 = sanitize_attribute_value(identifier)
+
+            layer.SetAttributeFilter(f'{self.id_field} = {identifier2}')
 
             ogr_feature = self._get_next_feature(layer, identifier)
             result = self._ogr_feature_to_json(
@@ -902,3 +904,25 @@ def _ignore_gdal_error(inst, fn, *args, **kwargs) -> Any:
     """
     value = getattr(inst, fn)(*args, **kwargs)
     return value
+
+
+def sanitize_attribute_value(value) -> str:
+    """
+    Sanitize an attribute value used in an
+    OGR layer SetAttributeFilter function
+
+    :param value: `str` of attribute value
+
+    :returns: `str` of sanitized attribute value
+    """
+
+    if value is None:
+        return 'NULL'
+
+    if isinstance(value, bool):
+        return '1' if value else '0'
+
+    if isinstance(value, (int, float)):
+        return f"'{value}'"
+
+    return "'" + str(value).replace("'", "''") + "'"

--- a/tests/provider/test_ogr_gpkg_provider.py
+++ b/tests/provider/test_ogr_gpkg_provider.py
@@ -80,6 +80,14 @@ def test_get(config_poi_portugal):
     assert result['id'] == 536678593
     assert 'cafe' in result['properties']['fclass']
 
+    with pytest.raises(ProviderItemNotFoundError):
+        item_id = 'foo%27%20OR%20%271%27%3D%271'
+        p.get(item_id)
+
+    with pytest.raises(ProviderItemNotFoundError):
+        item_id = "x' OR (SELECT substr(sql,1,1) FROM sqlite_master WHERE name='secret_table')='C"  # noqa
+        p.get(item_id)
+
 
 def test_get_not_existing_feature_raise_exception(
     config_poi_portugal
@@ -397,3 +405,23 @@ def test_query_with_property_filtering(config_gpkg_4326):
         assert 'straatnaam' in feature['properties']
 
         assert feature['properties']['straatnaam'] == 'Arnhemseweg'
+
+    feature_collection = p.query(
+        properties=[
+            ('straatnaam', "Arnhemseweg' OR '1'='1")
+        ]
+    )
+
+    assert feature_collection.get('type') == 'FeatureCollection'
+    features = feature_collection.get('features')
+    assert len(features) == 0
+
+    feature_collection = p.query(
+        properties=[
+            ('straatnaam', "doesnotexist' OR '1'='1")
+        ]
+    )
+
+    assert feature_collection.get('type') == 'FeatureCollection'
+    features = feature_collection.get('features')
+    assert len(features) == 0


### PR DESCRIPTION
# Overview
This PR fixes OGR attribute filter sanitization and quoting when executing layer `SetAttributeFilter` in the OGR feature provider.
# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
