### PR TITLE
safeguard item template hrefs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,6 +130,7 @@ jobs:
         pip3 install -r requirements-pubsub.txt
         pip3 install .
         pip3 install GDAL==`gdal-config --version`
+        pip3 install "pyproj<3.8"
     - name: setup test data ⚙️
       run: |
         pybabel compile -d locale -l es

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,6 @@ jobs:
         pip3 install -r requirements-pubsub.txt
         pip3 install .
         pip3 install GDAL==`gdal-config --version`
-        pip3 install "pyproj<3.8"
     - name: setup test data ⚙️
       run: |
         pybabel compile -d locale -l es

--- a/pygeoapi/templates/collections/items/item.html
+++ b/pygeoapi/templates/collections/items/item.html
@@ -5,7 +5,9 @@
 {# Optionally renders an img element, otherwise standard value or link rendering #}
 {% macro render_item_value(v, width) -%}
     {% set val = v | string | trim %}
-    {% if val|length and val.lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.bmp')) %}
+    {% if (val|length and val.lower().startswith(('http://', 'https://')) and
+           val.lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.bmp'))
+    ) %}
         {# Ends with image extension: render img element with link to image #}
         <a href="{{ val }}"><img src="{{ val }}" alt="{{ val.split('/') | last }}" width="{{ width }}"/></a>
     {% elif v is string or v is number %}

--- a/tests/other/test_crs.py
+++ b/tests/other/test_crs.py
@@ -270,7 +270,7 @@ def test_transform_bbox():
         None,
         pygeofilter.ast.GeometryIntersects(
             pygeofilter.ast.Attribute(name='geometry'),
-            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955419), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
+            Geometry({'type': 'Point', 'coordinates': (2313681.808628421, 4641307.939955416), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
         ),
         id='unnested-geometry-transformed-coords-explicit-input-crs-ewkt'
     ),
@@ -281,7 +281,7 @@ def test_transform_bbox():
         None,
         pygeofilter.ast.GeometryIntersects(
             pygeofilter.ast.Attribute(name='geometry'),
-            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955419), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
+            Geometry({'type': 'Point', 'coordinates': (2313681.808628421, 4641307.939955416), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
         ),
         id='unnested-geometry-transformed-coords-explicit-input-crs-filter-crs'
     ),
@@ -292,7 +292,7 @@ def test_transform_bbox():
         None,
         pygeofilter.ast.GeometryIntersects(
             pygeofilter.ast.Attribute(name='geometry'),
-            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955419), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
+            Geometry({'type': 'Point', 'coordinates': (2313681.808628421, 4641307.939955416), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
         ),
         id='unnested-geometry-transformed-coords-ewkt-crs-overrides-filter-crs'
     ),

--- a/tests/other/test_crs.py
+++ b/tests/other/test_crs.py
@@ -270,7 +270,7 @@ def test_transform_bbox():
         None,
         pygeofilter.ast.GeometryIntersects(
             pygeofilter.ast.Attribute(name='geometry'),
-            Geometry({'type': 'Point', 'coordinates': (2313681.808628421, 4641307.939955416), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
+            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955419), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
         ),
         id='unnested-geometry-transformed-coords-explicit-input-crs-ewkt'
     ),
@@ -281,7 +281,7 @@ def test_transform_bbox():
         None,
         pygeofilter.ast.GeometryIntersects(
             pygeofilter.ast.Attribute(name='geometry'),
-            Geometry({'type': 'Point', 'coordinates': (2313681.808628421, 4641307.939955416), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
+            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955419), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
         ),
         id='unnested-geometry-transformed-coords-explicit-input-crs-filter-crs'
     ),
@@ -292,7 +292,7 @@ def test_transform_bbox():
         None,
         pygeofilter.ast.GeometryIntersects(
             pygeofilter.ast.Attribute(name='geometry'),
-            Geometry({'type': 'Point', 'coordinates': (2313681.808628421, 4641307.939955416), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
+            Geometry({'type': 'Point', 'coordinates': (2313681.8086284213, 4641307.939955419), 'crs': {'properties': {'name': 'urn:ogc:def:crs:EPSG::3004'}}}) # noqa
         ),
         id='unnested-geometry-transformed-coords-ewkt-crs-overrides-filter-crs'
     ),


### PR DESCRIPTION
# Overview
This PR safeguards Jinja item templates when attempting to display image links.  As well, pyproj install on CI is updated given the pyproj 3.8.0 release.

# Related Issue / discussion
Thanks to @mikemahoney218-usgs.
<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information
None
# Dependency policy (RFC2)

- [x] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [x] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [x] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [x] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [x] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
