### PR TITLE
OAProc: prevent redirects on callbacks

### DIFF
--- a/pygeoapi/process/manager/base.py
+++ b/pygeoapi/process/manager/base.py
@@ -517,7 +517,7 @@ class BaseManager:
             LOGGER.error(f'{msg}: {url}')
             raise ProcessorExecuteError(msg)
 
-        response = requests.post(url, json=data)
+        response = requests.post(url, json=data, allow_redirects=False)
         LOGGER.debug(
             f'Response: {response.status_code}'
         )

--- a/tests/api/test_processes.py
+++ b/tests/api/test_processes.py
@@ -397,11 +397,12 @@ def test_execute_process(config, api_):
         rsp_headers, code, response = execute_process(api_, req, 'hello-world')
     assert code == HTTPStatus.OK
     post_mocker.assert_any_call(
-        req_body_7['subscriber']['inProgressUri'], json={}
+        req_body_7['subscriber']['inProgressUri'], json={},
+        allow_redirects=False
     )
     post_mocker.assert_any_call(
         req_body_7['subscriber']['successUri'],
-        json={'id': 'echo', 'value': 'Hello Test!'}
+        json={'id': 'echo', 'value': 'Hello Test!'}, allow_redirects=False
     )
     assert post_mocker.call_count == 2
 


### PR DESCRIPTION
# Overview
This PR prevents redirects for OGC API - Processes process execution when a `subscriber` object is defined.
# Related Issue / discussion

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
